### PR TITLE
Add K8S SLO dashboards

### DIFF
--- a/internal/coo/manifests/values.go
+++ b/internal/coo/manifests/values.go
@@ -11,6 +11,7 @@ import (
 	imanifests "github.com/stolostron/multicluster-observability-addon/internal/analytics/incident-detection/manifests"
 	"github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
 	hcp "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm/hosted-control-plane"
+	slo "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm/k8s-slo"
 	incident_management "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/incident-management"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -137,6 +138,8 @@ func buildACMDashboards() []DashboardValue {
 		{acm.BuildACMClustersByAlert, "ACMClustersByAlert"},
 		{hcp.BuildACMHCPOverview, "ACMHCPOverview"},
 		{hcp.BuildACMHCPResources, "ACMHCPResources"},
+		{slo.BuildSLOAPIServer, "SLOAPIServer"},
+		{slo.BuildSLOAPIServerCluster, "SLOAPIServerCluster"},
 	}
 
 	return buildDashboards(builders, dsThanos)

--- a/internal/perses/dashboards/acm/helpers.go
+++ b/internal/perses/dashboards/acm/helpers.go
@@ -1,0 +1,78 @@
+package acm
+
+import (
+	"fmt"
+
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	v1Common "github.com/perses/perses/pkg/model/api/v1/common"
+	dashboardModel "github.com/perses/perses/pkg/model/api/v1/dashboard"
+	"github.com/perses/perses/pkg/model/api/v1/variable"
+)
+
+type GridItem struct {
+	X, Y, W, H int
+}
+
+func AddTextVariable(name string, value string, displayName string) dashboard.Option {
+	return func(builder *dashboard.Builder) error {
+		display := &variable.Display{Name: displayName}
+		builder.Dashboard.Spec.Variables = append(builder.Dashboard.Spec.Variables, dashboardModel.Variable{
+			Kind: variable.KindText,
+			Spec: &dashboardModel.TextVariableSpec{
+				TextSpec: variable.TextSpec{
+					Value:   value,
+					Display: display,
+				},
+				Name: name,
+			},
+		})
+		return nil
+	}
+}
+
+func AddCustomPanelGroup(title string, positions []GridItem, panelOpts ...panelgroup.Option) dashboard.Option {
+	return func(builder *dashboard.Builder) error {
+		pg, err := panelgroup.New(title, panelOpts...)
+		if err != nil {
+			return err
+		}
+
+		if builder.Dashboard.Spec.Panels == nil {
+			builder.Dashboard.Spec.Panels = make(map[string]*v1.Panel)
+		}
+
+		layoutIdx := len(builder.Dashboard.Spec.Layouts)
+		gridItems := make([]dashboardModel.GridItem, 0, len(pg.Panels))
+
+		for i := range pg.Panels {
+			panelRef := fmt.Sprintf("%d_%d", layoutIdx, i)
+			builder.Dashboard.Spec.Panels[panelRef] = &pg.Panels[i]
+
+			gi := positions[i]
+			gridItems = append(gridItems, dashboardModel.GridItem{
+				X:      gi.X,
+				Y:      gi.Y,
+				Width:  gi.W,
+				Height: gi.H,
+				Content: &v1Common.JSONRef{
+					Ref: fmt.Sprintf("#/spec/panels/%s", panelRef),
+				},
+			})
+		}
+
+		builder.Dashboard.Spec.Layouts = append(builder.Dashboard.Spec.Layouts, dashboardModel.Layout{
+			Kind: "Grid",
+			Spec: dashboardModel.GridLayoutSpec{
+				Display: &dashboardModel.GridLayoutDisplay{
+					Title:    title,
+					Collapse: &dashboardModel.GridLayoutCollapse{Open: true},
+				},
+				Items: gridItems,
+			},
+		})
+
+		return nil
+	}
+}

--- a/internal/perses/dashboards/acm/hosted-control-plane/acm-hcp-overview.go
+++ b/internal/perses/dashboards/acm/hosted-control-plane/acm-hcp-overview.go
@@ -1,68 +1,18 @@
 package hosted_control_plane
 
 import (
-	"fmt"
-
 	"github.com/perses/perses/go-sdk/dashboard"
-	panelgroup "github.com/perses/perses/go-sdk/panel-group"
-	v1 "github.com/perses/perses/pkg/model/api/v1"
-	v1Common "github.com/perses/perses/pkg/model/api/v1/common"
-	dashboardModel "github.com/perses/perses/pkg/model/api/v1/dashboard"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
 	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/hosted-control-plane"
 )
 
-func addCustomPanelGroup(title string, positions []gridItem, panelOpts ...panelgroup.Option) dashboard.Option {
-	return func(builder *dashboard.Builder) error {
-		pg, err := panelgroup.New(title, panelOpts...)
-		if err != nil {
-			return err
-		}
-
-		if builder.Dashboard.Spec.Panels == nil {
-			builder.Dashboard.Spec.Panels = make(map[string]*v1.Panel)
-		}
-
-		layoutIdx := len(builder.Dashboard.Spec.Layouts)
-		gridItems := make([]dashboardModel.GridItem, 0, len(pg.Panels))
-
-		for i := range pg.Panels {
-			panelRef := fmt.Sprintf("%d_%d", layoutIdx, i)
-			builder.Dashboard.Spec.Panels[panelRef] = &pg.Panels[i]
-
-			gi := positions[i]
-			gridItems = append(gridItems, dashboardModel.GridItem{
-				X:      gi.x,
-				Y:      gi.y,
-				Width:  gi.w,
-				Height: gi.h,
-				Content: &v1Common.JSONRef{
-					Ref: fmt.Sprintf("#/spec/panels/%s", panelRef),
-				},
-			})
-		}
-
-		builder.Dashboard.Spec.Layouts = append(builder.Dashboard.Spec.Layouts, dashboardModel.Layout{
-			Kind: "Grid",
-			Spec: dashboardModel.GridLayoutSpec{
-				Display: &dashboardModel.GridLayoutDisplay{
-					Title:    title,
-					Collapse: &dashboardModel.GridLayoutCollapse{Open: true},
-				},
-				Items: gridItems,
-			},
-		})
-
-		return nil
-	}
-}
-
 func withRequestBasedCapacityGroup(datasource string) dashboard.Option {
-	return addCustomPanelGroup(
+	return acm.AddCustomPanelGroup(
 		"Estimated capacity based on HCP resource requests",
-		[]gridItem{
-			{x: 0, y: 0, w: 12, h: 12},
-			{x: 12, y: 0, w: 12, h: 7},
-			{x: 12, y: 7, w: 12, h: 5},
+		[]acm.GridItem{
+			{X: 0, Y: 0, W: 12, H: 12},
+			{X: 12, Y: 0, W: 12, H: 7},
+			{X: 12, Y: 7, W: 12, H: 5},
 		},
 		panels.RequestBasedLimitEstimation(),
 		panels.WorkerNodeCapacities(datasource),
@@ -71,12 +21,12 @@ func withRequestBasedCapacityGroup(datasource string) dashboard.Option {
 }
 
 func withQPSBasedCapacityGroup(datasource string) dashboard.Option {
-	return addCustomPanelGroup(
+	return acm.AddCustomPanelGroup(
 		"Estimated capacity based on API server query (QPS)",
-		[]gridItem{
-			{x: 0, y: 0, w: 12, h: 14},
-			{x: 12, y: 0, w: 12, h: 6},
-			{x: 12, y: 6, w: 12, h: 8},
+		[]acm.GridItem{
+			{X: 0, Y: 0, W: 12, H: 14},
+			{X: 12, Y: 0, W: 12, H: 6},
+			{X: 12, Y: 6, W: 12, H: 8},
 		},
 		panels.LoadBasedLimitEstimation(),
 		panels.QPSSettings(datasource),
@@ -85,10 +35,10 @@ func withQPSBasedCapacityGroup(datasource string) dashboard.Option {
 }
 
 func withHCPListGroup(datasource string) dashboard.Option {
-	return addCustomPanelGroup(
+	return acm.AddCustomPanelGroup(
 		"Hosted Control Planes List",
-		[]gridItem{
-			{x: 0, y: 0, w: 24, h: 7},
+		[]acm.GridItem{
+			{X: 0, Y: 0, W: 24, H: 7},
 		},
 		panels.HCPList(datasource),
 	)

--- a/internal/perses/dashboards/acm/hosted-control-plane/acm-hcp-resources.go
+++ b/internal/perses/dashboards/acm/hosted-control-plane/acm-hcp-resources.go
@@ -12,23 +12,20 @@ import (
 	v1Common "github.com/perses/perses/pkg/model/api/v1/common"
 	dashboardModel "github.com/perses/perses/pkg/model/api/v1/dashboard"
 	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
 	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/hosted-control-plane"
 )
 
-type gridItem struct {
-	x, y, w, h int
-}
-
-var hcpResourcesGridItems = []gridItem{
-	{x: 0, y: 0, w: 3, h: 4},    // 0: Number of pods
-	{x: 3, y: 0, w: 21, h: 16},  // 1: CPU usage graph
-	{x: 0, y: 4, w: 3, h: 4},    // 2: CPU Requests %
-	{x: 0, y: 8, w: 3, h: 4},    // 3: CPU Requests
-	{x: 0, y: 12, w: 3, h: 4},   // 4: CPU Usage
-	{x: 0, y: 16, w: 3, h: 4},   // 5: Memory Requests %
-	{x: 3, y: 16, w: 21, h: 14}, // 6: Memory Usage (w/o cache) graph
-	{x: 0, y: 20, w: 3, h: 5},   // 7: Memory Requests
-	{x: 0, y: 25, w: 3, h: 5},   // 8: Memory Usage
+var hcpResourcesGridItems = []acm.GridItem{
+	{X: 0, Y: 0, W: 3, H: 4},    // 0: Number of pods
+	{X: 3, Y: 0, W: 21, H: 16},  // 1: CPU usage graph
+	{X: 0, Y: 4, W: 3, H: 4},    // 2: CPU Requests %
+	{X: 0, Y: 8, W: 3, H: 4},    // 3: CPU Requests
+	{X: 0, Y: 12, W: 3, H: 4},   // 4: CPU Usage
+	{X: 0, Y: 16, W: 3, H: 4},   // 5: Memory Requests %
+	{X: 3, Y: 16, W: 21, H: 14}, // 6: Memory Usage (w/o cache) graph
+	{X: 0, Y: 20, W: 3, H: 5},   // 7: Memory Requests
+	{X: 0, Y: 25, W: 3, H: 5},   // 8: Memory Usage
 }
 
 func withHCPResourcesLayout(datasource string) dashboard.Option {
@@ -61,10 +58,10 @@ func withHCPResourcesLayout(datasource string) dashboard.Option {
 
 			gi := hcpResourcesGridItems[i]
 			gridItems = append(gridItems, dashboardModel.GridItem{
-				X:      gi.x,
-				Y:      gi.y,
-				Width:  gi.w,
-				Height: gi.h,
+				X:      gi.X,
+				Y:      gi.Y,
+				Width:  gi.W,
+				Height: gi.H,
 				Content: &v1Common.JSONRef{
 					Ref: fmt.Sprintf("#/spec/panels/%s", panelRef),
 				},

--- a/internal/perses/dashboards/acm/k8s-slo/k8s-slo-api-server-cluster.go
+++ b/internal/perses/dashboards/acm/k8s-slo/k8s-slo-api-server-cluster.go
@@ -1,0 +1,83 @@
+package slo
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/community-mixins/pkg/promql"
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/k8s-slo"
+)
+
+func withSLOOverviewGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Service-Level Overview - Kubernetes API Server Request Duration",
+		panelgroup.PanelsPerLine(3),
+		panelgroup.PanelHeight(4),
+		panels.ClusterTarget(datasource),
+		panels.ClusterPast7Days(datasource),
+		panels.ClusterPast30Days(datasource),
+	)
+}
+
+func withErrorBudget7dGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Error Budget for 7 Days",
+		panelgroup.PanelsPerLine(3),
+		panelgroup.PanelHeight(5),
+		panels.ClusterDayOfWeek(datasource),
+		panels.ClusterErrorBudget7d(datasource),
+		panels.ClusterDowntimeRemaining7d(datasource),
+	)
+}
+
+func withErrorBudget30dGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Error Budget for 30 Days",
+		panelgroup.PanelsPerLine(3),
+		panelgroup.PanelHeight(5),
+		panels.ClusterDayOfMonth(datasource),
+		panels.ClusterErrorBudget30d(datasource),
+		panels.ClusterDowntimeRemaining30d(datasource),
+	)
+}
+
+func withTrendGroup(datasource string) dashboard.Option {
+	return acm.AddCustomPanelGroup(
+		"Trend",
+		[]acm.GridItem{
+			{X: 0, Y: 0, W: 24, H: 8}, // SLI trend time series
+			{X: 0, Y: 8, W: 24, H: 6}, // SLI table
+		},
+		panels.ClusterSLITrend(datasource),
+		panels.ClusterSLITable(datasource),
+	)
+}
+
+func BuildSLOAPIServerCluster(project string, datasource string, _ string) (dashboard.Builder, error) {
+	return dashboard.New("k8s-slo-api-server-cluster",
+		dashboard.ProjectName(project),
+		dashboard.Name("Kubernetes / Service-Level Overview / API Server / Cluster"),
+
+		dashboard.AddVariable("cluster",
+			listVar.List(
+				labelValuesVar.PrometheusLabelValues("cluster",
+					dashboards.AddVariableDatasource(datasource),
+					labelValuesVar.Matchers(
+						promql.SetLabelMatchers(
+							"sli:apiserver_request_duration_seconds:trend:1m",
+							[]promql.LabelMatcher{},
+						),
+					),
+				),
+				listVar.DisplayName("Cluster"),
+				listVar.AllowAllValue(false),
+				listVar.AllowMultiple(false),
+			),
+		),
+
+		withSLOOverviewGroup(datasource),
+		withErrorBudget7dGroup(datasource),
+		withErrorBudget30dGroup(datasource),
+		withTrendGroup(datasource),
+	)
+}

--- a/internal/perses/dashboards/acm/k8s-slo/k8s-slo-api-server-cluster.go
+++ b/internal/perses/dashboards/acm/k8s-slo/k8s-slo-api-server-cluster.go
@@ -45,8 +45,8 @@ func withTrendGroup(datasource string) dashboard.Option {
 	return acm.AddCustomPanelGroup(
 		"Trend",
 		[]acm.GridItem{
-			{X: 0, Y: 0, W: 24, H: 8}, // SLI trend time series
-			{X: 0, Y: 8, W: 24, H: 6}, // SLI table
+			{X: 0, Y: 0, W: 24, H: 8},
+			{X: 0, Y: 8, W: 24, H: 6},
 		},
 		panels.ClusterSLITrend(datasource),
 		panels.ClusterSLITable(datasource),

--- a/internal/perses/dashboards/acm/k8s-slo/k8s-slo-api-server.go
+++ b/internal/perses/dashboards/acm/k8s-slo/k8s-slo-api-server.go
@@ -14,9 +14,9 @@ func withFleetOverviewGroup(datasource string) dashboard.Option {
 	return acm.AddCustomPanelGroup(
 		"Fleet Overview",
 		[]acm.GridItem{
-			{X: 0, Y: 0, W: 12, H: 5},  // Clusters exceeded SLO
-			{X: 12, Y: 0, W: 12, H: 5}, // Clusters meeting SLO
-			{X: 0, Y: 5, W: 24, H: 7},  // Top Clusters table
+			{X: 0, Y: 0, W: 12, H: 5},
+			{X: 12, Y: 0, W: 12, H: 5},
+			{X: 0, Y: 5, W: 24, H: 7},
 		},
 		panels.FleetClustersExceededSLO(datasource),
 		panels.FleetClustersMeetingSLO(datasource),

--- a/internal/perses/dashboards/acm/k8s-slo/k8s-slo-api-server.go
+++ b/internal/perses/dashboards/acm/k8s-slo/k8s-slo-api-server.go
@@ -1,0 +1,65 @@
+package slo
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/community-mixins/pkg/promql"
+	"github.com/perses/perses/go-sdk/dashboard"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/k8s-slo"
+)
+
+func withFleetOverviewGroup(datasource string) dashboard.Option {
+	return acm.AddCustomPanelGroup(
+		"Fleet Overview",
+		[]acm.GridItem{
+			{X: 0, Y: 0, W: 12, H: 5},  // Clusters exceeded SLO
+			{X: 12, Y: 0, W: 12, H: 5}, // Clusters meeting SLO
+			{X: 0, Y: 5, W: 24, H: 7},  // Top Clusters table
+		},
+		panels.FleetClustersExceededSLO(datasource),
+		panels.FleetClustersMeetingSLO(datasource),
+		panels.FleetTopClusters(datasource),
+	)
+}
+
+func withFleetSLITrendGroup(datasource string) dashboard.Option {
+	return acm.AddCustomPanelGroup(
+		"API Server Request Duration - Status",
+		[]acm.GridItem{
+			{X: 0, Y: 0, W: 24, H: 9},
+		},
+		panels.FleetSLITrend(datasource),
+	)
+}
+
+func BuildSLOAPIServer(project string, datasource string, _ string) (dashboard.Builder, error) {
+	return dashboard.New("k8s-slo-api-server",
+		dashboard.ProjectName(project),
+		dashboard.Name("Kubernetes / Service-Level Overview / API Server"),
+
+		dashboard.AddVariable("cluster",
+			listVar.List(
+				labelValuesVar.PrometheusLabelValues("cluster",
+					dashboards.AddVariableDatasource(datasource),
+					labelValuesVar.Matchers(
+						promql.SetLabelMatchers(
+							"sli:apiserver_request_duration_seconds:trend:1m",
+							[]promql.LabelMatcher{},
+						),
+					),
+				),
+				listVar.DisplayName("Cluster"),
+				listVar.AllowAllValue(true),
+				listVar.AllowMultiple(true),
+			),
+		),
+
+		acm.AddTextVariable("window", "7d", "Window"),
+		acm.AddTextVariable("top", "20", "Top"),
+
+		withFleetOverviewGroup(datasource),
+		withFleetSLITrendGroup(datasource),
+	)
+}

--- a/internal/perses/panels/acm/k8s-slo/k8s-slo-api-server-cluster.go
+++ b/internal/perses/panels/acm/k8s-slo/k8s-slo-api-server-cluster.go
@@ -1,0 +1,313 @@
+package slo
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	gaugePanel "github.com/perses/plugins/gaugechart/sdk/go"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	tsPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+// Service-Level Overview group panels
+
+func ClusterTarget(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Target",
+		panel.Description("The service-level target for the API server request duration service-level objective (SLO)."),
+		statPanel.Chart(
+			statPanel.Calculation(common.LastNumberCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["SLIBinTrend"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterPast7Days(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Past 7 Days",
+		panel.Description("Service-level objective (SLO) status from over a 7 days period. (The SLO is calculated from # of request duration >= target / total count of request durations)"),
+		statPanel.Chart(
+			statPanel.Calculation(common.LastNumberCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "red"},
+					{Value: 95, Color: "#EAB839"},
+					{Value: 99, Color: "green"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["SLO7d"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterPast30Days(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Past 30 Days",
+		panel.Description("Service-level objective (SLO) status from over a 30 days period. (The SLO is calculated from # of request duration >= target / total count of request durations)"),
+		statPanel.Chart(
+			statPanel.Calculation(common.LastNumberCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "red"},
+					{Value: 95, Color: "#EAB839"},
+					{Value: 99, Color: "green"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["SLO30d"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+// Error Budget for 7 Days group panels
+
+func ClusterDayOfWeek(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Day of the week",
+		panel.Description("The current day within the week period."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation(common.LastNumberCalculation),
+			gaugePanel.Max(7),
+			gaugePanel.Format(common.Format{
+				Unit: &dashboards.DecimalUnit,
+			}),
+			gaugePanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "orange"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["DayOfWeek"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterErrorBudget7d(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Error Budget (Past 7 Days)",
+		panel.Description("The amount of error budget that has been consumed for the API server request duration service-level objective (SLO)."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation(common.LastNumberCalculation),
+			gaugePanel.Max(1),
+			gaugePanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			gaugePanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 50, Color: "#EAB839"},
+					{Value: 80, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["ErrorBudget7d"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterDowntimeRemaining7d(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Downtime Remaining (Past 7-days)",
+		panel.Description("The time remaining within the 7d period in which the cluster can afford downtime."),
+		statPanel.Chart(
+			statPanel.Calculation(common.LastNumberCalculation),
+			statPanel.Format(common.Format{
+				Unit: &minutesUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["DowntimeRemaining7d"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+// Error Budget for 30 Days group panels
+
+func ClusterDayOfMonth(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Day of the month",
+		panel.Description("The current day within the month period."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation(common.LastNumberCalculation),
+			gaugePanel.Max(31),
+			gaugePanel.Format(common.Format{
+				Unit: &dashboards.DecimalUnit,
+			}),
+			gaugePanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "orange"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["DayOfMonth"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterErrorBudget30d(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Error Budget (Past 30 Days)",
+		panel.Description("The amount of error budget that has been consumed for the API server request duration service-level objective (SLO)."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation(common.LastNumberCalculation),
+			gaugePanel.Max(1),
+			gaugePanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			gaugePanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 50, Color: "#EAB839"},
+					{Value: 80, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["ErrorBudget30d"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterDowntimeRemaining30d(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Downtime Remaining (Past 30-days)",
+		panel.Description("The time remaining within the 30d period in which the cluster can afford downtime."),
+		statPanel.Chart(
+			statPanel.Calculation(common.LastNumberCalculation),
+			statPanel.Format(common.Format{
+				Unit: &minutesUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["DowntimeRemaining30d"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+// Trend group panels
+
+func ClusterSLITrend(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("API Server Request Duration - SLI",
+		panel.Description("Trending graph of the service-level indicators (SLI) over relative time period used to compute the service-level objective (SLO)."),
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+				Min: 0.8,
+				Max: 1,
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 0,
+				PointRadius: 1,
+				ShowPoints:  tsPanel.AlwaysShowPoints,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["SLITrend"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TargetThreshold"].Pretty(0),
+				query.SeriesNameFormat("Target Threshold"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterSLITable(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("API Server Request Duration - SLI ",
+		panel.Description("The collected service-level indicator (SLI) values for the API server request duration service-level objective (SLO), over the relative time range."),
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name:   "timestamp",
+					Header: "Time",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "cluster",
+					Header: "Cluster",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "clusterID",
+					Header: "ClusterID",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value",
+					Header: "SLI",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit: &dashboards.PercentDecimalUnit,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["SLITrend"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}

--- a/internal/perses/panels/acm/k8s-slo/k8s-slo-api-server-cluster.go
+++ b/internal/perses/panels/acm/k8s-slo/k8s-slo-api-server-cluster.go
@@ -12,8 +12,6 @@ import (
 	tsPanel "github.com/perses/plugins/timeserieschart/sdk/go"
 )
 
-// Service-Level Overview group panels
-
 func ClusterTarget(datasource string) panelgroup.Option {
 	return panelgroup.AddPanel("Target",
 		panel.Description("The service-level target for the API server request duration service-level objective (SLO)."),
@@ -157,8 +155,6 @@ func ClusterDowntimeRemaining7d(datasource string) panelgroup.Option {
 	)
 }
 
-// Error Budget for 30 Days group panels
-
 func ClusterDayOfMonth(datasource string) panelgroup.Option {
 	return panelgroup.AddPanel("Day of the month",
 		panel.Description("The current day within the month period."),
@@ -232,8 +228,6 @@ func ClusterDowntimeRemaining30d(datasource string) panelgroup.Option {
 	)
 }
 
-// Trend group panels
-
 func ClusterSLITrend(datasource string) panelgroup.Option {
 	return panelgroup.AddPanel("API Server Request Duration - SLI",
 		panel.Description("Trending graph of the service-level indicators (SLI) over relative time period used to compute the service-level objective (SLO)."),
@@ -277,6 +271,18 @@ func ClusterSLITable(datasource string) panelgroup.Option {
 		panel.Description("The collected service-level indicator (SLI) values for the API server request duration service-level objective (SLO), over the relative time range."),
 		tablePanel.Table(
 			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "prometheus",
+					Hide: true,
+				},
+				{
+					Name: "receive",
+					Hide: true,
+				},
+				{
+					Name: "tenant_id",
+					Hide: true,
+				},
 				{
 					Name:   "timestamp",
 					Header: "Time",

--- a/internal/perses/panels/acm/k8s-slo/k8s-slo-api-server.go
+++ b/internal/perses/panels/acm/k8s-slo/k8s-slo-api-server.go
@@ -122,11 +122,6 @@ func FleetTopClusters(datasource string) panelgroup.Option {
 					Align:  tablePanel.LeftAlign,
 				},
 				{
-					Name:   "target",
-					Header: "Target",
-					Align:  tablePanel.LeftAlign,
-				},
-				{
 					Name:   "value #1",
 					Header: "SLO",
 					Align:  tablePanel.LeftAlign,

--- a/internal/perses/panels/acm/k8s-slo/k8s-slo-api-server.go
+++ b/internal/perses/panels/acm/k8s-slo/k8s-slo-api-server.go
@@ -1,0 +1,201 @@
+package slo
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	tsPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+func FleetClustersExceededSLO(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Number of cluster that has exceeded the SLO",
+		panel.Description("A total number of the clusters that have exceeded their service-level objective (SLO) target."),
+		statPanel.Chart(
+			statPanel.Calculation(common.LastNumberCalculation),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 1, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				FleetQueries["ClustersExceededSLO"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func FleetClustersMeetingSLO(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Number of clusters that are meeting the SLO",
+		panel.Description("A total number of clusters that haven't breached the service-level objective (SLO) target."),
+		statPanel.Chart(
+			statPanel.Calculation(common.LastNumberCalculation),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "red"},
+					{Value: 1, Color: "green"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				FleetQueries["ClustersMeetingSLO"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func FleetTopClusters(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Top Clusters",
+		panel.Description("List of the topk cluster over a $window period. The results are sorted from worst offending clusters to passing clusters."),
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "cluster",
+					},
+				},
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "clusterID",
+					},
+				},
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "prometheus",
+					},
+				},
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "receive",
+					},
+				},
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "tenant_id",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"cluster"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name: "clusterID",
+					Hide: true,
+				},
+				{
+					Name: "prometheus",
+					Hide: true,
+				},
+				{
+					Name: "receive",
+					Hide: true,
+				},
+				{
+					Name: "tenant_id",
+					Hide: true,
+				},
+				{
+					Name:   "cluster",
+					Header: "Cluster",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "target",
+					Header: "Target",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "SLO",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit: &dashboards.PercentDecimalUnit,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "Error Budget",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit: &dashboards.PercentDecimalUnit,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				FleetQueries["TopClustersSLO"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				FleetQueries["TopClustersErrorBudget"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func FleetSLITrend(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Top Cluster's SLI Trend",
+		panel.Description("The service-level indicator (SLI) trend of the topk clusters over a relative time. The results are sorted from worst offending clusters to passing clusters."),
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+				Min: 0.8,
+				Max: 1,
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 0,
+				PointRadius: 1,
+				ShowPoints:  tsPanel.AlwaysShowPoints,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				FleetQueries["TopClustersSLITrend"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				FleetQueries["TargetThreshold"].Pretty(0),
+				query.SeriesNameFormat("Target Threshold"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+var minutesUnit = string(common.MinutesUnit)

--- a/internal/perses/panels/acm/k8s-slo/k8s-slo-queries.go
+++ b/internal/perses/panels/acm/k8s-slo/k8s-slo-queries.go
@@ -87,7 +87,6 @@ func errorBudget(rangeStr string) parser.Expr {
 
 // Fleet-level SLO queries (use $window variable for range)
 var FleetQueries = map[string]parser.Expr{
-
 	"ClustersExceededSLO": promqlbuilder.Sum(
 		promqlbuilder.Lss(
 			fleetSLO(),

--- a/internal/perses/panels/acm/k8s-slo/k8s-slo-queries.go
+++ b/internal/perses/panels/acm/k8s-slo/k8s-slo-queries.go
@@ -1,0 +1,180 @@
+package slo
+
+import (
+	promqlbuilder "github.com/perses/promql-builder"
+	"github.com/perses/promql-builder/label"
+	"github.com/perses/promql-builder/matrix"
+	"github.com/perses/promql-builder/vector"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/promql/parser/posrange"
+)
+
+// variableExpr renders a Perses variable reference (e.g. $top) as a PromQL expression.
+type variableExpr struct {
+	name string
+}
+
+func (v *variableExpr) String() string                            { return v.name }
+func (v *variableExpr) Pretty(int) string                         { return v.name }
+func (v *variableExpr) Type() parser.ValueType                    { return parser.ValueTypeScalar }
+func (v *variableExpr) PromQLExpr()                               {}
+func (v *variableExpr) PositionRange() posrange.PositionRange     { return posrange.PositionRange{} }
+func (v *variableExpr) SetPositionRange(_ posrange.PositionRange) {}
+
+// fleetSLIBinTrendMatrix returns a matrix selector for the SLI bin trend metric
+// with cluster regex match and $window range variable.
+func fleetSLIBinTrendMatrix() *matrix.Builder {
+	return matrix.New(
+		vector.New(
+			vector.WithMetricName("sli:apiserver_request_duration_seconds:bin:trend:1m"),
+			vector.WithLabelMatchers(
+				label.New("cluster").EqualRegexp("$cluster"),
+			),
+		),
+		matrix.WithRangeAsVariable("$window"),
+	)
+}
+
+// fleetSLO returns floor(sum_over_time(sli_bin_trend[$window])) / count_over_time(sli_bin_trend[$window])
+func fleetSLO() parser.Expr {
+	return promqlbuilder.Div(
+		promqlbuilder.Floor(promqlbuilder.SumOverTime(fleetSLIBinTrendMatrix())),
+		promqlbuilder.CountOverTime(fleetSLIBinTrendMatrix()),
+	)
+}
+
+// bottomKVariable creates a bottomk aggregation using a variable parameter (e.g. $top).
+func bottomKVariable(variable string, expr parser.Expr) *parser.AggregateExpr {
+	return &parser.AggregateExpr{
+		Op:    parser.BOTTOMK,
+		Expr:  expr,
+		Param: &variableExpr{name: variable},
+	}
+}
+
+// clusterSLIBinTrendMatrix returns a matrix selector for the SLI bin trend metric
+// with exact cluster match and the given range string.
+func clusterSLIBinTrendMatrix(rangeStr string) *matrix.Builder {
+	return matrix.New(
+		vector.New(
+			vector.WithMetricName("sli:apiserver_request_duration_seconds:bin:trend:1m"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+			),
+		),
+		matrix.WithRangeAsString(rangeStr),
+	)
+}
+
+// clusterSLO returns max(floor(sum_over_time(sli_bin_trend[range])) / count_over_time(sli_bin_trend[range]))
+// Wrapped in max() to collapse extra labels (receive, tenant_id, etc.) into a single series for stat/gauge panels.
+func clusterSLO(rangeStr string) parser.Expr {
+	return promqlbuilder.Max(
+		promqlbuilder.Div(
+			promqlbuilder.Floor(promqlbuilder.SumOverTime(clusterSLIBinTrendMatrix(rangeStr))),
+			promqlbuilder.CountOverTime(clusterSLIBinTrendMatrix(rangeStr)),
+		),
+	)
+}
+
+// errorBudget returns 0.99 - SLO(range)
+func errorBudget(rangeStr string) parser.Expr {
+	return promqlbuilder.Sub(
+		promqlbuilder.NewNumber(0.99),
+		clusterSLO(rangeStr),
+	)
+}
+
+// Fleet-level SLO queries (use $window variable for range)
+var FleetQueries = map[string]parser.Expr{
+	// Number of clusters exceeding SLO target
+	"ClustersExceededSLO": promqlbuilder.Sum(
+		promqlbuilder.Lss(
+			fleetSLO(),
+			promqlbuilder.NewNumber(0.99),
+		).Bool(),
+	),
+	// Number of clusters meeting SLO target
+	"ClustersMeetingSLO": promqlbuilder.Sum(
+		promqlbuilder.Gte(
+			fleetSLO(),
+			promqlbuilder.NewNumber(0.99),
+		).Bool(),
+	),
+	// Top clusters sorted by worst SLO
+	"TopClustersSLO": promqlbuilder.SortDesc(
+		bottomKVariable("$top", fleetSLO()),
+	),
+	// Top clusters error budget
+	"TopClustersErrorBudget": promqlbuilder.Sub(
+		promqlbuilder.NewNumber(0.99),
+		promqlbuilder.SortDesc(
+			bottomKVariable("$top", fleetSLO()),
+		),
+	),
+	// Top clusters SLI trend
+	"TopClustersSLITrend": bottomKVariable("$top",
+		vector.New(
+			vector.WithMetricName("sli:apiserver_request_duration_seconds:trend:1m"),
+			vector.WithLabelMatchers(
+				label.New("cluster").EqualRegexp("$cluster"),
+			),
+		),
+	),
+	// Target threshold line
+	"TargetThreshold": promqlbuilder.NewNumber(0.99),
+}
+
+// Cluster-level SLO queries
+var ClusterQueries = map[string]parser.Expr{
+	// SLI bin trend (for Target stat)
+	"SLIBinTrend": vector.New(
+		vector.WithMetricName("sli:apiserver_request_duration_seconds:bin:trend:1m"),
+		vector.WithLabelMatchers(
+			label.New("cluster").Equal("$cluster"),
+		),
+	),
+	// SLO over 7 days
+	"SLO7d": clusterSLO("7d"),
+	// SLO over 30 days
+	"SLO30d": clusterSLO("30d"),
+	// Day of the week
+	"DayOfWeek": &parser.Call{
+		Func: parser.Functions["day_of_week"],
+		Args: parser.Expressions{},
+	},
+	// Day of the month
+	"DayOfMonth": &parser.Call{
+		Func: parser.Functions["day_of_month"],
+		Args: parser.Expressions{},
+	},
+	// Error budget consumed (7 days)
+	"ErrorBudget7d": errorBudget("7d"),
+	// Error budget consumed (30 days)
+	"ErrorBudget30d": errorBudget("30d"),
+	// Downtime remaining (7 days) in minutes: error_budget * total_minutes * -1
+	"DowntimeRemaining7d": promqlbuilder.Mul(
+		promqlbuilder.Mul(
+			errorBudget("7d"),
+			promqlbuilder.NewNumber(10080), // 7 * 24 * 60
+		),
+		promqlbuilder.NewNumber(-1),
+	),
+	// Downtime remaining (30 days) in minutes: error_budget * total_minutes * -1
+	"DowntimeRemaining30d": promqlbuilder.Mul(
+		promqlbuilder.Mul(
+			errorBudget("30d"),
+			promqlbuilder.NewNumber(43200), // 30 * 24 * 60
+		),
+		promqlbuilder.NewNumber(-1),
+	),
+	// SLI trend
+	"SLITrend": vector.New(
+		vector.WithMetricName("sli:apiserver_request_duration_seconds:trend:1m"),
+		vector.WithLabelMatchers(
+			label.New("cluster").Equal("$cluster"),
+		),
+	),
+	// Target threshold line
+	"TargetThreshold": promqlbuilder.NewNumber(0.99),
+}

--- a/internal/perses/panels/acm/k8s-slo/k8s-slo-queries.go
+++ b/internal/perses/panels/acm/k8s-slo/k8s-slo-queries.go
@@ -87,32 +87,32 @@ func errorBudget(rangeStr string) parser.Expr {
 
 // Fleet-level SLO queries (use $window variable for range)
 var FleetQueries = map[string]parser.Expr{
-	// Number of clusters exceeding SLO target
+
 	"ClustersExceededSLO": promqlbuilder.Sum(
 		promqlbuilder.Lss(
 			fleetSLO(),
 			promqlbuilder.NewNumber(0.99),
 		).Bool(),
 	),
-	// Number of clusters meeting SLO target
+
 	"ClustersMeetingSLO": promqlbuilder.Sum(
 		promqlbuilder.Gte(
 			fleetSLO(),
 			promqlbuilder.NewNumber(0.99),
 		).Bool(),
 	),
-	// Top clusters sorted by worst SLO
+
 	"TopClustersSLO": promqlbuilder.SortDesc(
 		bottomKVariable("$top", fleetSLO()),
 	),
-	// Top clusters error budget
+
 	"TopClustersErrorBudget": promqlbuilder.Sub(
 		promqlbuilder.NewNumber(0.99),
 		promqlbuilder.SortDesc(
 			bottomKVariable("$top", fleetSLO()),
 		),
 	),
-	// Top clusters SLI trend
+
 	"TopClustersSLITrend": bottomKVariable("$top",
 		vector.New(
 			vector.WithMetricName("sli:apiserver_request_duration_seconds:trend:1m"),
@@ -121,46 +121,44 @@ var FleetQueries = map[string]parser.Expr{
 			),
 		),
 	),
-	// Target threshold line
+
 	"TargetThreshold": promqlbuilder.NewNumber(0.99),
 }
 
-// Cluster-level SLO queries
 var ClusterQueries = map[string]parser.Expr{
-	// SLI bin trend (for Target stat)
 	"SLIBinTrend": vector.New(
 		vector.WithMetricName("sli:apiserver_request_duration_seconds:bin:trend:1m"),
 		vector.WithLabelMatchers(
 			label.New("cluster").Equal("$cluster"),
 		),
 	),
-	// SLO over 7 days
+
 	"SLO7d": clusterSLO("7d"),
-	// SLO over 30 days
+
 	"SLO30d": clusterSLO("30d"),
-	// Day of the week
+
 	"DayOfWeek": &parser.Call{
 		Func: parser.Functions["day_of_week"],
 		Args: parser.Expressions{},
 	},
-	// Day of the month
+
 	"DayOfMonth": &parser.Call{
 		Func: parser.Functions["day_of_month"],
 		Args: parser.Expressions{},
 	},
-	// Error budget consumed (7 days)
+
 	"ErrorBudget7d": errorBudget("7d"),
-	// Error budget consumed (30 days)
+
 	"ErrorBudget30d": errorBudget("30d"),
-	// Downtime remaining (7 days) in minutes: error_budget * total_minutes * -1
+
 	"DowntimeRemaining7d": promqlbuilder.Mul(
 		promqlbuilder.Mul(
 			errorBudget("7d"),
-			promqlbuilder.NewNumber(10080), // 7 * 24 * 60
+			promqlbuilder.NewNumber(10080),
 		),
 		promqlbuilder.NewNumber(-1),
 	),
-	// Downtime remaining (30 days) in minutes: error_budget * total_minutes * -1
+
 	"DowntimeRemaining30d": promqlbuilder.Mul(
 		promqlbuilder.Mul(
 			errorBudget("30d"),
@@ -168,13 +166,13 @@ var ClusterQueries = map[string]parser.Expr{
 		),
 		promqlbuilder.NewNumber(-1),
 	),
-	// SLI trend
+
 	"SLITrend": vector.New(
 		vector.WithMetricName("sli:apiserver_request_duration_seconds:trend:1m"),
 		vector.WithLabelMatchers(
 			label.New("cluster").Equal("$cluster"),
 		),
 	),
-	// Target threshold line
+
 	"TargetThreshold": promqlbuilder.NewNumber(0.99),
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes API Server SLO dashboards for fleet and cluster scopes.
  * New panels: SLO targets, past‑7/30d summaries, error budget, downtime remaining, SLI trend charts, and top‑clusters tables.
  * Multi‑select cluster variable and configurable window/top controls for filtering and horizon selection.
  * Improved dashboard layout/grouping for more consistent custom panel groups and grid composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->