### PR TITLE
Konflux: migrate to common pipeline for release-2.12

### DIFF
--- a/.tekton/multicluster-observability-addon-acm-212-pull-request.yaml
+++ b/.tekton/multicluster-observability-addon-acm-212-pull-request.yaml
@@ -29,6 +29,12 @@ spec:
     value: Dockerfile.Konflux
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/multicluster-observability-addon-acm-212-push.yaml
+++ b/.tekton/multicluster-observability-addon-acm-212-push.yaml
@@ -22,10 +22,22 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/multicluster-observability-addon-acm-212:{{revision}}
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    - linux/ppc64le
+    - linux/s390x
+    - linux/arm64
   - name: dockerfile
     value: Dockerfile.Konflux
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
This ensures we don't have to manually update tekton files with new task refs. ACM-23303