### PR TITLE
fix(cve): CVE-2026-34986 - go-jose v4.1.3→v4.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
## CVE Details
- **CVE ID:** CVE-2026-34986
- **Severity:** High
- **Package:** github.com/go-jose/go-jose/v4
- **Affected Version:** v4.1.3
- **Fixed Version:** v4.1.4

## Description
Go JOSE: Denial of Service via crafted JSON Web Encryption (JWE) object. Decrypting a JWE object will panic if the `alg` field indicates a key wrapping algorithm and the `encrypted_key` field is empty.

## Fix Summary
- Updated `github.com/go-jose/go-jose/v4` from v4.1.3 to v4.1.4
- Ran `go mod tidy` to ensure dependency consistency

## Test Results
- ⏳ Build verification in progress — CI will confirm

## Breaking Changes
- None expected — patch-level dependency update

## Jira References
- ACM-32576

## Verification Steps
- [ ] CI passes
- [ ] `go mod tidy` produces no changes
- [ ] `govulncheck ./...` no longer reports CVE-2026-34986

## Risk Assessment
**Low** — patch-level update to an indirect dependency, fixing a DoS vector

---
🤖 Generated with [Claude Code](https://claude.ai/code)