### PR TITLE
Tune some metrics default values

### DIFF
--- a/internal/metrics/resource/agentssa.go
+++ b/internal/metrics/resource/agentssa.go
@@ -38,7 +38,7 @@ func NewDefaultPrometheusAgent(ns, name string, isUWL bool, placementRef addonv1
 						corev1.ResourceMemory: resource.MustParse("150Mi"),
 					},
 				},
-				ScrapeInterval: "60s",
+				ScrapeInterval: "120s",
 				SecurityContext: &corev1.PodSecurityContext{
 					RunAsNonRoot: ptr.To(true),
 				},

--- a/internal/metrics/resource/agentssa.go
+++ b/internal/metrics/resource/agentssa.go
@@ -157,16 +157,6 @@ func (p *PrometheusAgentSSA) setPrometheusRemoteWriteConfig() {
 			KeyFile:  p.formatSecretPath(config.ClientCertSecretName, "tls.key"),
 		},
 		// WriteRelabelConfigs is set individually for each managed cluster in order to enforce cluster identification labels
-		QueueConfig: &prometheusv1.QueueConfig{
-			BatchSendDeadline: ptr.To(prometheusv1.Duration("15s")),
-			Capacity:          12000,
-			MaxShards:         3,
-			MinShards:         1,
-			MaxSamplesPerSend: 4000,
-			MinBackoff:        ptr.To(prometheusv1.Duration("1s")),
-			MaxBackoff:        ptr.To(prometheusv1.Duration("30s")),
-			RetryOnRateLimit:  true,
-		},
 	}
 
 	// Ensure there is a single instance of our config

--- a/internal/metrics/resource/agentssa.go
+++ b/internal/metrics/resource/agentssa.go
@@ -54,6 +54,11 @@ func NewDefaultPrometheusAgent(ns, name string, isUWL bool, placementRef addonv1
 		agent.Labels = map[string]string{}
 	}
 
+	if isUWL {
+		// Listen to all namespaces by default. Can be overridden by the user.
+		agent.Spec.ScrapeConfigNamespaceSelector = &metav1.LabelSelector{}
+	}
+
 	maps.Copy(agent.Labels, makeConfigResourceLabels(isUWL, placementRef))
 
 	return agent
@@ -199,8 +204,6 @@ func (p *PrometheusAgentSSA) setWatchedResources() {
 		p.desiredAgent.Spec.ScrapeConfigSelector = &metav1.LabelSelector{
 			MatchLabels: config.UserWorkloadPrometheusMatchLabels,
 		}
-		// Listen to all namespaces
-		p.desiredAgent.Spec.ScrapeConfigNamespaceSelector = &metav1.LabelSelector{}
 	} else {
 		p.desiredAgent.Spec.ScrapeConfigSelector = &metav1.LabelSelector{
 			MatchLabels: config.PlatformPrometheusMatchLabels,


### PR DESCRIPTION
Increase default scrape interval to 120s to avoid too many out of order errors.
Remove custom remote write queue config.
Make watched user namespaces configurable.