### PR TITLE
[fix]: metrics hub hostname with no scheme

### DIFF
--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -107,8 +107,8 @@ func BuildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Opti
 		// Platform Observability Options
 		case KeyMetricsHubHostname:
 			val := keyvalue.Value
-			if !strings.HasPrefix(keyvalue.Value, "http") {
-				val = "https://" + keyvalue.Value
+			if !strings.HasPrefix(val, "http") {
+				val = "https://" + val
 			}
 			url, err := url.Parse(val)
 			if err != nil {

--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -114,6 +114,15 @@ func BuildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Opti
 			if err != nil {
 				return opts, fmt.Errorf("%w: %s", errInvalidMetricsHubHostname, err.Error())
 			}
+			
+			// Hostname validation:
+			// - Check if host is empty
+			// - Check for invalid hostname formats like ":"
+			if strings.TrimSpace(url.Host) == "" || url.Host == ":" ||
+				strings.HasPrefix(url.Host, ":") {
+				return opts, fmt.Errorf("%w: invalid hostname format '%s'", errInvalidMetricsHubHostname, url.Host)
+			}
+
 			opts.Platform.Metrics.HubEndpoint = url
 		case KeyPlatformMetricsCollection:
 			if keyvalue.Value == string(PrometheusAgentV1alpha1) {

--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -114,12 +114,11 @@ func BuildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Opti
 			if err != nil {
 				return opts, fmt.Errorf("%w: %s", errInvalidMetricsHubHostname, err.Error())
 			}
-			
+
 			// Hostname validation:
 			// - Check if host is empty
 			// - Check for invalid hostname formats like ":"
-			if strings.TrimSpace(url.Host) == "" || url.Host == ":" ||
-				strings.HasPrefix(url.Host, ":") {
+			if strings.TrimSpace(url.Host) == "" || url.Host == ":" || strings.HasPrefix(url.Host, ":") {
 				return opts, fmt.Errorf("%w: invalid hostname format '%s'", errInvalidMetricsHubHostname, url.Host)
 			}
 

--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -3,6 +3,7 @@ package addon
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 )
@@ -105,12 +106,13 @@ func BuildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Opti
 			opts.UserWorkloads.Logs.SubscriptionChannel = keyvalue.Value
 		// Platform Observability Options
 		case KeyMetricsHubHostname:
-			url, err := url.Parse(keyvalue.Value)
+			val := keyvalue.Value
+			if !strings.HasPrefix(keyvalue.Value, "http") {
+				val = "https://" + keyvalue.Value
+			}
+			url, err := url.Parse(val)
 			if err != nil {
 				return opts, fmt.Errorf("%w: %s", errInvalidMetricsHubHostname, err.Error())
-			}
-			if url.Scheme == "" {
-				url.Scheme = "https"
 			}
 			opts.Platform.Metrics.HubEndpoint = url
 		case KeyPlatformMetricsCollection:

--- a/internal/addon/options_test.go
+++ b/internal/addon/options_test.go
@@ -39,13 +39,43 @@ func TestBuildOptions(t *testing.T) {
 			expectedOpts: Options{},
 		},
 		{
-			name: "valid metrics",
+			name: "valid metrics without scheme for hub",
 			addOnDeploy: &addonapiv1alpha1.AddOnDeploymentConfig{
 				Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
 					CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
 						{Name: KeyPlatformMetricsCollection, Value: string(PrometheusAgentV1alpha1)},
 						{Name: KeyUserWorkloadMetricsCollection, Value: string(PrometheusAgentV1alpha1)},
 						{Name: KeyMetricsHubHostname, Value: "metrics.example.com"},
+					},
+				},
+			},
+			expectedOpts: Options{
+				Platform: PlatformOptions{
+					Enabled: true,
+					Metrics: MetricsOptions{
+						CollectionEnabled: true,
+						HubEndpoint: &url.URL{
+							Scheme: "https",
+							Host:   "metrics.example.com",
+						},
+					},
+				},
+				UserWorkloads: UserWorkloadOptions{
+					Enabled: true,
+					Metrics: MetricsOptions{
+						CollectionEnabled: true,
+					},
+				},
+			},
+		},
+		{
+			name: "valid metrics",
+			addOnDeploy: &addonapiv1alpha1.AddOnDeploymentConfig{
+				Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
+					CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
+						{Name: KeyPlatformMetricsCollection, Value: string(PrometheusAgentV1alpha1)},
+						{Name: KeyUserWorkloadMetricsCollection, Value: string(PrometheusAgentV1alpha1)},
+						{Name: KeyMetricsHubHostname, Value: "https://metrics.example.com"},
 					},
 				},
 			},

--- a/internal/addon/options_test.go
+++ b/internal/addon/options_test.go
@@ -45,7 +45,7 @@ func TestBuildOptions(t *testing.T) {
 					CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
 						{Name: KeyPlatformMetricsCollection, Value: string(PrometheusAgentV1alpha1)},
 						{Name: KeyUserWorkloadMetricsCollection, Value: string(PrometheusAgentV1alpha1)},
-						{Name: KeyMetricsHubHostname, Value: "https://metrics.example.com"},
+						{Name: KeyMetricsHubHostname, Value: "metrics.example.com"},
 					},
 				},
 			},
@@ -73,11 +73,11 @@ func TestBuildOptions(t *testing.T) {
 			addOnDeploy: &addonapiv1alpha1.AddOnDeploymentConfig{
 				Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
 					CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
-						{Name: KeyMetricsHubHostname, Value: "://invalid-url"},
+						{Name: KeyMetricsHubHostname, Value: ":invalid-url"},
 					},
 				},
 			},
-			expectedErrMsg: "invalid metrics hub hostname: parse \"://invalid-url\": missing protocol scheme",
+			expectedErrMsg: "invalid metrics hub hostname: parse \"https://:invalid-url\": invalid port \":invalid-url\" after host",
 		},
 		{
 			name: "valid logs",

--- a/internal/addon/options_test.go
+++ b/internal/addon/options_test.go
@@ -103,11 +103,11 @@ func TestBuildOptions(t *testing.T) {
 			addOnDeploy: &addonapiv1alpha1.AddOnDeploymentConfig{
 				Spec: addonapiv1alpha1.AddOnDeploymentConfigSpec{
 					CustomizedVariables: []addonapiv1alpha1.CustomizedVariable{
-						{Name: KeyMetricsHubHostname, Value: ":invalid-url"},
+						{Name: KeyMetricsHubHostname, Value: "://invalid-url"},
 					},
 				},
 			},
-			expectedErrMsg: "invalid metrics hub hostname: parse \"https://:invalid-url\": invalid port \":invalid-url\" after host",
+			expectedErrMsg: "invalid metrics hub hostname: invalid hostname format ':'",
 		},
 		{
 			name: "valid logs",


### PR DESCRIPTION
When there is no scheme specified in the metrics hub hostname key from the AddOnDeploymentConfig, it fails reading it.