### PR TITLE
ACM-24954: use cluster id claim

### DIFF
--- a/internal/addon/common/managedcluster.go
+++ b/internal/addon/common/managedcluster.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"slices"
+
+	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+// GetManagedClusterID returns the cluster ID with following priotity order:
+// 1. The `clusterID` label on the `ManagedCluster` resource.
+// 2. The `id.k8s.io` cluster claim on the `ManagedCluster` resource.
+// 3. The name of the `ManagedCluster` resource.
+func GetManagedClusterID(cluster *clusterv1.ManagedCluster) string {
+	if val, ok := cluster.Labels[addoncfg.ManagedClusterLabelClusterID]; ok {
+		return val
+	}
+
+	idx := slices.IndexFunc(cluster.Status.ClusterClaims, func(c clusterv1.ManagedClusterClaim) bool {
+		return c.Name == addoncfg.ClusterClaimClusterID
+	})
+	if idx != -1 {
+		return cluster.Status.ClusterClaims[idx].Value
+	}
+
+	return cluster.Name
+}

--- a/internal/addon/common/managedcluster_test.go
+++ b/internal/addon/common/managedcluster_test.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"testing"
+
+	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
+)
+
+func TestGetManagedClusterID(t *testing.T) {
+	cases := []struct {
+		name              string
+		cluster           *clusterv1.ManagedCluster
+		expectedClusterID string
+	}{
+		{
+			name: "with clusterID label",
+			cluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster1",
+					Labels: map[string]string{
+						addoncfg.ManagedClusterLabelClusterID: "cluster1-id-from-label",
+					},
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					ClusterClaims: []clusterv1.ManagedClusterClaim{
+						{
+							Name:  addoncfg.ClusterClaimClusterID,
+							Value: "cluster1-id-from-claim",
+						},
+					},
+				},
+			},
+			expectedClusterID: "cluster1-id-from-label",
+		},
+		{
+			name: "with id.k8s.io claim",
+			cluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster2",
+				},
+				Status: clusterv1.ManagedClusterStatus{
+					ClusterClaims: []clusterv1.ManagedClusterClaim{
+						{
+							Name:  addoncfg.ClusterClaimClusterID,
+							Value: "cluster2-id-from-claim",
+						},
+					},
+				},
+			},
+			expectedClusterID: "cluster2-id-from-claim",
+		},
+		{
+			name: "with no label or claim",
+			cluster: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster3",
+				},
+			},
+			expectedClusterID: "cluster3",
+		},
+		{
+			name:              "with empty cluster",
+			cluster:           &clusterv1.ManagedCluster{},
+			expectedClusterID: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			clusterID := GetManagedClusterID(c.cluster)
+			if clusterID != c.expectedClusterID {
+				t.Errorf("expected cluster ID %s, got %s", c.expectedClusterID, clusterID)
+			}
+		})
+	}
+}

--- a/internal/addon/config/config.go
+++ b/internal/addon/config/config.go
@@ -47,6 +47,9 @@ const (
 	PlacementRefNameLabelKey      = "placement-ref-name"
 	PlacementRefNamespaceLabelKey = "placement-ref-namespace"
 
+	ClusterClaimClusterID        = "id.k8s.io"
+	ManagedClusterLabelClusterID = "clusterID"
+
 	ComponentK8sLabelKey = "app.kubernetes.io/component"
 	ManagedByK8sLabelKey = "app.kubernetes.io/managed-by"
 	PartOfK8sLabelKey    = "app.kubernetes.io/part-of"

--- a/internal/metrics/config/config.go
+++ b/internal/metrics/config/config.go
@@ -23,8 +23,6 @@ const (
 	PrometheusCAConfigMapName       = "prometheus-server-ca"
 	HubInstallNamespace             = "open-cluster-management-observability"
 
-	ManagedClusterLabelClusterID = "clusterID"
-
 	// Monitoring resources (meta monitoring)
 	PlatformRBACProxyTLSSecret     = "prometheus-agent-platform-kube-rbac-proxy-tls"
 	UserWorkloadRBACProxyTLSSecret = "prometheus-agent-user-workload-kube-rbac-proxy-tls"

--- a/internal/metrics/handlers/handler.go
+++ b/internal/metrics/handlers/handler.go
@@ -43,10 +43,7 @@ func (o *OptionsBuilder) Build(ctx context.Context, mcAddon *addonapiv1alpha1.Ma
 	}
 
 	ret.ClusterName = managedCluster.Name
-	ret.ClusterID = managedCluster.Labels[config.ManagedClusterLabelClusterID]
-	if ret.ClusterID == "" {
-		ret.ClusterID = managedCluster.Name
-	}
+	ret.ClusterID = common.GetManagedClusterID(managedCluster)
 
 	// Fetch image overrides
 	var err error

--- a/internal/metrics/handlers/handler_test.go
+++ b/internal/metrics/handlers/handler_test.go
@@ -200,7 +200,7 @@ func TestBuildOptions(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: spokeName,
 					Labels: map[string]string{
-						config.ManagedClusterLabelClusterID: "test-cluster-id",
+						addoncfg.ManagedClusterLabelClusterID: "test-cluster-id",
 					},
 				},
 			},
@@ -486,7 +486,7 @@ func TestBuildOptions(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "local-cluster-custom-name",
 						Labels: map[string]string{
-							config.ManagedClusterLabelClusterID:                         "test-cluster-id",
+							addoncfg.ManagedClusterLabelClusterID:                       "test-cluster-id",
 							"feature.open-cluster-management.io/addon-hypershift-addon": "available",
 							"local-cluster": "true",
 						},

--- a/internal/metrics/handlers/hypershift.go
+++ b/internal/metrics/handlers/hypershift.go
@@ -13,6 +13,7 @@ import (
 	prometheusalpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
+	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
 	"github.com/stolostron/multicluster-observability-addon/internal/metrics/config"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -66,7 +67,7 @@ func (h *Hypershift) GenerateResources(ctx context.Context, etcdConfig, apiServe
 		},
 		{
 			SourceLabels: []prometheusv1.LabelName{config.ManagementClusterIDMetricLabel}, // Management cluster is the current ManagedCluster
-			Regex:        h.ManagedCluster.Labels[config.ManagedClusterLabelClusterID],
+			Regex:        h.ManagedCluster.Labels[addoncfg.ManagedClusterLabelClusterID],
 			Action:       "keep",
 		},
 	}
@@ -349,7 +350,7 @@ func (h *Hypershift) generateMetricsRelabelConfigs(hostedCluster clusterIdentity
 		{
 			TargetLabel: config.ManagementClusterIDMetricLabel,
 			Action:      "replace",
-			Replacement: ptr.To(h.ManagedCluster.Labels[config.ManagedClusterLabelClusterID]),
+			Replacement: ptr.To(h.ManagedCluster.Labels[addoncfg.ManagedClusterLabelClusterID]),
 		},
 		{
 			TargetLabel: config.ManagementClusterNameMetricLabel,


### PR DESCRIPTION
Changes the way the clusterID is defined for non OCP spokes.