### PR TITLE
POC: list resources instead of getting them | auth to annotations | support multiple static secrets 

### DIFF
--- a/deploy/resources/cluster-management-addon.yaml
+++ b/deploy/resources/cluster-management-addon.yaml
@@ -1,43 +1,20 @@
 apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: ClusterManagementAddOn
 metadata:
- name: multicluster-observability-addon
+  name: multicluster-observability-addon
+  annotations:
+    addon.open-cluster-management.io/lifecycle: addon-manager
 spec:
- addOnMeta:
-   displayName: Multi Cluster Observability Addon
-   description: "multicluster-observability-addon is the addon to configure spoke clusters to collect and forward logs/traces to a given set of outputs"
- supportedConfigs:
-   # Describes the general addon configuration applicable for all managed clusters. It includes:
-   # - Default subscription channel name for install the `Red Hat OpenShift Logging` operator on each managed cluster.
-   # - Default subscription channel name for install the `Red Hat OpenShift distributed tracing data collection` operator on each managed cluster.
-   - group: addon.open-cluster-management.io
-     resource: addondeploymentconfigs
-     defaultConfig:
-       name: multicluster-observability-addon
-       namespace: open-cluster-management
-
-   # Describe per managed cluster sensitive data per target forwarding location, currently supported:
-   # - TLS client certificates for mTLS communication with a log output / trace exporter.
-   # - Client credentials for password based authentication with a log output / trace exporter.
-   - resource: secrets
-
-   # Describe per managed cluster auxilliary config per log output / trace exporter.
-   - resource: configmaps
-
-   # Describes the default log forwarding outputs for each log type applied to all managed clusters.
-   - group: logging.openshift.io
-     resource: clusterlogforwarders
-     # The default config is the main stanza of a ClusterLogForwarder resource
-     # that describes where logs should be forwarded for all managed cluster.
-     defaultConfig:
-       name: instance
-       namespace: open-cluster-management
-
-   # Describes the default OpenTelemetryCollector type applied to all managed clusters.
-   - group: opentelemetry.io
-     resource: opentelemetrycollectors
-     # The default config is the main stanza of an OpenTelemetryCollector resource
-     # that describes where traces should be forwarded for all managed cluster.
-     defaultConfig:
-       name: spoke-otelcol
-       namespace: open-cluster-management
+  addOnMeta:
+    displayName: Multi Cluster Observability Addon
+    description: "multicluster-observability-addon is the addon to configure spoke clusters to collect and forward logs/traces to a given set of outputs"
+  supportedConfigs:
+    - group: addon.open-cluster-management.io
+      resource: addondeploymentconfigs
+      defaultConfig:
+        name: multicluster-observability-addon
+        namespace: open-cluster-management
+    - group: logging.openshift.io
+      resource: clusterlogforwarders
+    - group: opentelemetry.io
+      resource: opentelemetrycollectors

--- a/internal/addon/authentication/provider.go
+++ b/internal/addon/authentication/provider.go
@@ -3,6 +3,7 @@ package authentication
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/ViaQ/logerr/v2/kverrors"
 	"github.com/rhobs/multicluster-observability-addon/internal/addon"
@@ -189,4 +190,22 @@ func BuildAuthenticationMap(inputMap map[string]string) map[Target]Authenticatio
 	}
 
 	return result
+}
+
+func BuildAuthenticationFromAnnotations(annotations map[string]string) (map[Target]AuthenticationType, error) {
+	result := make(map[Target]AuthenticationType)
+	for annotation, annValue := range annotations {
+		if !strings.HasPrefix(annotation, AnnotationAuthOutput) {
+			continue
+		}
+		split := strings.Split(annotation, "/")
+		if len(split) < 2 {
+			return result, kverrors.New("unable to extract output name from annotation", "annotation", annotation)
+		}
+		target := Target(split[1])
+		authType := AuthenticationType(annValue)
+		result[target] = authType
+	}
+
+	return result, nil
 }

--- a/internal/addon/authentication/var.go
+++ b/internal/addon/authentication/var.go
@@ -11,6 +11,7 @@ const (
 	MCO AuthenticationType = "MCO"
 
 	AnnotationCAToInject = "authentication.mcoa.openshift.io/ca"
+	AnnotationAuthOutput = "authentication.mcoa.openshift.io/"
 )
 
 var certManagerCRDs = []string{"certificates.cert-manager.io", "issuers.cert-manager.io", "clusterissuers.cert-manager.io"}

--- a/internal/addon/authentication/var.go
+++ b/internal/addon/authentication/var.go
@@ -10,8 +10,9 @@ const (
 	// MCO represents an authentication type that will re-use the MCO provided credentials
 	MCO AuthenticationType = "MCO"
 
-	AnnotationCAToInject = "authentication.mcoa.openshift.io/ca"
-	AnnotationAuthOutput = "authentication.mcoa.openshift.io/"
+	AnnotationCAToInject           = "authentication.mcoa.openshift.io/ca"
+	AnnotationAuthOutput           = "authentication.mcoa.openshift.io/"
+	labelDiscoverStaticAuthSecrets = "authentication.mcoa.openshift.io/static-authentication"
 )
 
 var certManagerCRDs = []string{"certificates.cert-manager.io", "issuers.cert-manager.io", "clusterissuers.cert-manager.io"}

--- a/internal/logging/handlers/handler.go
+++ b/internal/logging/handlers/handler.go
@@ -68,6 +68,9 @@ func BuildOptions(k8s client.Client, mcAddon *addonapiv1alpha1.ManagedClusterAdd
 			return resources, kverrors.New("missing ca bundle in configmap", "key", "service-ca.crt")
 		}
 	}
+	authConfig.OwnerLabels = map[string]string{
+		manifests.LabelCLFRef: clfRef,
+	}
 
 	secretsProvider, err := authentication.NewSecretsProvider(k8s, mcAddon.Namespace, addon.Logging, authConfig)
 	if err != nil {

--- a/internal/logging/helm_test.go
+++ b/internal/logging/helm_test.go
@@ -74,18 +74,6 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 
 	// Register the addon for the managed cluster
 	managedClusterAddOn = addontesting.NewAddon("test", "cluster-1")
-	managedClusterAddOn.Spec.Configs = []addonapiv1alpha1.AddOnConfig{
-		{
-			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
-				Group:    "",
-				Resource: "configmaps",
-			},
-			ConfigReferent: addonapiv1alpha1.ConfigReferent{
-				Namespace: "open-cluster-management",
-				Name:      "logging-auth",
-			},
-		},
-	}
 	managedClusterAddOn.Status.ConfigReferences = []addonapiv1alpha1.ConfigReference{
 		{
 			ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
@@ -181,7 +169,7 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 			Name:      "logging-auth",
 			Namespace: "open-cluster-management",
 			Labels: map[string]string{
-				"mcoa.openshift.io/signal": "logging",
+				"mcoa.openshift.io/clf-ref": "open-cluster-management/instance",
 			},
 		},
 		Data: map[string]string{

--- a/internal/logging/helm_test.go
+++ b/internal/logging/helm_test.go
@@ -61,7 +61,6 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 		// Addon configuration
 		addOnDeploymentConfig *addonapiv1alpha1.AddOnDeploymentConfig
 		clf                   *loggingv1.ClusterLogForwarder
-		authCM                *corev1.ConfigMap
 		staticCred            *corev1.Secret
 
 		// Test clients
@@ -102,6 +101,10 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "instance",
 			Namespace: "open-cluster-management",
+			Annotations: map[string]string{
+				"authentication.mcoa.openshift.io/cluster-logs": "StaticAuthentication",
+				"authentication.mcoa.openshift.io/app-logs":     "StaticAuthentication",
+			},
 		},
 		Spec: loggingv1.ClusterLogForwarderSpec{
 			Inputs: []loggingv1.InputSpec{
@@ -164,20 +167,6 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 		},
 	}
 
-	authCM = &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "logging-auth",
-			Namespace: "open-cluster-management",
-			Labels: map[string]string{
-				"mcoa.openshift.io/clf-ref": "open-cluster-management/instance",
-			},
-		},
-		Data: map[string]string{
-			"app-logs":     "StaticAuthentication",
-			"cluster-logs": "StaticAuthentication",
-		},
-	}
-
 	addOnDeploymentConfig = &addonapiv1alpha1.AddOnDeploymentConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "multicluster-observability-addon",
@@ -196,7 +185,7 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 	// Setup the fake k8s client
 	fakeKubeClient = fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
-		WithObjects(clf, staticCred, authCM).
+		WithObjects(clf, staticCred).
 		Build()
 
 	// Setup the fake addon client

--- a/internal/logging/helm_test.go
+++ b/internal/logging/helm_test.go
@@ -161,7 +161,8 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 			Name:      "cluster-logs",
 			Namespace: "cluster-1",
 			Labels: map[string]string{
-				"mcoa.openshift.io/clf-ref":                              "open-cluster-management/instance",
+				"mcoa.openshift.io/clf-namespace":                        "open-cluster-management",
+				"mcoa.openshift.io/clf-name":                             "instance",
 				"authentication.mcoa.openshift.io/static-authentication": "cluster-logs",
 			},
 		},
@@ -176,7 +177,8 @@ func Test_Logging_AllConfigsTogether_AllResources(t *testing.T) {
 			Name:      "app-logs",
 			Namespace: "cluster-1",
 			Labels: map[string]string{
-				"mcoa.openshift.io/clf-ref":                              "open-cluster-management/instance",
+				"mcoa.openshift.io/clf-namespace":                        "open-cluster-management",
+				"mcoa.openshift.io/clf-name":                             "instance",
 				"authentication.mcoa.openshift.io/static-authentication": "app-logs",
 			},
 		},

--- a/internal/logging/manifests/var.go
+++ b/internal/logging/manifests/var.go
@@ -4,7 +4,6 @@ import (
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/rhobs/multicluster-observability-addon/internal/addon/authentication"
 	"github.com/rhobs/multicluster-observability-addon/internal/manifests"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -16,18 +15,9 @@ const (
 
 	certOrganizatonalUnit = "multicluster-observability-addon"
 	certDNSNameCollector  = "collector.openshift-logging.svc"
-
-	staticSecretName      = "static-authentication"
-	staticSecretNamespace = "open-cluster-management"
 )
 
 var AuthDefaultConfig = &authentication.Config{
-	StaticAuthConfig: manifests.StaticAuthenticationConfig{
-		ExistingSecret: client.ObjectKey{
-			Name:      staticSecretName,
-			Namespace: staticSecretNamespace,
-		},
-	},
 	MTLSConfig: manifests.MTLSConfig{
 		CommonName: "", // Should be set when using these defaults
 		Subject: &v1.X509Subject{

--- a/internal/logging/manifests/var.go
+++ b/internal/logging/manifests/var.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	LabelCLFRef                = "mcoa.openshift.io/clf-ref"
+	LabelCLFNamespace          = "mcoa.openshift.io/clf-namespace"
+	LabelCLFName               = "mcoa.openshift.io/clf-name"
 	AnnotationTargetOutputName = "logging.mcoa.openshift.io/target-output-name"
 
 	subscriptionChannelValueKey = "loggingSubscriptionChannel"

--- a/internal/logging/manifests/var.go
+++ b/internal/logging/manifests/var.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	LabelCLFRef                = "mcoa.openshift.io/clf-ref"
 	AnnotationTargetOutputName = "logging.mcoa.openshift.io/target-output-name"
 
 	subscriptionChannelValueKey = "loggingSubscriptionChannel"

--- a/internal/manifests/secrets_test.go
+++ b/internal/manifests/secrets_test.go
@@ -1,7 +1,6 @@
 package manifests
 
 import (
-	"context"
 	"testing"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -9,18 +8,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func Test_BuildStaticSecret(t *testing.T) {
 	key := client.ObjectKey{Name: "foo", Namespace: "foo"}
-	saConfig := StaticAuthenticationConfig{
-		ExistingSecret: client.ObjectKey{
-			Name:      "bar",
-			Namespace: "bar",
-		},
-	}
-
 	existingSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
@@ -32,12 +23,7 @@ func Test_BuildStaticSecret(t *testing.T) {
 		},
 	}
 
-	fakeKubeClient := fake.NewClientBuilder().
-		WithObjects(&existingSecret).
-		Build()
-
-	s, err := BuildStaticSecret(context.TODO(), fakeKubeClient, key, saConfig)
-	require.NoError(t, err)
+	s := BuildStaticSecret(key, &existingSecret)
 	require.Equal(t, existingSecret.Data, s.Data)
 }
 
@@ -55,8 +41,7 @@ func Test_BuildMTLSSecret(t *testing.T) {
 		},
 	}
 
-	c, err := BuildCertificate(key, mTLSConfig)
-	require.NoError(t, err)
+	c := BuildCertificate(key, mTLSConfig)
 	require.Equal(t, "foo", c.Spec.SecretName)
 	require.Equal(t, mTLSConfig.CommonName, c.Spec.CommonName)
 	require.Equal(t, mTLSConfig.Subject, c.Spec.Subject)

--- a/main.go
+++ b/main.go
@@ -163,8 +163,6 @@ func runController(ctx context.Context, kubeConfig *rest.Config) error {
 
 	mcoaAgentAddon, err := addonfactory.NewAgentAddonFactory(addon.Name, addon.FS, "manifests/charts/mcoa").
 		WithConfigGVRs(
-			schema.GroupVersionResource{Version: "v1", Resource: "secrets"},
-			schema.GroupVersionResource{Version: "v1", Resource: "configmaps"},
 			schema.GroupVersionResource{Version: "v1", Group: "logging.openshift.io", Resource: "clusterlogforwarders"},
 			schema.GroupVersionResource{Version: "v1alpha1", Group: "opentelemetry.io", Resource: "opentelemetrycollectors"},
 			utils.AddOnDeploymentConfigGVR,


### PR DESCRIPTION
This PR is a prof of concept to improve the general design of the addon. The goal is not to merge it but to discuss the ideas implemented in each commit and possibly adopt each one individually in it's own PR.

#### List resources instead of looking for a reference

During grooming the we noticed that if we want to support  the idea of clusterset deployments that we can use the `ClusterManagedAddon` `Placement`  installation to reference different CLF. However in this mode the addon-manager creates the `ManagedClusterAddon`. This would be a friction point of integration with GitOps tools, because of this we propose a move to an architecture that pull resources (apart from CLF, OTEL Collector) using label instead of looking for them in the `ManagedClusterAddon`). This not only gives us direct support for clusterset installations but it also allows the user to create one less resource.

#### Move authentication to annotations of root resource (CLF, OTEL Collector)

During grooming the we noticed that nowadays we require the user to create too many resources, this improvement proposes that we move the authentication methods used to the annotations of the root resource. This not only makes so this information lives closer to output configuration but it allow makes it so the user don't need to create an extra resource.

#### Allow multiple static secrets

The first implementation of the addon only allowed for one single static secret to be provided to the user, in this POC we propose an approach that allows a user to provide multiple static secrets that will be selected using labels