### PR TITLE
addon: use labels instead of annotations to determine hub cluster

### DIFF
--- a/hack/addon-install/templates/aws-secret-default.yaml
+++ b/hack/addon-install/templates/aws-secret-default.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: open-cluster-management
 type: Opaque
 data:
-  access_key_id: {{ .Values.awsCredentials.accessKeyID | b64enc }}
-  access_key_secret: {{ .Values.awsCredentials.accessKeySecret | b64enc }}
+  aws_access_key_id: {{ .Values.awsCredentials.accessKeyID | b64enc }}
+  aws_access_key_secret: {{ .Values.awsCredentials.accessKeySecret | b64enc }}

--- a/hack/addon-install/templates/aws-secret.yaml
+++ b/hack/addon-install/templates/aws-secret.yaml
@@ -5,5 +5,5 @@ metadata:
   namespace: {{ .Values.spokeClusterName }}
 type: Opaque
 data:
-  access_key_id: {{ .Values.awsCredentials.accessKeyID | b64enc }}
-  access_key_secret: {{ .Values.awsCredentials.accessKeySecret | b64enc }}
+  aws_access_key_id: {{ .Values.awsCredentials.accessKeyID | b64enc }}
+  aws_access_key_secret: {{ .Values.awsCredentials.accessKeySecret | b64enc }}

--- a/internal/addon/helm/values.go
+++ b/internal/addon/helm/values.go
@@ -143,7 +143,7 @@ func buildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Opti
 }
 
 func isHubCluster(cluster *clusterv1.ManagedCluster) bool {
-	val, ok := cluster.Annotations[annotationLocalCluster]
+	val, ok := cluster.Labels[annotationLocalCluster]
 	if !ok {
 		return false
 	}

--- a/internal/addon/helm/values_test.go
+++ b/internal/addon/helm/values_test.go
@@ -102,7 +102,7 @@ func Test_Mcoa_Disable_Chart_Hub(t *testing.T) {
 	)
 
 	managedCluster = addontesting.NewManagedCluster("cluster-1")
-	managedCluster.Annotations = map[string]string{
+	managedCluster.Labels = map[string]string{
 		"local-cluster": "true",
 	}
 	managedClusterAddOn = addontesting.NewAddon("test", "cluster-1")


### PR DESCRIPTION
In https://github.com/rhobs/multicluster-observability-addon/pull/48 I've incorrectly used annotations instead of labels to determine if a cluster is the hub cluster.

Fix secret keys for CLF when forwarding logs to CW