### PR TITLE
Support image registry overrides from AddOnDeploymentConfig

### DIFF
--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -107,6 +107,7 @@ type Options struct {
 	NodeSelector     map[string]string
 	ResourceReqs     []addonapiv1alpha1.ContainerResourceRequirements
 	ProxyConfig      ProxyConfig
+	Registries       []addonapiv1alpha1.ImageMirror
 }
 
 func (o Options) validate() error {
@@ -154,6 +155,7 @@ func BuildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Opti
 	}
 
 	opts.ProxyConfig.NoProxy = addOnDeployment.Spec.ProxyConfig.NoProxy
+	opts.Registries = addOnDeployment.Spec.Registries
 
 	if addOnDeployment.Spec.CustomizedVariables == nil {
 		return opts, nil

--- a/internal/controllers/resourcecreator/controller.go
+++ b/internal/controllers/resourcecreator/controller.go
@@ -144,7 +144,7 @@ func (r *ResourceCreatorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// Reconcile metrics resources
 	objs := []common.DefaultConfig{}
-	images, err := mconfig.GetImageOverrides(ctx, r.Client)
+	images, err := mconfig.GetImageOverrides(ctx, r.Client, opts.Registries, r.Log)
 	if err != nil && !errors.IsNotFound(err) {
 		return ctrl.Result{}, fmt.Errorf("failed to get image overrides: %w", err)
 	}

--- a/internal/metrics/config/config_test.go
+++ b/internal/metrics/config/config_test.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	addonapiv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetImageOverrides(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	baseImages := map[string]string{
+		"prometheus_config_reloader":    "quay.io/prometheus-operator/prometheus-config-reloader:v0.60.0",
+		"kube_rbac_proxy":               "quay.io/brancz/kube-rbac-proxy:v0.14.0",
+		"obo_prometheus_rhel9_operator": "quay.io/rhobs/obo-prometheus-operator:v0.0.1",
+		"kube_state_metrics":            "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0",
+		"node_exporter":                 "quay.io/prometheus/node-exporter:v1.0.0",
+		"prometheus":                    "quay.io/prometheus/prometheus:v2.0.0",
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ImagesConfigMapObjKey.Name,
+			Namespace: ImagesConfigMapObjKey.Namespace,
+		},
+		Data: baseImages,
+	}
+
+	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm).Build()
+
+	tests := []struct {
+		name       string
+		registries []addonapiv1alpha1.ImageMirror
+		expected   ImageOverrides
+	}{
+		{
+			name:       "no overrides",
+			registries: nil,
+			expected: ImageOverrides{
+				PrometheusConfigReloader:   "quay.io/prometheus-operator/prometheus-config-reloader:v0.60.0",
+				KubeRBACProxy:              "quay.io/brancz/kube-rbac-proxy:v0.14.0",
+				CooPrometheusOperatorImage: "quay.io/rhobs/obo-prometheus-operator:v0.0.1",
+				KubeStateMetrics:           "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0",
+				NodeExporter:               "quay.io/prometheus/node-exporter:v1.0.0",
+				Prometheus:                 "quay.io/prometheus/prometheus:v2.0.0",
+			},
+		},
+		{
+			name: "full image override",
+			registries: []addonapiv1alpha1.ImageMirror{
+				{
+					Source: "quay.io/prometheus/prometheus",
+					Mirror: "registry.example.com/prometheus/prometheus",
+				},
+			},
+			expected: ImageOverrides{
+				PrometheusConfigReloader:   "quay.io/prometheus-operator/prometheus-config-reloader:v0.60.0",
+				KubeRBACProxy:              "quay.io/brancz/kube-rbac-proxy:v0.14.0",
+				CooPrometheusOperatorImage: "quay.io/rhobs/obo-prometheus-operator:v0.0.1",
+				KubeStateMetrics:           "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0",
+				NodeExporter:               "quay.io/prometheus/node-exporter:v1.0.0",
+				Prometheus:                 "registry.example.com/prometheus/prometheus:v2.0.0",
+			},
+		},
+		{
+			name: "registry domain override - should be ignored",
+			registries: []addonapiv1alpha1.ImageMirror{
+				{
+					Source: "quay.io",
+					Mirror: "registry.example.com",
+				},
+			},
+			expected: ImageOverrides{
+				PrometheusConfigReloader:   "quay.io/prometheus-operator/prometheus-config-reloader:v0.60.0",
+				KubeRBACProxy:              "quay.io/brancz/kube-rbac-proxy:v0.14.0",
+				CooPrometheusOperatorImage: "quay.io/rhobs/obo-prometheus-operator:v0.0.1",
+				KubeStateMetrics:           "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0",
+				NodeExporter:               "quay.io/prometheus/node-exporter:v1.0.0",
+				Prometheus:                 "quay.io/prometheus/prometheus:v2.0.0",
+			},
+		},
+		{
+			name: "org override - should be ignored",
+			registries: []addonapiv1alpha1.ImageMirror{
+				{
+					Source: "quay.io/prometheus",
+					Mirror: "registry.example.com/prometheus",
+				},
+			},
+			expected: ImageOverrides{
+				PrometheusConfigReloader:   "quay.io/prometheus-operator/prometheus-config-reloader:v0.60.0",
+				KubeRBACProxy:              "quay.io/brancz/kube-rbac-proxy:v0.14.0",
+				CooPrometheusOperatorImage: "quay.io/rhobs/obo-prometheus-operator:v0.0.1",
+				KubeStateMetrics:           "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0",
+				NodeExporter:               "quay.io/prometheus/node-exporter:v1.0.0",
+				Prometheus:                 "quay.io/prometheus/prometheus:v2.0.0", // "quay.io/prometheus" is prefix of "quay.io/prometheus/prometheus" but not exact match for repo
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetImageOverrides(context.Background(), client, tt.registries, logr.Discard())
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/internal/metrics/handlers/handler.go
+++ b/internal/metrics/handlers/handler.go
@@ -77,7 +77,7 @@ func (o *OptionsBuilder) Build(ctx context.Context, mcAddon *addonapiv1alpha1.Ma
 
 	// Fetch image overrides
 	var err error
-	ret.Images, err = config.GetImageOverrides(ctx, o.Client)
+	ret.Images, err = config.GetImageOverrides(ctx, o.Client, opts.Registries, o.Logger)
 	if err != nil {
 		return ret, fmt.Errorf("failed to get image overrides: %w", err)
 	}


### PR DESCRIPTION
This PR implements support for the addonDeploymentConfig.spec.registries feature specifically for metrics collection components.