### PR TITLE
chore: fix "make addon-deploy"

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -15,6 +15,8 @@ resources:
 - crds/observability.openshift.io_clusterlogforwarders.yaml
 - crds/opentelemetry.io_opentelemetrycollectors.yaml
 - crds/opentelemetry.io_instrumentations.yaml
+- crds/monitoring.coreos.com_prometheusagents.yaml
+- crds/monitoring.coreos.com_scrapeconfigs.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/deploy/resources/cluster_role.yaml
+++ b/deploy/resources/cluster_role.yaml
@@ -64,3 +64,8 @@
     - apiGroups: ["opentelemetry.io"]
       resources: ["opentelemetrycollectors", "instrumentations"]
       verbs: ["get", "list", "watch"]
+    # Role for addon to perform metrics specific actions
+    - apiGroups: ["monitoring.coreos.com"]
+      resources: ["scrapeconfigs", "prometheusagents", "prometheusrules"]
+      verbs: ["get", "list", "watch"]
+


### PR DESCRIPTION
With https://github.com/stolostron/multicluster-observability-addon/pull/77 we introduced metrics to MCOA, however we forgot to update the resources to make "make addon-deploy" work, this PR fixes that.

This PR also updates the "make addon-deploy" instruction to use "--server-side" since the prometheus-operator CRDs are too big to simply create with "kubectl apply" see https://github.com/prometheus-operator/prometheus-operator/issues/4439