### PR TITLE
chore: otelcol set management state to managed

### DIFF
--- a/hack/addon-install/templates/otelcol-instance.yaml
+++ b/hack/addon-install/templates/otelcol-instance.yaml
@@ -4,6 +4,7 @@ metadata:
   name: instance
   namespace: open-cluster-management-observability
 spec:
+  managementState: unmanaged
   config:
     exporters:
       debug: {}

--- a/internal/tracing/manifests/tracing.go
+++ b/internal/tracing/manifests/tracing.go
@@ -2,6 +2,8 @@ package manifests
 
 import (
 	"encoding/json"
+
+	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 )
 
 func buildSecrets(resources Options) ([]SecretValue, error) {
@@ -18,4 +20,10 @@ func buildSecrets(resources Options) ([]SecretValue, error) {
 		secretsValue = append(secretsValue, secretValue)
 	}
 	return secretsValue, nil
+}
+
+func buildOTELColSpec(opts Options) (*otelv1beta1.OpenTelemetryCollectorSpec, error) {
+	otelColSpec := opts.OpenTelemetryCollector.Spec
+	otelColSpec.ManagementState = otelv1beta1.ManagementStateManaged
+	return &otelColSpec, nil
 }

--- a/internal/tracing/manifests/values.go
+++ b/internal/tracing/manifests/values.go
@@ -28,11 +28,15 @@ func BuildValues(opts Options) (TracingValues, error) {
 	}
 	values.Secrets = secrets
 
-	b, err := json.Marshal(&opts.OpenTelemetryCollector.Spec)
+	otelColSpec, err := buildOTELColSpec(opts)
 	if err != nil {
 		return values, err
 	}
 
+	b, err := json.Marshal(otelColSpec)
+	if err != nil {
+		return values, err
+	}
 	values.OTELColSpec = string(b)
 
 	if opts.Instrumentation != nil {


### PR DESCRIPTION
This PR makes it so MCOA sets the OTELCol managementState to managed. With users now having to install the operators on the Hub we recommend them creating the resources with managementState set to unmanaged to avoid the operators running on the cluster from reconciling them.