### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Dockerfile.Konflux
+++ b/Dockerfile.Konflux
@@ -17,7 +17,7 @@ COPY internal/ internal/
 
 # Build
 # Enable CGO for FIPS compliance (dynamic linking)
-RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -mod=readonly -a -o multicluster-observability-addon main.go
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux GO111MODULE=on go build -mod=readonly -a -o multicluster-observability-addon main.go
 
 # IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
 # 1. Update FROM statement below


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847