### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,66 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY internal/ internal/
+
+# Build
+# Enable CGO for FIPS compliance (dynamic linking)
+RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on GOEXPERIMENT=strictfipsruntime go build -mod=readonly -a -o multicluster-observability-addon main.go
+
+# IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
+# 1. Update FROM statement below
+# 2. Update 'name' label to match new destination repo (rhel9 → rhel10)
+# 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
+# 4. Verify destination repository exists in registry.redhat.io
+# 5. Run 'make verify-containerfile-labels' to check consistency (if script exists)
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    com.redhat.component="mcoa" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="rhacm2/acm-multicluster-observability-addon-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    maintainer="$IMAGE_MAINTAINER" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+
+WORKDIR /
+COPY --from=builder /workspace/multicluster-observability-addon .
+USER 65532:65532
+
+ENTRYPOINT ["/multicluster-observability-addon"]


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)