### PR TITLE
Add K8s compute dashboards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY main.go main.go
 COPY internal/ internal/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=readonly -a -o multicluster-observability-addon main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -mod=readonly -a -o multicluster-observability-addon main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25.5 as builder
+FROM --platform=$BUILDPLATFORM golang:1.25.8 as builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -17,7 +17,7 @@ COPY main.go main.go
 COPY internal/ internal/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -mod=readonly -a -o multicluster-observability-addon main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod=readonly -a -o multicluster-observability-addon main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/internal/coo/manifests/values.go
+++ b/internal/coo/manifests/values.go
@@ -11,6 +11,7 @@ import (
 	imanifests "github.com/stolostron/multicluster-observability-addon/internal/analytics/incident-detection/manifests"
 	"github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
 	hcp "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm/hosted-control-plane"
+	compute "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm/k8s/compute"
 	networking "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm/k8s/networking"
 	slo "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm/k8s/slo"
 	incident_management "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/incident-management"
@@ -145,6 +146,12 @@ func buildACMDashboards() []DashboardValue {
 		{networking.BuildNetworkingNamespacePods, "NetworkingNamespacePods"},
 		{networking.BuildNetworkingNode, "NetworkingNode"},
 		{networking.BuildNetworkingPod, "NetworkingPod"},
+		{compute.BuildComputeCluster, "ComputeCluster"},
+		{compute.BuildComputeNamespacePods, "ComputeNamespacePods"},
+		{compute.BuildComputeNamespaceWorkloads, "ComputeNamespaceWorkloads"},
+		{compute.BuildComputeNodePods, "ComputeNodePods"},
+		{compute.BuildComputePod, "ComputePod"},
+		{compute.BuildComputeWorkload, "ComputeWorkload"},
 	}
 
 	return buildDashboards(builders, dsThanos)

--- a/internal/perses/dashboards/acm/k8s/compute/compute-cluster.go
+++ b/internal/perses/dashboards/acm/k8s/compute/compute-cluster.go
@@ -1,0 +1,75 @@
+package compute
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/k8s/compute"
+)
+
+func withClusterHeadlinesGroup(datasource string) dashboard.Option {
+	return acm.AddCustomPanelGroup(
+		"Headlines",
+		[]acm.GridItem{
+			{X: 0, Y: 0, W: 4, H: 3},
+			{X: 4, Y: 0, W: 4, H: 3},
+			{X: 8, Y: 0, W: 4, H: 3},
+			{X: 12, Y: 0, W: 4, H: 3},
+			{X: 16, Y: 0, W: 4, H: 3},
+			{X: 20, Y: 0, W: 4, H: 3},
+		},
+		panels.ClusterCPUUtilisation(datasource),
+		panels.ClusterCPURequestsCommitment(datasource),
+		panels.ClusterCPULimitsCommitment(datasource),
+		panels.ClusterMemoryUtilisation(datasource),
+		panels.ClusterMemoryRequestsCommitment(datasource),
+		panels.ClusterMemoryLimitsCommitment(datasource),
+	)
+}
+
+func withClusterCPUGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.ClusterCPUUsage(datasource),
+	)
+}
+
+func withClusterCPUQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(14),
+		panels.ClusterCPUQuota(datasource),
+	)
+}
+
+func withClusterMemoryGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.ClusterMemoryUsage(datasource),
+	)
+}
+
+func withClusterMemoryQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Requests",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(12),
+		panels.ClusterMemoryQuota(datasource),
+	)
+}
+
+func BuildComputeCluster(project string, datasource string, _ string) (dashboard.Builder, error) {
+	return dashboard.New("k8s-compute-resources-cluster",
+		dashboard.ProjectName(project),
+		dashboard.Name("Kubernetes / Compute Resources / Cluster"),
+
+		acm.GetClusterVariable(datasource),
+
+		withClusterHeadlinesGroup(datasource),
+		withClusterCPUGroup(datasource),
+		withClusterCPUQuotaGroup(datasource),
+		withClusterMemoryGroup(datasource),
+		withClusterMemoryQuotaGroup(datasource),
+	)
+}

--- a/internal/perses/dashboards/acm/k8s/compute/compute-namespace-pods.go
+++ b/internal/perses/dashboards/acm/k8s/compute/compute-namespace-pods.go
@@ -1,0 +1,72 @@
+package compute
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/k8s/compute"
+)
+
+func withNamespacePodsHeadlinesGroup(datasource string) dashboard.Option {
+	return acm.AddCustomPanelGroup(
+		"Headlines",
+		[]acm.GridItem{
+			{X: 0, Y: 0, W: 6, H: 3},
+			{X: 6, Y: 0, W: 6, H: 3},
+			{X: 12, Y: 0, W: 6, H: 3},
+			{X: 18, Y: 0, W: 6, H: 3},
+		},
+		panels.NamespacePodsCPUUtilisationFromRequests(datasource),
+		panels.NamespacePodsCPUUtilisationFromLimits(datasource),
+		panels.NamespacePodsMemoryUtilisationFromRequests(datasource),
+		panels.NamespacePodsMemoryUtilisationFromLimits(datasource),
+	)
+}
+
+func withNamespacePodsCPUUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.NamespacePodsCPUUsage(datasource),
+	)
+}
+
+func withNamespacePodsCPUQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(8),
+		panels.NamespacePodsCPUQuota(datasource),
+	)
+}
+
+func withNamespacePodsMemoryUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.NamespacePodsMemoryUsage(datasource),
+	)
+}
+
+func withNamespacePodsMemoryQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(8),
+		panels.NamespacePodsMemoryQuota(datasource),
+	)
+}
+
+func BuildComputeNamespacePods(project string, datasource string, _ string) (dashboard.Builder, error) {
+	return dashboard.New("k8s-compute-resources-namespace-pods",
+		dashboard.ProjectName(project),
+		dashboard.Name("Kubernetes / Compute Resources / Namespace (Pods)"),
+
+		acm.GetClusterVariable(datasource),
+		acm.GetNamespaceVariable(datasource),
+
+		withNamespacePodsHeadlinesGroup(datasource),
+		withNamespacePodsCPUUsageGroup(datasource),
+		withNamespacePodsCPUQuotaGroup(datasource),
+		withNamespacePodsMemoryUsageGroup(datasource),
+		withNamespacePodsMemoryQuotaGroup(datasource),
+	)
+}

--- a/internal/perses/dashboards/acm/k8s/compute/compute-namespace-workloads.go
+++ b/internal/perses/dashboards/acm/k8s/compute/compute-namespace-workloads.go
@@ -1,0 +1,56 @@
+package compute
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/k8s/compute"
+)
+
+func withNamespaceWorkloadsCPUUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.NamespaceWorkloadsCPUUsage(datasource),
+	)
+}
+
+func withNamespaceWorkloadsCPUQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(12),
+		panels.NamespaceWorkloadsCPUQuota(datasource),
+	)
+}
+
+func withNamespaceWorkloadsMemoryUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.NamespaceWorkloadsMemoryUsage(datasource),
+	)
+}
+
+func withNamespaceWorkloadsMemoryQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(11),
+		panels.NamespaceWorkloadsMemoryQuota(datasource),
+	)
+}
+
+func BuildComputeNamespaceWorkloads(project string, datasource string, _ string) (dashboard.Builder, error) {
+	return dashboard.New("k8s-compute-resources-namespace-workloads",
+		dashboard.ProjectName(project),
+		dashboard.Name("Kubernetes / Compute Resources / Namespace (Workloads)"),
+
+		acm.GetClusterVariable(datasource),
+		acm.GetNamespaceVariable(datasource),
+		acm.GetTypeVariable(datasource),
+
+		withNamespaceWorkloadsCPUUsageGroup(datasource),
+		withNamespaceWorkloadsCPUQuotaGroup(datasource),
+		withNamespaceWorkloadsMemoryUsageGroup(datasource),
+		withNamespaceWorkloadsMemoryQuotaGroup(datasource),
+	)
+}

--- a/internal/perses/dashboards/acm/k8s/compute/compute-node-pods.go
+++ b/internal/perses/dashboards/acm/k8s/compute/compute-node-pods.go
@@ -1,0 +1,55 @@
+package compute
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/k8s/compute"
+)
+
+func withNodePodsCPUUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.NodePodsCPUUsage(datasource),
+	)
+}
+
+func withNodePodsCPUQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(12),
+		panels.NodePodsCPUQuota(datasource),
+	)
+}
+
+func withNodePodsMemoryUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(9),
+		panels.NodePodsMemoryUsage(datasource),
+	)
+}
+
+func withNodePodsMemoryQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(12),
+		panels.NodePodsMemoryQuota(datasource),
+	)
+}
+
+func BuildComputeNodePods(project string, datasource string, _ string) (dashboard.Builder, error) {
+	return dashboard.New("k8s-compute-resources-node-pods",
+		dashboard.ProjectName(project),
+		dashboard.Name("Kubernetes / Compute Resources / Node (Pods)"),
+
+		acm.GetClusterVariable(datasource),
+		acm.GetNodeVariable(datasource),
+
+		withNodePodsCPUUsageGroup(datasource),
+		withNodePodsCPUQuotaGroup(datasource),
+		withNodePodsMemoryUsageGroup(datasource),
+		withNodePodsMemoryQuotaGroup(datasource),
+	)
+}

--- a/internal/perses/dashboards/acm/k8s/compute/compute-pod.go
+++ b/internal/perses/dashboards/acm/k8s/compute/compute-pod.go
@@ -1,0 +1,65 @@
+package compute
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/k8s/compute"
+)
+
+func withPodCPUUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.PodCPUUsage(datasource),
+	)
+}
+
+func withPodCPUThrottlingGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Throttling",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.PodCPUThrottling(datasource),
+	)
+}
+
+func withPodCPUQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(9),
+		panels.PodCPUQuota(datasource),
+	)
+}
+
+func withPodMemoryUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.PodMemoryUsage(datasource),
+	)
+}
+
+func withPodMemoryQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(9),
+		panels.PodMemoryQuota(datasource),
+	)
+}
+
+func BuildComputePod(project string, datasource string, _ string) (dashboard.Builder, error) {
+	return dashboard.New("k8s-compute-resources-pod",
+		dashboard.ProjectName(project),
+		dashboard.Name("Kubernetes / Compute Resources / Pod"),
+
+		acm.GetClusterVariable(datasource),
+		acm.GetNamespaceVariable(datasource),
+		acm.GetPodVariable(datasource),
+
+		withPodCPUUsageGroup(datasource),
+		withPodCPUThrottlingGroup(datasource),
+		withPodCPUQuotaGroup(datasource),
+		withPodMemoryUsageGroup(datasource),
+		withPodMemoryQuotaGroup(datasource),
+	)
+}

--- a/internal/perses/dashboards/acm/k8s/compute/compute-workload.go
+++ b/internal/perses/dashboards/acm/k8s/compute/compute-workload.go
@@ -1,0 +1,57 @@
+package compute
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	acm "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/acm/k8s/compute"
+)
+
+func withWorkloadCPUUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.WorkloadCPUUsage(datasource),
+	)
+}
+
+func withWorkloadCPUQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("CPU Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.WorkloadCPUQuota(datasource),
+	)
+}
+
+func withWorkloadMemoryUsageGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Usage",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.WorkloadMemoryUsage(datasource),
+	)
+}
+
+func withWorkloadMemoryQuotaGroup(datasource string) dashboard.Option {
+	return dashboard.AddPanelGroup("Memory Quota",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(7),
+		panels.WorkloadMemoryQuota(datasource),
+	)
+}
+
+func BuildComputeWorkload(project string, datasource string, _ string) (dashboard.Builder, error) {
+	return dashboard.New("k8s-compute-resources-workload",
+		dashboard.ProjectName(project),
+		dashboard.Name("Kubernetes / Compute Resources / Workload"),
+
+		acm.GetClusterVariable(datasource),
+		acm.GetNamespaceVariable(datasource),
+		acm.GetWorkloadVariable(datasource),
+		acm.GetTypeVariable(datasource),
+
+		withWorkloadCPUUsageGroup(datasource),
+		withWorkloadCPUQuotaGroup(datasource),
+		withWorkloadMemoryUsageGroup(datasource),
+		withWorkloadMemoryQuotaGroup(datasource),
+	)
+}

--- a/internal/perses/panels/acm/k8s/compute/compute-cluster.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-cluster.go
@@ -14,7 +14,7 @@ import (
 // Cluster dashboard panels
 
 func ClusterCPUUtilisation(datasource string) panelgroup.Option {
-	return panelgroup.AddPanel("CPU Utilisation",
+	return panelgroup.AddPanel("CPU Utilization",
 		statPanel.Chart(
 			statPanel.Calculation(common.MeanCalculation),
 			statPanel.Format(common.Format{
@@ -86,7 +86,7 @@ func ClusterCPULimitsCommitment(datasource string) panelgroup.Option {
 }
 
 func ClusterMemoryUtilisation(datasource string) panelgroup.Option {
-	return panelgroup.AddPanel("Memory Utilisation",
+	return panelgroup.AddPanel("Memory Utilization",
 		statPanel.Chart(
 			statPanel.Calculation(common.MeanCalculation),
 			statPanel.Format(common.Format{

--- a/internal/perses/panels/acm/k8s/compute/compute-cluster.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-cluster.go
@@ -1,0 +1,540 @@
+package compute
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	tsPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+// Cluster dashboard panels
+
+func ClusterCPUUtilisation(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Utilisation",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["CPUUtilisation"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterCPURequestsCommitment(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Requests Commitment",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["CPURequestsCommitment"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterCPULimitsCommitment(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Limits Commitment",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["CPULimitsCommitment"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterMemoryUtilisation(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Utilisation",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["MemoryUtilisation"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterMemoryRequestsCommitment(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Requests Commitment",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["MemoryRequestsCommitment"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterMemoryLimitsCommitment(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Limits Commitment",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["MemoryLimitsCommitment"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterCPUUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["CPUUsageByNamespace"].Pretty(0),
+				query.SeriesNameFormat("{{ namespace }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterCPUQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "namespace",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"namespace"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name: "__name__",
+					Hide: true,
+				},
+				{
+					Name: "cluster",
+					Hide: true,
+				},
+				{
+					Name: "clusterID",
+					Hide: true,
+				},
+				{
+					Name: "prometheus",
+					Hide: true,
+				},
+				{
+					Name: "receive",
+					Hide: true,
+				},
+				{
+					Name: "tenant_id",
+					Hide: true,
+				},
+				{
+					Name:   "namespace",
+					Header: "Namespace",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "Pods",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 0,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "Workloads",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 0,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "CPU Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "CPU Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "CPU Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #6",
+					Header: "CPU Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #7",
+					Header: "CPU Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TablePodsByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableWorkloadsByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableCPUUsageByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableCPURequestsByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableCPURequestsPercentByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableCPULimitsByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableCPULimitsPercentByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterMemoryUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage (w/o cache)",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["MemoryUsageByNamespace"].Pretty(0),
+				query.SeriesNameFormat("{{ namespace }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func ClusterMemoryQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Requests by Namespace",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "namespace",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"namespace"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name: "__name__",
+					Hide: true,
+				},
+				{
+					Name: "cluster",
+					Hide: true,
+				},
+				{
+					Name: "clusterID",
+					Hide: true,
+				},
+				{
+					Name: "prometheus",
+					Hide: true,
+				},
+				{
+					Name: "receive",
+					Hide: true,
+				},
+				{
+					Name: "tenant_id",
+					Hide: true,
+				},
+				{
+					Name:   "namespace",
+					Header: "Namespace",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "Pods",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 0,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "Workloads",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 0,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "Memory Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "Memory Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "Memory Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #6",
+					Header: "Memory Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #7",
+					Header: "Memory Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TablePodsByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableWorkloadsByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableMemoryUsageByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableMemoryRequestsByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableMemoryRequestsPercentByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableMemoryLimitsByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				ClusterQueries["TableMemoryLimitsPercentByNamespace"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}

--- a/internal/perses/panels/acm/k8s/compute/compute-namespace-pods.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-namespace-pods.go
@@ -14,7 +14,7 @@ import (
 // Namespace (Pods) dashboard panels
 
 func NamespacePodsCPUUtilisationFromRequests(datasource string) panelgroup.Option {
-	return panelgroup.AddPanel("CPU Utilisation (from requests)",
+	return panelgroup.AddPanel("CPU Utilization (from requests)",
 		statPanel.Chart(
 			statPanel.Calculation(common.MeanCalculation),
 			statPanel.Format(common.Format{
@@ -38,7 +38,7 @@ func NamespacePodsCPUUtilisationFromRequests(datasource string) panelgroup.Optio
 }
 
 func NamespacePodsCPUUtilisationFromLimits(datasource string) panelgroup.Option {
-	return panelgroup.AddPanel("CPU Utilisation (from limits)",
+	return panelgroup.AddPanel("CPU Utilization (from limits)",
 		statPanel.Chart(
 			statPanel.Calculation(common.MeanCalculation),
 			statPanel.Format(common.Format{
@@ -86,7 +86,7 @@ func NamespacePodsMemoryUtilisationFromRequests(datasource string) panelgroup.Op
 }
 
 func NamespacePodsMemoryUtilisationFromLimits(datasource string) panelgroup.Option {
-	return panelgroup.AddPanel("Memory Utilisation (from limits)",
+	return panelgroup.AddPanel("Memory Utilization (from limits)",
 		statPanel.Chart(
 			statPanel.Calculation(common.MeanCalculation),
 			statPanel.Format(common.Format{

--- a/internal/perses/panels/acm/k8s/compute/compute-namespace-pods.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-namespace-pods.go
@@ -1,0 +1,444 @@
+package compute
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	tsPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+// Namespace (Pods) dashboard panels
+
+func NamespacePodsCPUUtilisationFromRequests(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Utilisation (from requests)",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["CPUUtilisationFromRequests"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespacePodsCPUUtilisationFromLimits(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Utilisation (from limits)",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["CPUUtilisationFromLimits"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespacePodsMemoryUtilisationFromRequests(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Utilization (from requests)",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["MemoryUtilisationFromRequests"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespacePodsMemoryUtilisationFromLimits(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Utilisation (from limits)",
+		statPanel.Chart(
+			statPanel.Calculation(common.MeanCalculation),
+			statPanel.Format(common.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+			statPanel.Thresholds(common.Thresholds{
+				Steps: []common.StepOption{
+					{Value: 0, Color: "green"},
+					{Value: 0.7, Color: "#EAB839"},
+					{Value: 0.8, Color: "red"},
+				},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["MemoryUtilisationFromLimits"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespacePodsCPUUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["CPUUsageByPod"].Pretty(0),
+				query.SeriesNameFormat("{{ pod }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["CPUQuotaRequests"].Pretty(0),
+				query.SeriesNameFormat("quota - requests"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["CPUQuotaLimits"].Pretty(0),
+				query.SeriesNameFormat("quota - limits"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespacePodsCPUQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "pod",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"pod"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "pod",
+					Header: "Pod",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "CPU Usage",
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "CPU Requests",
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "CPU Requests %",
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "CPU Limits",
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "CPU Limits %",
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableCPUUsageByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableCPURequestsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableCPURequestsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableCPULimitsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableCPULimitsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespacePodsMemoryUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage (w/o cache)",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["MemoryUsageByPod"].Pretty(0),
+				query.SeriesNameFormat("{{ pod }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["MemoryQuotaRequests"].Pretty(0),
+				query.SeriesNameFormat("quota - requests"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["MemoryQuotaLimits"].Pretty(0),
+				query.SeriesNameFormat("quota - limits"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespacePodsMemoryQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "pod",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"pod"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "pod",
+					Header: "Pod",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "Memory Usage",
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "Memory Requests",
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "Memory Requests %",
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "Memory Limits",
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "Memory Limits %",
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #6",
+					Header: "Memory Usage (RSS)",
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #7",
+					Header: "Memory Usage (Cache)",
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #8",
+					Header: "Memory Usage (Swap)",
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableMemoryUsageByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableMemoryRequestsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableMemoryRequestsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableMemoryLimitsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableMemoryLimitsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableMemoryRSSByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableMemoryCacheByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespacePodsQueries["TableMemorySwapByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}

--- a/internal/perses/panels/acm/k8s/compute/compute-namespace-workloads.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-namespace-workloads.go
@@ -1,0 +1,315 @@
+package compute
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	tsPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+// Namespace (Workloads) dashboard panels
+
+func NamespaceWorkloadsCPUUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["CPUUsageByWorkload"].Pretty(0),
+				query.SeriesNameFormat("{{ workload }} - {{ workload_type }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespaceWorkloadsCPUQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "workload",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"workload"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "workload",
+					Header: "Workload",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "Running Pods",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						DecimalPlaces: 0,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "CPU Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "CPU Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "CPU Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "CPU Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #6",
+					Header: "CPU Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableRunningPods"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableCPUUsageByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableCPURequestsByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableCPURequestsPercentByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableCPULimitsByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableCPULimitsPercentByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespaceWorkloadsMemoryUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["MemoryUsageByWorkload"].Pretty(0),
+				query.SeriesNameFormat("{{ workload }} - {{ workload_type }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NamespaceWorkloadsMemoryQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "workload",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"workload"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "workload",
+					Header: "Workload",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "Running Pods",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						DecimalPlaces: 0,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "Memory Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "Memory Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "Memory Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "Memory Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #6",
+					Header: "Memory Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableRunningPods"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableMemoryUsageByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableMemoryRequestsByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableMemoryRequestsPercentByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableMemoryLimitsByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NamespaceWorkloadsQueries["TableMemoryLimitsPercentByWorkload"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}

--- a/internal/perses/panels/acm/k8s/compute/compute-node-pods.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-node-pods.go
@@ -1,0 +1,332 @@
+package compute
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	tsPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+// Node (Pods) dashboard panels
+
+func NodePodsCPUUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["CPUUsageByPod"].Pretty(0),
+				query.SeriesNameFormat("{{ pod }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NodePodsCPUQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "pod",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"pod"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "pod",
+					Header: "Pod",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "CPU Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "CPU Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "CPU Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "CPU Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "CPU Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableCPUUsageByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableCPURequestsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableCPURequestsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableCPULimitsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableCPULimitsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NodePodsMemoryUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage (w/o cache)",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["MemoryUsageByPod"].Pretty(0),
+				query.SeriesNameFormat("{{ pod }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func NodePodsMemoryQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "pod",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"pod"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "pod",
+					Header: "Pod",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "Memory Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "Memory Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "Memory Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "Memory Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "Memory Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #6",
+					Header: "Memory Usage (RSS)",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #7",
+					Header: "Memory Usage (Cache)",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #8",
+					Header: "Memory Usage (Swap)",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableMemoryUsageByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableMemoryRequestsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableMemoryRequestsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableMemoryLimitsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableMemoryLimitsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableMemoryRSSByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableMemoryCacheByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				NodePodsQueries["TableMemorySwapByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}

--- a/internal/perses/panels/acm/k8s/compute/compute-pod.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-pod.go
@@ -1,0 +1,389 @@
+package compute
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	tsPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+// Pod dashboard panels
+
+func PodCPUUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["CPUUsageByContainer"].Pretty(0),
+				query.SeriesNameFormat("{{ container }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["CPURequestsOverlay"].Pretty(0),
+				query.SeriesNameFormat("requests"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["CPULimitsOverlay"].Pretty(0),
+				query.SeriesNameFormat("limits"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func PodCPUThrottling(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Throttling",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["CPUThrottling"].Pretty(0),
+				query.SeriesNameFormat("{{ container }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func PodCPUQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "container",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"container"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "container",
+					Header: "Container",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "CPU Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "CPU Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "CPU Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "CPU Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "CPU Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableCPUUsageByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableCPURequestsByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableCPURequestsPercentByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableCPULimitsByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableCPULimitsPercentByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func PodMemoryUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["MemoryUsageByContainer"].Pretty(0),
+				query.SeriesNameFormat("{{ container }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["MemoryRequestsOverlay"].Pretty(0),
+				query.SeriesNameFormat("requests"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["MemoryLimitsOverlay"].Pretty(0),
+				query.SeriesNameFormat("limits"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func PodMemoryQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "container",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"container"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "container",
+					Header: "Container",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "Memory Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "Memory Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "Memory Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "Memory Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "Memory Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #6",
+					Header: "Memory Usage (RSS)",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #7",
+					Header: "Memory Usage (Cache)",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #8",
+					Header: "Memory Usage (Swap)",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableMemoryUsageByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableMemoryRequestsByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableMemoryRequestsPercentByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableMemoryLimitsByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableMemoryLimitsPercentByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableMemoryRSSByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableMemoryCacheByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				PodQueries["TableMemorySwapByContainer"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}

--- a/internal/perses/panels/acm/k8s/compute/compute-queries.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-queries.go
@@ -356,6 +356,7 @@ var NamespacePodsQueries = map[string]parser.Expr{
 			vector.New(
 				vector.WithMetricName("kube_pod_container_resource_requests"),
 				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
 					label.New("namespace").Equal("$namespace"),
 					label.New("resource").Equal("memory"),
 				),
@@ -378,6 +379,7 @@ var NamespacePodsQueries = map[string]parser.Expr{
 			vector.New(
 				vector.WithMetricName("kube_pod_container_resource_limits"),
 				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
 					label.New("namespace").Equal("$namespace"),
 					label.New("resource").Equal("memory"),
 				),
@@ -562,6 +564,7 @@ var NamespacePodsQueries = map[string]parser.Expr{
 			vector.New(
 				vector.WithMetricName("kube_pod_container_resource_requests"),
 				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
 					label.New("namespace").Equal("$namespace"),
 					label.New("resource").Equal("memory"),
 				),
@@ -594,6 +597,7 @@ var NamespacePodsQueries = map[string]parser.Expr{
 			vector.New(
 				vector.WithMetricName("kube_pod_container_resource_limits"),
 				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
 					label.New("namespace").Equal("$namespace"),
 					label.New("resource").Equal("memory"),
 				),
@@ -935,6 +939,7 @@ var NodePodsQueries = map[string]parser.Expr{
 			vector.New(
 				vector.WithMetricName("kube_pod_container_resource_requests"),
 				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
 					label.New("node").Equal("$node"),
 					label.New("resource").Equal("memory"),
 				),
@@ -970,6 +975,7 @@ var NodePodsQueries = map[string]parser.Expr{
 			vector.New(
 				vector.WithMetricName("kube_pod_container_resource_limits"),
 				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
 					label.New("node").Equal("$node"),
 					label.New("resource").Equal("memory"),
 				),
@@ -1240,6 +1246,7 @@ var PodQueries = map[string]parser.Expr{
 			vector.New(
 				vector.WithMetricName("kube_pod_container_resource_requests"),
 				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
 					label.New("namespace").Equal("$namespace"),
 					label.New("pod").Equal("$pod"),
 					label.New("resource").Equal("memory"),
@@ -1275,6 +1282,7 @@ var PodQueries = map[string]parser.Expr{
 			vector.New(
 				vector.WithMetricName("kube_pod_container_resource_limits"),
 				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
 					label.New("namespace").Equal("$namespace"),
 					label.New("pod").Equal("$pod"),
 					label.New("resource").Equal("memory"),

--- a/internal/perses/panels/acm/k8s/compute/compute-queries.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-queries.go
@@ -1,0 +1,1482 @@
+package compute
+
+import (
+	promqlbuilder "github.com/perses/promql-builder"
+	"github.com/perses/promql-builder/label"
+	"github.com/perses/promql-builder/matrix"
+	"github.com/perses/promql-builder/vector"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// Cluster-level queries
+
+var ClusterQueries = map[string]parser.Expr{
+	// Stat panel queries
+	"CPUUtilisation": promqlbuilder.Sub(
+		promqlbuilder.NewNumber(1),
+		vector.New(
+			vector.WithMetricName("node_cpu_seconds_total:mode_idle:avg_rate5m"),
+		),
+	),
+	"CPURequestsCommitment": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_node_status_allocatable"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		),
+	),
+	"CPULimitsCommitment": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits:sum"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_node_status_allocatable"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		),
+	),
+	"MemoryUtilisation": promqlbuilder.Sub(
+		promqlbuilder.NewNumber(1),
+		promqlbuilder.Div(
+			promqlbuilder.Sum(
+				vector.New(
+					vector.WithMetricName(":node_memory_MemAvailable_bytes:sum"),
+					vector.WithLabelMatchers(
+						label.New("cluster").Equal("$cluster"),
+					),
+				),
+			),
+			promqlbuilder.Sum(
+				vector.New(
+					vector.WithMetricName("kube_node_status_allocatable"),
+					vector.WithLabelMatchers(
+						label.New("cluster").Equal("$cluster"),
+						label.New("resource").Equal("memory"),
+					),
+				),
+			),
+		),
+	),
+	"MemoryRequestsCommitment": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_node_status_allocatable"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		),
+	),
+	"MemoryLimitsCommitment": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits:sum"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_node_status_allocatable"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		),
+	),
+
+	// Graph queries
+	"CPUUsageByNamespace": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+			),
+		),
+	).By("namespace"),
+	"MemoryUsageByNamespace": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_rss"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("namespace"),
+
+	// CPU Quota table queries
+	"TablePodsByNamespace": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_info"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+			),
+		),
+	).By("namespace"),
+	"TableWorkloadsByNamespace": vector.New(
+		vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel:avg"),
+		vector.WithLabelMatchers(
+			label.New("cluster").Equal("$cluster"),
+		),
+	),
+	"TableCPUUsageByNamespace": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+			),
+		),
+	).By("namespace"),
+	"TableCPURequestsByNamespace": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	).By("namespace"),
+	"TableCPURequestsPercentByNamespace": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+				),
+			),
+		).By("namespace"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		).By("namespace"),
+	),
+	"TableCPULimitsByNamespace": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits:sum"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	).By("namespace"),
+	"TableCPULimitsPercentByNamespace": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+				),
+			),
+		).By("namespace"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits:sum"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		).By("namespace"),
+	),
+
+	// Memory Quota table queries
+	"TableMemoryUsageByNamespace": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_rss"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("namespace"),
+	"TableMemoryRequestsByNamespace": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	).By("namespace"),
+	"TableMemoryRequestsPercentByNamespace": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_rss"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+				),
+			),
+		).By("namespace"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		).By("namespace"),
+	),
+	"TableMemoryLimitsByNamespace": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits:sum"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	).By("namespace"),
+	"TableMemoryLimitsPercentByNamespace": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_rss"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+				),
+			),
+		).By("namespace"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits:sum"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		).By("namespace"),
+	),
+}
+
+// Namespace (Pods) queries
+
+var NamespacePodsQueries = map[string]parser.Expr{
+	// Stat panel queries
+	"CPUUtilisationFromRequests": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+				),
+			),
+		),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		),
+	),
+	"CPUUtilisationFromLimits": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+				),
+			),
+		),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		),
+	),
+	"MemoryUtilisationFromRequests": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+				),
+			),
+		),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		),
+	),
+	"MemoryUtilisationFromLimits": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+				),
+			),
+		),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		),
+	),
+
+	// Graph queries
+	"CPUUsageByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+			),
+		),
+	).By("pod"),
+	"CPUQuotaRequests": promqlbuilder.Scalar(
+		vector.New(
+			vector.WithMetricName("kube_resourcequota"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("type").Equal("hard"),
+				label.New("resource").Equal("requests.cpu"),
+			),
+		),
+	),
+	"CPUQuotaLimits": promqlbuilder.Scalar(
+		vector.New(
+			vector.WithMetricName("kube_resourcequota"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("type").Equal("hard"),
+				label.New("resource").Equal("limits.cpu"),
+			),
+		),
+	),
+	"MemoryUsageByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_working_set_bytes"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("pod"),
+	"MemoryQuotaRequests": promqlbuilder.Scalar(
+		vector.New(
+			vector.WithMetricName("kube_resourcequota"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("type").Equal("hard"),
+				label.New("resource").Equal("requests.memory"),
+			),
+		),
+	),
+	"MemoryQuotaLimits": promqlbuilder.Scalar(
+		vector.New(
+			vector.WithMetricName("kube_resourcequota"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("type").Equal("hard"),
+				label.New("resource").Equal("limits.memory"),
+			),
+		),
+	),
+
+	// CPU Quota table queries
+	"TableCPUUsageByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+			),
+		),
+	).By("pod"),
+	"TableCPURequestsByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	).By("pod"),
+	"TableCPURequestsPercentByPod": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+				),
+			),
+		).By("pod"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		).By("pod"),
+	),
+	"TableCPULimitsByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	).By("pod"),
+	"TableCPULimitsPercentByPod": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+				),
+			),
+		).By("pod"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		).By("pod"),
+	),
+
+	// Memory Quota table queries
+	"TableMemoryUsageByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_working_set_bytes"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("pod"),
+	"TableMemoryRequestsByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	).By("pod"),
+	"TableMemoryRequestsPercentByPod": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+				),
+			),
+		).By("pod"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		).By("pod"),
+	),
+	"TableMemoryLimitsByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	).By("pod"),
+	"TableMemoryLimitsPercentByPod": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+				),
+			),
+		).By("pod"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		).By("pod"),
+	),
+	"TableMemoryRSSByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_rss"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("pod"),
+	"TableMemoryCacheByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_cache"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("pod"),
+	"TableMemorySwapByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_swap"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("container").NotEqual(""),
+			),
+		),
+	).By("pod"),
+}
+
+// Namespace (Workloads) queries - use workload join pattern
+
+func workloadCPUUsage() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("workload", "workload_type")
+}
+
+func workloadCPURequests() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("workload", "workload_type")
+}
+
+func workloadCPULimits() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("workload", "workload_type")
+}
+
+func workloadMemoryUsage() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("workload", "workload_type")
+}
+
+func workloadMemoryRequests() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("workload", "workload_type")
+}
+
+func workloadMemoryLimits() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("workload", "workload_type")
+}
+
+var NamespaceWorkloadsQueries = map[string]parser.Expr{
+	"CPUUsageByWorkload":                   workloadCPUUsage(),
+	"TableRunningPods":                     promqlbuilder.Count(vector.New(vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"), vector.WithLabelMatchers(label.New("cluster").Equal("$cluster"), label.New("namespace").Equal("$namespace"), label.New("workload_type").Equal("$type")))).By("workload", "workload_type"),
+	"TableCPUUsageByWorkload":              workloadCPUUsage(),
+	"TableCPURequestsByWorkload":           workloadCPURequests(),
+	"TableCPURequestsPercentByWorkload":    promqlbuilder.Div(workloadCPUUsage(), workloadCPURequests()),
+	"TableCPULimitsByWorkload":             workloadCPULimits(),
+	"TableCPULimitsPercentByWorkload":      promqlbuilder.Div(workloadCPUUsage(), workloadCPULimits()),
+	"MemoryUsageByWorkload":                workloadMemoryUsage(),
+	"TableMemoryUsageByWorkload":           workloadMemoryUsage(),
+	"TableMemoryRequestsByWorkload":        workloadMemoryRequests(),
+	"TableMemoryRequestsPercentByWorkload": promqlbuilder.Div(workloadMemoryUsage(), workloadMemoryRequests()),
+	"TableMemoryLimitsByWorkload":          workloadMemoryLimits(),
+	"TableMemoryLimitsPercentByWorkload":   promqlbuilder.Div(workloadMemoryUsage(), workloadMemoryLimits()),
+}
+
+// Node (Pods) queries
+
+var NodePodsQueries = map[string]parser.Expr{
+	// Graph queries
+	"CPUUsageByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+			),
+		),
+	).By("pod"),
+	"MemoryUsageByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_working_set_bytes"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+				label.New("job").Equal("kubelet"),
+				label.New("metrics_path").Equal("/metrics/cadvisor"),
+				label.New("image").NotEqual(""),
+			),
+		),
+	).By("pod"),
+
+	// CPU Quota table queries
+	"TableCPUUsageByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+			),
+		),
+	).By("pod"),
+	"TableCPURequestsByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	).By("pod"),
+	"TableCPURequestsPercentByPod": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("node").Equal("$node"),
+				),
+			),
+		).By("pod"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("node").Equal("$node"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		).By("pod"),
+	),
+	"TableCPULimitsByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	).By("pod"),
+	"TableCPULimitsPercentByPod": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("node").Equal("$node"),
+				),
+			),
+		).By("pod"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("node").Equal("$node"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		).By("pod"),
+	),
+
+	// Memory Quota table queries
+	"TableMemoryUsageByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_working_set_bytes"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+				label.New("job").Equal("kubelet"),
+				label.New("metrics_path").Equal("/metrics/cadvisor"),
+				label.New("image").NotEqual(""),
+			),
+		),
+	).By("pod"),
+	"TableMemoryRequestsByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	).By("pod"),
+	"TableMemoryRequestsPercentByPod": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("node").Equal("$node"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+					label.New("job").Equal("kubelet"),
+					label.New("metrics_path").Equal("/metrics/cadvisor"),
+					label.New("image").NotEqual(""),
+				),
+			),
+		).By("pod"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("node").Equal("$node"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		).By("pod"),
+	),
+	"TableMemoryLimitsByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	).By("pod"),
+	"TableMemoryLimitsPercentByPod": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("node").Equal("$node"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+					label.New("job").Equal("kubelet"),
+					label.New("metrics_path").Equal("/metrics/cadvisor"),
+					label.New("image").NotEqual(""),
+				),
+			),
+		).By("pod"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("node").Equal("$node"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		).By("pod"),
+	),
+	"TableMemoryRSSByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_rss"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("pod"),
+	"TableMemoryCacheByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_cache"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("pod"),
+	"TableMemorySwapByPod": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_swap"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("node").Equal("$node"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+				label.New("job").Equal("kubelet"),
+				label.New("metrics_path").Equal("/metrics/cadvisor"),
+				label.New("image").NotEqual(""),
+			),
+		),
+	).By("pod"),
+}
+
+// Pod queries (by container)
+
+var PodQueries = map[string]parser.Expr{
+	// Graph queries
+	"CPUUsageByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+			vector.WithLabelMatchers(
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("container").NotEqual("POD"),
+				label.New("cluster").Equal("$cluster"),
+			),
+		),
+	).By("container"),
+	"CPURequestsOverlay": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	),
+	"CPULimitsOverlay": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	),
+	"CPUThrottling": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			promqlbuilder.Increase(
+				matrix.New(
+					vector.New(
+						vector.WithMetricName("container_cpu_cfs_throttled_periods_total"),
+						vector.WithLabelMatchers(
+							label.New("namespace").Equal("$namespace"),
+							label.New("pod").Equal("$pod"),
+							label.New("container").NotEqual("POD"),
+							label.New("cluster").Equal("$cluster"),
+						),
+					),
+					matrix.WithRangeAsString("5m"),
+				),
+			),
+		).By("container"),
+		promqlbuilder.Sum(
+			promqlbuilder.Increase(
+				matrix.New(
+					vector.New(
+						vector.WithMetricName("container_cpu_cfs_periods_total"),
+						vector.WithLabelMatchers(
+							label.New("namespace").Equal("$namespace"),
+							label.New("pod").Equal("$pod"),
+							label.New("container").NotEqual("POD"),
+							label.New("cluster").Equal("$cluster"),
+						),
+					),
+					matrix.WithRangeAsString("5m"),
+				),
+			),
+		).By("container"),
+	),
+	"MemoryUsageByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_working_set_bytes"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("container").NotEqual("POD"),
+				label.New("container").NotEqual(""),
+			),
+		),
+	).By("container"),
+	"MemoryRequestsOverlay": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	),
+	"MemoryLimitsOverlay": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	),
+
+	// CPU Quota table queries
+	"TableCPUUsageByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("container"),
+	"TableCPURequestsByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	).By("container"),
+	"TableCPURequestsPercentByContainer": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("pod").Equal("$pod"),
+				),
+			),
+		).By("container"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("pod").Equal("$pod"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		).By("container"),
+	),
+	"TableCPULimitsByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("resource").Equal("cpu"),
+			),
+		),
+	).By("container"),
+	"TableCPULimitsPercentByContainer": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("pod").Equal("$pod"),
+				),
+			),
+		).By("container"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("pod").Equal("$pod"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+		).By("container"),
+	),
+
+	// Memory Quota table queries
+	"TableMemoryUsageByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_working_set_bytes"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("container").NotEqual("POD"),
+				label.New("container").NotEqual(""),
+			),
+		),
+	).By("container"),
+	"TableMemoryRequestsByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_requests"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	).By("container"),
+	"TableMemoryRequestsPercentByContainer": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("pod").Equal("$pod"),
+				),
+			),
+		).By("container"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("namespace").Equal("$namespace"),
+					label.New("pod").Equal("$pod"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		).By("container"),
+	),
+	"TableMemoryLimitsByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("kube_pod_container_resource_limits"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("container").NotEqual(""),
+				label.New("resource").Equal("memory"),
+			),
+		),
+	).By("container"),
+	"TableMemoryLimitsPercentByContainer": promqlbuilder.Div(
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("pod").Equal("$pod"),
+					label.New("container").NotEqual(""),
+				),
+			),
+		).By("container"),
+		promqlbuilder.Sum(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("namespace").Equal("$namespace"),
+					label.New("pod").Equal("$pod"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+		).By("container"),
+	),
+	"TableMemoryRSSByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_rss"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("container"),
+	"TableMemoryCacheByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_cache"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("container"),
+	"TableMemorySwapByContainer": promqlbuilder.Sum(
+		vector.New(
+			vector.WithMetricName("container_memory_swap"),
+			vector.WithLabelMatchers(
+				label.New("cluster").Equal("$cluster"),
+				label.New("namespace").Equal("$namespace"),
+				label.New("pod").Equal("$pod"),
+				label.New("container").NotEqual(""),
+				label.New("container").NotEqual("POD"),
+			),
+		),
+	).By("container"),
+}
+
+// Workload queries (specific workload, by pod)
+
+func specificWorkloadCPUUsage() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate5m"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload").Equal("$workload"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("pod")
+}
+
+func specificWorkloadCPURequests() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload").Equal("$workload"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("pod")
+}
+
+func specificWorkloadCPULimits() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("cpu"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload").Equal("$workload"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("pod")
+}
+
+func specificWorkloadMemoryUsage() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("container_memory_working_set_bytes"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("container").NotEqual(""),
+					label.New("container").NotEqual("POD"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload").Equal("$workload"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("pod")
+}
+
+func specificWorkloadMemoryRequests() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_requests"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload").Equal("$workload"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("pod")
+}
+
+func specificWorkloadMemoryLimits() parser.Expr {
+	return promqlbuilder.Sum(
+		promqlbuilder.Mul(
+			vector.New(
+				vector.WithMetricName("kube_pod_container_resource_limits"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("resource").Equal("memory"),
+				),
+			),
+			vector.New(
+				vector.WithMetricName("namespace_workload_pod:kube_pod_owner:relabel"),
+				vector.WithLabelMatchers(
+					label.New("cluster").Equal("$cluster"),
+					label.New("namespace").Equal("$namespace"),
+					label.New("workload").Equal("$workload"),
+					label.New("workload_type").Equal("$type"),
+				),
+			),
+		).On("namespace", "pod").GroupLeft("workload", "workload_type"),
+	).By("pod")
+}
+
+var WorkloadQueries = map[string]parser.Expr{
+	"CPUUsageByPod":                   specificWorkloadCPUUsage(),
+	"TableCPUUsageByPod":              specificWorkloadCPUUsage(),
+	"TableCPURequestsByPod":           specificWorkloadCPURequests(),
+	"TableCPURequestsPercentByPod":    promqlbuilder.Div(specificWorkloadCPUUsage(), specificWorkloadCPURequests()),
+	"TableCPULimitsByPod":             specificWorkloadCPULimits(),
+	"TableCPULimitsPercentByPod":      promqlbuilder.Div(specificWorkloadCPUUsage(), specificWorkloadCPULimits()),
+	"MemoryUsageByPod":                specificWorkloadMemoryUsage(),
+	"TableMemoryUsageByPod":           specificWorkloadMemoryUsage(),
+	"TableMemoryRequestsByPod":        specificWorkloadMemoryRequests(),
+	"TableMemoryRequestsPercentByPod": promqlbuilder.Div(specificWorkloadMemoryUsage(), specificWorkloadMemoryRequests()),
+	"TableMemoryLimitsByPod":          specificWorkloadMemoryLimits(),
+	"TableMemoryLimitsPercentByPod":   promqlbuilder.Div(specificWorkloadMemoryUsage(), specificWorkloadMemoryLimits()),
+}

--- a/internal/perses/panels/acm/k8s/compute/compute-workload.go
+++ b/internal/perses/panels/acm/k8s/compute/compute-workload.go
@@ -1,0 +1,287 @@
+package compute
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	tsPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+// Workload dashboard panels
+
+func WorkloadCPUUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["CPUUsageByPod"].Pretty(0),
+				query.SeriesNameFormat("{{ pod }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func WorkloadCPUQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "pod",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"pod"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "pod",
+					Header: "Pod",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "CPU Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "CPU Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "CPU Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "CPU Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.DecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "CPU Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableCPUUsageByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableCPURequestsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableCPURequestsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableCPULimitsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableCPULimitsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func WorkloadMemoryUsage(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage",
+		tsPanel.Chart(
+			tsPanel.WithYAxis(tsPanel.YAxis{
+				Show: true,
+				Format: &common.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+			tsPanel.WithVisual(tsPanel.Visual{
+				AreaOpacity: 1,
+				Stack:       tsPanel.AllStack,
+				LineWidth:   0,
+			}),
+			tsPanel.WithLegend(tsPanel.Legend{
+				Position: tsPanel.BottomPosition,
+				Mode:     tsPanel.ListMode,
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["MemoryUsageByPod"].Pretty(0),
+				query.SeriesNameFormat("{{ pod }}"),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}
+
+func WorkloadMemoryQuota(datasource string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Quota",
+		tablePanel.Table(
+			tablePanel.Transform([]common.Transform{
+				{
+					Kind: common.MergeIndexedColumnsKind,
+					Spec: common.MergeIndexedColumnsSpec{
+						Column: "pod",
+					},
+				},
+				{
+					Kind: common.JoinByColumValueKind,
+					Spec: common.JoinByColumnValueSpec{
+						Columns: []string{"pod"},
+					},
+				},
+			}),
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{
+					Name: "timestamp",
+					Hide: true,
+				},
+				{
+					Name:   "pod",
+					Header: "Pod",
+					Align:  tablePanel.LeftAlign,
+				},
+				{
+					Name:   "value #1",
+					Header: "Memory Usage",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #2",
+					Header: "Memory Requests",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #3",
+					Header: "Memory Requests %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #4",
+					Header: "Memory Limits",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.BytesUnit,
+						DecimalPlaces: 2,
+					},
+				},
+				{
+					Name:   "value #5",
+					Header: "Memory Limits %",
+					Align:  tablePanel.LeftAlign,
+					Format: &common.Format{
+						Unit:          &dashboards.PercentDecimalUnit,
+						DecimalPlaces: 2,
+					},
+				},
+			}),
+			tablePanel.WithDensity("compact"),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableMemoryUsageByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableMemoryRequestsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableMemoryRequestsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableMemoryLimitsByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				WorkloadQueries["TableMemoryLimitsPercentByPod"].Pretty(0),
+				dashboards.AddQueryDataSource(datasource),
+			),
+		),
+	)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added six Kubernetes compute dashboards: Cluster, Namespace (Pods), Namespace (Workloads), Node (Pods), Pod, and Workload — each providing CPU and memory usage visuals, utilization metrics, quota/requests/limits tables, and related charts/tables for drilling into clusters, namespaces, nodes, pods, and workloads.

* **Chores**
  * Updated Go build toolchain from 1.25.5 to 1.25.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->