### PR TITLE
addon: prepare addon for multiple same-GVK configs

### DIFF
--- a/internal/addon/addon.go
+++ b/internal/addon/addon.go
@@ -26,8 +26,8 @@ func NewRegistrationOption(agentName string) *agent.RegistrationOption {
 	}
 }
 
-func GetObjectKey(configRef []addonapiv1alpha1.ConfigReference, group, resource string) client.ObjectKey {
-	var key client.ObjectKey
+func GetObjectKeys(configRef []addonapiv1alpha1.ConfigReference, group, resource string) []client.ObjectKey {
+	var keys []client.ObjectKey
 	for _, config := range configRef {
 		if config.ConfigGroupResource.Group != group {
 			continue
@@ -36,11 +36,12 @@ func GetObjectKey(configRef []addonapiv1alpha1.ConfigReference, group, resource 
 			continue
 		}
 
-		key.Name = config.Name
-		key.Namespace = config.Namespace
-		break
+		keys = append(keys, client.ObjectKey{
+			Name:      config.Name,
+			Namespace: config.Namespace,
+		})
 	}
-	return key
+	return keys
 }
 
 // AgentHealthProber returns a HealthProber struct that contains the necessary

--- a/internal/addon/helm/values_test.go
+++ b/internal/addon/helm/values_test.go
@@ -16,8 +16,10 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/addontesting"
 	"open-cluster-management.io/addon-framework/pkg/agent"
+	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -138,4 +140,102 @@ func Test_Mcoa_Disable_Chart_Hub(t *testing.T) {
 	objects, err := loggingAgentAddon.Manifests(managedCluster, managedClusterAddOn)
 	require.NoError(t, err)
 	require.Empty(t, objects)
+}
+
+func TestGetAddOnDeploymentConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		mcAddon      *addonapiv1alpha1.ManagedClusterAddOn
+		existingAODC *addonapiv1alpha1.AddOnDeploymentConfig
+		expectedErr  error
+	}{
+		{
+			name: "No AODC reference",
+			mcAddon: &addonapiv1alpha1.ManagedClusterAddOn{
+				Status: addonapiv1alpha1.ManagedClusterAddOnStatus{
+					ConfigReferences: nil,
+				},
+			},
+			expectedErr: errMissingAODCRef,
+		},
+		{
+			name: "Multiple AODC references",
+			mcAddon: &addonapiv1alpha1.ManagedClusterAddOn{
+				Status: addonapiv1alpha1.ManagedClusterAddOnStatus{
+					ConfigReferences: []addonapiv1alpha1.ConfigReference{
+						{
+							ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+								Group:    addonutils.AddOnDeploymentConfigGVR.Group,
+								Resource: addon.AddonDeploymentConfigResource,
+							},
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
+								Name:      "foo",
+								Namespace: "foo",
+							},
+						},
+						{
+							ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+								Group:    addonutils.AddOnDeploymentConfigGVR.Group,
+								Resource: addon.AddonDeploymentConfigResource,
+							},
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
+								Name:      "bar",
+								Namespace: "bar",
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errMultipleAODCRef,
+		},
+		{
+			name: "AODC reference found",
+			mcAddon: &addonapiv1alpha1.ManagedClusterAddOn{
+				Status: addonapiv1alpha1.ManagedClusterAddOnStatus{
+					ConfigReferences: []addonapiv1alpha1.ConfigReference{
+						{
+							ConfigGroupResource: addonapiv1alpha1.ConfigGroupResource{
+								Group:    addonutils.AddOnDeploymentConfigGVR.Group,
+								Resource: addon.AddonDeploymentConfigResource,
+							},
+							ConfigReferent: addonapiv1alpha1.ConfigReferent{
+								Name:      "foo",
+								Namespace: "foo",
+							},
+						},
+					},
+				},
+			},
+			existingAODC: &addonapiv1alpha1.AddOnDeploymentConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "foo",
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fake client with the existing AODC if provided
+			objs := []client.Object{}
+			if tt.existingAODC != nil {
+				objs = append(objs, tt.existingAODC)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
+
+			// Call the function
+			ctx := context.TODO()
+			_, err := getAddOnDeploymentConfig(ctx, fakeClient, tt.mcAddon)
+
+			// require the results
+			if tt.expectedErr != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/logging/handlers/handler.go
+++ b/internal/logging/handlers/handler.go
@@ -2,12 +2,18 @@ package handlers
 
 import (
 	"context"
+	"errors"
 
 	loggingv1 "github.com/openshift/cluster-logging-operator/apis/logging/v1"
 	"github.com/rhobs/multicluster-observability-addon/internal/addon"
 	"github.com/rhobs/multicluster-observability-addon/internal/logging/manifests"
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	errMissingCLFRef  = errors.New("missing ClusterLogForwarder reference on addon installation")
+	errMultipleCLFRef = errors.New("multiple ClusterLogForwarder references on addon installation")
 )
 
 func BuildOptions(ctx context.Context, k8s client.Client, mcAddon *addonapiv1alpha1.ManagedClusterAddOn, platform, userWorkloads addon.LogsOptions) (manifests.Options, error) {
@@ -22,9 +28,15 @@ func BuildOptions(ctx context.Context, k8s client.Client, mcAddon *addonapiv1alp
 		opts.SubscriptionChannel = userWorkloads.SubscriptionChannel
 	}
 
-	key := addon.GetObjectKey(mcAddon.Status.ConfigReferences, loggingv1.GroupVersion.Group, addon.ClusterLogForwardersResource)
+	keys := addon.GetObjectKeys(mcAddon.Status.ConfigReferences, loggingv1.GroupVersion.Group, addon.ClusterLogForwardersResource)
+	switch {
+	case len(keys) == 0:
+		return opts, errMissingCLFRef
+	case len(keys) > 1:
+		return opts, errMultipleCLFRef
+	}
 	clf := &loggingv1.ClusterLogForwarder{}
-	if err := k8s.Get(ctx, key, clf, &client.GetOptions{}); err != nil {
+	if err := k8s.Get(ctx, keys[0], clf, &client.GetOptions{}); err != nil {
 		return opts, err
 	}
 	opts.ClusterLogForwarder = clf


### PR DESCRIPTION
This PR contains a small refactor of the `GetObjectKey` to return multiple keys to support the use case for multiple same-GVK resources like OpenTelemetryCollector. I've coded the reconcile loops not to allow multiple instances of CLF & OTELCollector, just while, we still don't have the code to handle those use cases.

This PR was manually tested ✅ 

![image](https://github.com/user-attachments/assets/3dfd820a-b472-4c06-8d68-61db8eacf7d5)

cc @iblancasa 