### PR TITLE
fix: enable Perses in Hub when incident detection is enabled

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/coo/templates/monitoring-plugin.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/coo/templates/monitoring-plugin.yaml
@@ -16,9 +16,9 @@ spec:
         url: 'https://alertmanager.open-cluster-management-observability.svc:9095'
       thanosQuerier:
         url: 'https://rbac-query-proxy.open-cluster-management-observability.svc:8443'
-    perses:
-      enabled: true
 {{- end }}
+    perses:
+      enabled: {{ .Values.perses }}
 {{- if .Values.incidentDetection.enabled }}
     incidents:
       enabled: true

--- a/internal/coo/helm_test.go
+++ b/internal/coo/helm_test.go
@@ -120,11 +120,15 @@ func Test_IncidentDetection_AllConfigsTogether_AllResources(t *testing.T) {
 					Value: "uiplugins.v1alpha1.observability.openshift.io",
 				},
 			},
+			isHub: true,
 			expectedFunc: func(t *testing.T, objects []runtime.Object) {
 				require.GreaterOrEqual(t, len(objects), 4)
 				expectedUIPluginSpec := uiplugin.UIPluginSpec{
 					Type: "Monitoring",
 					Monitoring: &uiplugin.MonitoringConfig{
+						Perses: &uiplugin.PersesReference{
+							Enabled: true,
+						},
 						Incidents: &uiplugin.IncidentsReference{
 							Enabled: true,
 						},
@@ -141,7 +145,7 @@ func Test_IncidentDetection_AllConfigsTogether_AllResources(t *testing.T) {
 			},
 		},
 		{
-			name:  "incident detection",
+			name:  "platform metrics collection & UI",
 			isHub: true,
 			cv: []addonapiv1alpha1.CustomizedVariable{
 				{

--- a/internal/coo/manifests/values.go
+++ b/internal/coo/manifests/values.go
@@ -36,6 +36,7 @@ type COOValues struct {
 	Enabled            bool                                `json:"enabled"`
 	InstallCOO         bool                                `json:"installCOO"`
 	MonitoringUIPlugin bool                                `json:"monitoringUIPlugin"`
+	Perses             bool                                `json:"perses"`
 	Dashboards         []DashboardValue                    `json:"dashboards,omitempty"`
 	Metrics            *mmanifests.UIValues                `json:"metrics,omitempty"`
 	IncidentDetection  *imanifests.IncidentDetectionValues `json:"incidentDetection,omitempty"`
@@ -43,7 +44,7 @@ type COOValues struct {
 
 func BuildValues(opts addon.Options, installCOO bool, isHubCluster bool) *COOValues {
 	var dashboards []DashboardValue
-
+	var incidentDetectionEnabled bool
 	metricsUI := mmanifests.EnableUI(opts.Platform.Metrics, isHubCluster)
 	if metricsUI != nil {
 		if metricsUI.Enabled {
@@ -55,16 +56,20 @@ func BuildValues(opts addon.Options, installCOO bool, isHubCluster bool) *COOVal
 	incidentDetection := imanifests.EnableUI(opts.Platform.AnalyticsOptions.IncidentDetection)
 	if incidentDetection != nil {
 		if incidentDetection.Enabled {
-			dashboards = append(dashboards, buildIncidentDetetctionDashboards()...)
+			incidentDetectionEnabled = true
+			if isHubCluster {
+				dashboards = append(dashboards, buildIncidentDetetctionDashboards()...)
+			}
 		}
 	}
 
 	return &COOValues{
 		// Decide if this chart is needed
-		Enabled: len(dashboards) > 0,
+		Enabled: len(dashboards) > 0 || incidentDetectionEnabled,
 		// Decide if COO chart is needs to be installed
 		InstallCOO:         installCOO,
-		MonitoringUIPlugin: len(dashboards) > 0,
+		MonitoringUIPlugin: len(dashboards) > 0 || incidentDetectionEnabled,
+		Perses:             len(dashboards) > 0,
 		Dashboards:         dashboards,
 		Metrics:            metricsUI,
 		IncidentDetection:  incidentDetection,


### PR DESCRIPTION
COO & MonitoringPlugin must be installed every time the Incident detection is enabled. At the same time when the Incident detection is enabled, we would like to have the corresponding Perses dashboard available in the Hub cluster. 