### PR TITLE
Fix: Right-sizing configmap and Perses changes

### DIFF
--- a/internal/analytics/rightsizing/builder.go
+++ b/internal/analytics/rightsizing/builder.go
@@ -139,16 +139,6 @@ func ParsePlacementConfigMap(data map[string]string) (clusterv1beta1.Placement, 
 	return placement, true, nil
 }
 
-// GetDefaultPlacementConfigData returns default placement data for a dedicated
-// placement ConfigMap. Empty predicates = selects ALL clusters. Users can later
-// edit this ConfigMap to add label/claim filters.
-func GetDefaultPlacementConfigData() map[string]string {
-	placement := GetDefaultRSPlacement()
-	return map[string]string{
-		"placementConfiguration": FormatJSON(placement),
-	}
-}
-
 // GetDefaultNamespaceConfigData returns default config data for namespace right-sizing
 func GetDefaultNamespaceConfigData() map[string]string {
 	ruleConfig := GetDefaultRSPrometheusRuleConfig()

--- a/internal/analytics/rightsizing/handlers/handler.go
+++ b/internal/analytics/rightsizing/handlers/handler.go
@@ -54,9 +54,6 @@ func (o *OptionsBuilder) Build(ctx context.Context, cluster *clusterv1.ManagedCl
 		if err := o.ensureNamespaceConfigMap(ctx); err != nil {
 			o.Logger.Error(err, "Failed to ensure namespace ConfigMap exists, continuing with defaults")
 		}
-		if err := o.ensurePlacementConfigMap(ctx, rightsizing.NamespacePlacementCMName); err != nil {
-			o.Logger.Error(err, "Failed to ensure namespace placement ConfigMap exists, continuing with defaults")
-		}
 
 		nsConfigData, err := o.getConfigData(ctx, rightsizing.NamespaceConfigMapName)
 		if err != nil {
@@ -70,9 +67,7 @@ func (o *OptionsBuilder) Build(ctx context.Context, cluster *clusterv1.ManagedCl
 			}
 		}
 
-		nsPlacement := o.getPlacementOverride(ctx, rightsizing.NamespacePlacementCMName, nsConfigData.PlacementConfiguration)
-
-		if clusterMatchesPlacement(cluster, nsPlacement) {
+		if clusterMatchesPlacement(cluster, nsConfigData.PlacementConfiguration) {
 			nsOpts, err := o.buildNamespaceOptionsFromConfig(nsConfigData)
 			if err != nil {
 				return ret, fmt.Errorf("failed to build namespace right-sizing options: %w", err)
@@ -89,9 +84,6 @@ func (o *OptionsBuilder) Build(ctx context.Context, cluster *clusterv1.ManagedCl
 		if err := o.ensureVirtualizationConfigMap(ctx); err != nil {
 			o.Logger.Error(err, "Failed to ensure virtualization ConfigMap exists, continuing with defaults")
 		}
-		if err := o.ensurePlacementConfigMap(ctx, rightsizing.VirtualizationPlacementCMName); err != nil {
-			o.Logger.Error(err, "Failed to ensure virtualization placement ConfigMap exists, continuing with defaults")
-		}
 
 		virtConfigData, err := o.getConfigData(ctx, rightsizing.VirtualizationConfigMapName)
 		if err != nil {
@@ -105,9 +97,7 @@ func (o *OptionsBuilder) Build(ctx context.Context, cluster *clusterv1.ManagedCl
 			}
 		}
 
-		virtPlacement := o.getPlacementOverride(ctx, rightsizing.VirtualizationPlacementCMName, virtConfigData.PlacementConfiguration)
-
-		if clusterMatchesPlacement(cluster, virtPlacement) {
+		if clusterMatchesPlacement(cluster, virtConfigData.PlacementConfiguration) {
 			virtOpts, err := o.buildVirtualizationOptionsFromConfig(virtConfigData)
 			if err != nil {
 				return ret, fmt.Errorf("failed to build virtualization right-sizing options: %w", err)
@@ -190,12 +180,11 @@ func (o *OptionsBuilder) ensureVirtualizationConfigMap(ctx context.Context) erro
 }
 
 // createDefaultConfigMap creates a ConfigMap with the provided data.
-// The ConfigMap is labeled to indicate it's managed by MCOA for right-sizing.
+// The ConfigMap is labeled to indicate it's managed for right-sizing.
 //
-// NOTE: We do not delete existing ConfigMaps during mode switches (MCO <=> MCOA)
-// to preserve user customizations (namespace filters, recommendation %, etc.).
-// To support this, ownership (labels) should be updated when the new owner takes over.
-// In the future when only MCOA mode is supported, ownership transfer will not be needed.
+// Both MCO and MCOA use a "create if not exists" pattern for these ConfigMaps,
+// so user customizations (namespace filters, recommendation %, placement predicates)
+// are preserved across mode switches (MCO <=> MCOA).
 func (o *OptionsBuilder) createDefaultConfigMap(ctx context.Context, name string, data map[string]string) error {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -212,48 +201,6 @@ func (o *OptionsBuilder) createDefaultConfigMap(ctx context.Context, name string
 
 	o.Logger.V(1).Info("Created right-sizing ConfigMap", "name", name, "namespace", addoncfg.InstallNamespace)
 	return nil
-}
-
-// ensurePlacementConfigMap ensures a dedicated placement ConfigMap exists on the hub.
-// Created with default empty predicates (selects all clusters) so users can
-// simply `kubectl edit` it later to add label/claim filters.
-func (o *OptionsBuilder) ensurePlacementConfigMap(ctx context.Context, name string) error {
-	_, err := common.GetConfigMap(ctx, o.Client, addoncfg.InstallNamespace, name)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			o.Logger.Info("Creating dedicated placement ConfigMap with defaults",
-				"name", name,
-				"namespace", addoncfg.InstallNamespace)
-			return o.createDefaultConfigMap(ctx, name, rightsizing.GetDefaultPlacementConfigData())
-		}
-		return err
-	}
-	return nil
-}
-
-// getPlacementOverride checks for a dedicated MCOA-owned placement ConfigMap.
-// MCO periodically overwrites the RS ConfigMaps (rs-namespace-config, rs-virt-config),
-// resetting any custom placement predicates. Dedicated placement ConfigMaps
-// (rs-namespace-placement, rs-virt-placement) are owned only by MCOA and are
-// never overwritten by MCO, so user-configured placement predicates persist.
-// Falls back to the placement from the RS ConfigMap if no override exists.
-func (o *OptionsBuilder) getPlacementOverride(ctx context.Context, placementCMName string, fallback clusterv1beta1.Placement) clusterv1beta1.Placement {
-	cm, err := common.GetConfigMap(ctx, o.Client, addoncfg.InstallNamespace, placementCMName)
-	if err != nil {
-		return fallback
-	}
-
-	placement, found, err := rightsizing.ParsePlacementConfigMap(cm.Data)
-	if err != nil {
-		o.Logger.Error(err, "Failed to parse placement ConfigMap, using fallback", "name", placementCMName)
-		return fallback
-	}
-	if !found {
-		return fallback
-	}
-
-	o.Logger.V(2).Info("Using placement override from dedicated ConfigMap", "name", placementCMName)
-	return placement
 }
 
 // clusterMatchesPlacement evaluates placement predicates in-memory against

--- a/internal/analytics/rightsizing/handlers/rs_resources.go
+++ b/internal/analytics/rightsizing/handlers/rs_resources.go
@@ -49,17 +49,11 @@ func (o *OptionsBuilder) ReconcileRSResources(ctx context.Context, opts addon.Op
 		if err := o.deleteRSConfigMap(ctx, rightsizing.NamespaceConfigMapName); err != nil {
 			return fmt.Errorf("failed to cleanup namespace configmap: %w", err)
 		}
-		if err := o.deleteRSConfigMap(ctx, rightsizing.NamespacePlacementCMName); err != nil {
-			return fmt.Errorf("failed to cleanup namespace placement configmap: %w", err)
-		}
 	}
 
 	if !opts.Platform.AnalyticsOptions.RightSizing.VirtualizationEnabled {
 		if err := o.deleteRSConfigMap(ctx, rightsizing.VirtualizationConfigMapName); err != nil {
 			return fmt.Errorf("failed to cleanup virtualization configmap: %w", err)
-		}
-		if err := o.deleteRSConfigMap(ctx, rightsizing.VirtualizationPlacementCMName); err != nil {
-			return fmt.Errorf("failed to cleanup virtualization placement configmap: %w", err)
 		}
 	}
 

--- a/internal/analytics/rightsizing/handlers/rs_resources_test.go
+++ b/internal/analytics/rightsizing/handlers/rs_resources_test.go
@@ -91,7 +91,7 @@ func TestRSConfigMapPredicate(t *testing.T) {
 		Name: rightsizing.NamespaceConfigMapName, Namespace: "other-namespace",
 	}}
 
-	// Create: accepts RS ConfigMaps, rejects placement ConfigMaps and others
+	// Create: accepts RS ConfigMaps, rejects others
 	assert.True(t, pred.CreateFunc(event.CreateEvent{Object: rsNsCM}))
 	assert.True(t, pred.CreateFunc(event.CreateEvent{Object: rsVirtCM}))
 	assert.False(t, pred.CreateFunc(event.CreateEvent{Object: unrelatedCM}))
@@ -111,11 +111,9 @@ func TestRSConfigMapPredicate(t *testing.T) {
 
 func TestReconcileRSResources_CleanupNamespace(t *testing.T) {
 	nsCM := createTestConfigMap(rightsizing.NamespaceConfigMapName)
-	nsPlacementCM := createTestConfigMap(rightsizing.NamespacePlacementCMName)
 	virtCM := createTestConfigMap(rightsizing.VirtualizationConfigMapName)
-	virtPlacementCM := createTestConfigMap(rightsizing.VirtualizationPlacementCMName)
 
-	ob := newTestOptionsBuilder(t, nsCM, nsPlacementCM, virtCM, virtPlacementCM)
+	ob := newTestOptionsBuilder(t, nsCM, virtCM)
 	ctx := context.TODO()
 
 	opts := newPlatformOpts(false, true)
@@ -128,28 +126,16 @@ func TestReconcileRSResources_CleanupNamespace(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "namespace configmap should be deleted")
 
 	err = ob.Client.Get(ctx, types.NamespacedName{
-		Name: rightsizing.NamespacePlacementCMName, Namespace: addoncfg.InstallNamespace,
-	}, &corev1.ConfigMap{})
-	assert.True(t, apierrors.IsNotFound(err), "namespace placement configmap should be deleted")
-
-	err = ob.Client.Get(ctx, types.NamespacedName{
 		Name: rightsizing.VirtualizationConfigMapName, Namespace: addoncfg.InstallNamespace,
 	}, &corev1.ConfigMap{})
 	require.NoError(t, err, "virtualization configmap should still exist")
-
-	err = ob.Client.Get(ctx, types.NamespacedName{
-		Name: rightsizing.VirtualizationPlacementCMName, Namespace: addoncfg.InstallNamespace,
-	}, &corev1.ConfigMap{})
-	require.NoError(t, err, "virtualization placement configmap should still exist")
 }
 
 func TestReconcileRSResources_CleanupVirtualization(t *testing.T) {
 	nsCM := createTestConfigMap(rightsizing.NamespaceConfigMapName)
-	nsPlacementCM := createTestConfigMap(rightsizing.NamespacePlacementCMName)
 	virtCM := createTestConfigMap(rightsizing.VirtualizationConfigMapName)
-	virtPlacementCM := createTestConfigMap(rightsizing.VirtualizationPlacementCMName)
 
-	ob := newTestOptionsBuilder(t, nsCM, nsPlacementCM, virtCM, virtPlacementCM)
+	ob := newTestOptionsBuilder(t, nsCM, virtCM)
 	ctx := context.TODO()
 
 	opts := newPlatformOpts(true, false)
@@ -162,28 +148,16 @@ func TestReconcileRSResources_CleanupVirtualization(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "virtualization configmap should be deleted")
 
 	err = ob.Client.Get(ctx, types.NamespacedName{
-		Name: rightsizing.VirtualizationPlacementCMName, Namespace: addoncfg.InstallNamespace,
-	}, &corev1.ConfigMap{})
-	assert.True(t, apierrors.IsNotFound(err), "virtualization placement configmap should be deleted")
-
-	err = ob.Client.Get(ctx, types.NamespacedName{
 		Name: rightsizing.NamespaceConfigMapName, Namespace: addoncfg.InstallNamespace,
 	}, &corev1.ConfigMap{})
 	require.NoError(t, err, "namespace configmap should still exist")
-
-	err = ob.Client.Get(ctx, types.NamespacedName{
-		Name: rightsizing.NamespacePlacementCMName, Namespace: addoncfg.InstallNamespace,
-	}, &corev1.ConfigMap{})
-	require.NoError(t, err, "namespace placement configmap should still exist")
 }
 
 func TestReconcileRSResources_CleanupBoth(t *testing.T) {
 	nsCM := createTestConfigMap(rightsizing.NamespaceConfigMapName)
-	nsPlacementCM := createTestConfigMap(rightsizing.NamespacePlacementCMName)
 	virtCM := createTestConfigMap(rightsizing.VirtualizationConfigMapName)
-	virtPlacementCM := createTestConfigMap(rightsizing.VirtualizationPlacementCMName)
 
-	ob := newTestOptionsBuilder(t, nsCM, nsPlacementCM, virtCM, virtPlacementCM)
+	ob := newTestOptionsBuilder(t, nsCM, virtCM)
 	ctx := context.TODO()
 
 	opts := newPlatformOpts(false, false)
@@ -196,19 +170,9 @@ func TestReconcileRSResources_CleanupBoth(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "namespace configmap should be deleted")
 
 	err = ob.Client.Get(ctx, types.NamespacedName{
-		Name: rightsizing.NamespacePlacementCMName, Namespace: addoncfg.InstallNamespace,
-	}, &corev1.ConfigMap{})
-	assert.True(t, apierrors.IsNotFound(err), "namespace placement configmap should be deleted")
-
-	err = ob.Client.Get(ctx, types.NamespacedName{
 		Name: rightsizing.VirtualizationConfigMapName, Namespace: addoncfg.InstallNamespace,
 	}, &corev1.ConfigMap{})
 	assert.True(t, apierrors.IsNotFound(err), "virtualization configmap should be deleted")
-
-	err = ob.Client.Get(ctx, types.NamespacedName{
-		Name: rightsizing.VirtualizationPlacementCMName, Namespace: addoncfg.InstallNamespace,
-	}, &corev1.ConfigMap{})
-	assert.True(t, apierrors.IsNotFound(err), "virtualization placement configmap should be deleted")
 }
 
 func TestReconcileRSResources_CleanupIdempotent(t *testing.T) {
@@ -218,58 +182,6 @@ func TestReconcileRSResources_CleanupIdempotent(t *testing.T) {
 	opts := newPlatformOpts(false, false)
 	err := ob.ReconcileRSResources(ctx, opts)
 	require.NoError(t, err)
-}
-
-func TestEnsurePlacementConfigMap_CreatesWhenMissing(t *testing.T) {
-	ob := newTestOptionsBuilder(t)
-	ctx := context.TODO()
-
-	err := ob.ensurePlacementConfigMap(ctx, rightsizing.NamespacePlacementCMName)
-	require.NoError(t, err)
-
-	cm := &corev1.ConfigMap{}
-	err = ob.Client.Get(ctx, types.NamespacedName{
-		Name: rightsizing.NamespacePlacementCMName, Namespace: addoncfg.InstallNamespace,
-	}, cm)
-	require.NoError(t, err, "placement configmap should be created")
-
-	assert.Contains(t, cm.Data, "placementConfiguration")
-	assert.Equal(t, rightsizing.RSLabels(), cm.Labels)
-
-	placement, found, err := rightsizing.ParsePlacementConfigMap(cm.Data)
-	require.NoError(t, err)
-	assert.True(t, found)
-	assert.Empty(t, placement.Spec.Predicates, "default placement should have empty predicates")
-}
-
-func TestEnsurePlacementConfigMap_PreservesExisting(t *testing.T) {
-	existingCM := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      rightsizing.NamespacePlacementCMName,
-			Namespace: addoncfg.InstallNamespace,
-		},
-		Data: map[string]string{
-			"placementConfiguration": `{"spec":{"predicates":[{"requiredClusterSelector":{"labelSelector":{"matchLabels":{"env":"prod"}}}}]}}`,
-		},
-	}
-
-	ob := newTestOptionsBuilder(t, existingCM)
-	ctx := context.TODO()
-
-	err := ob.ensurePlacementConfigMap(ctx, rightsizing.NamespacePlacementCMName)
-	require.NoError(t, err)
-
-	cm := &corev1.ConfigMap{}
-	err = ob.Client.Get(ctx, types.NamespacedName{
-		Name: rightsizing.NamespacePlacementCMName, Namespace: addoncfg.InstallNamespace,
-	}, cm)
-	require.NoError(t, err)
-
-	placement, found, err := rightsizing.ParsePlacementConfigMap(cm.Data)
-	require.NoError(t, err)
-	assert.True(t, found)
-	assert.Len(t, placement.Spec.Predicates, 1, "existing predicates should be preserved")
-	assert.Equal(t, "prod", placement.Spec.Predicates[0].RequiredClusterSelector.LabelSelector.MatchLabels["env"])
 }
 
 func TestClusterMatchesPlacement_EmptyPredicates(t *testing.T) {

--- a/internal/analytics/rightsizing/types.go
+++ b/internal/analytics/rightsizing/types.go
@@ -25,12 +25,10 @@ const (
 	// Namespace right-sizing constants
 	NamespacePrometheusRuleName = "acm-rs-namespace-prometheus-rules"
 	NamespaceConfigMapName      = "rs-namespace-config"
-	NamespacePlacementCMName    = "rs-namespace-placement"
 
 	// Virtualization right-sizing constants
 	VirtualizationPrometheusRuleName = "acm-rs-virt-prometheus-rules"
 	VirtualizationConfigMapName      = "rs-virt-config"
-	VirtualizationPlacementCMName    = "rs-virt-placement"
 )
 
 // RSLabelFilter represents label filtering criteria for right-sizing

--- a/internal/controllers/watcher/controller.go
+++ b/internal/controllers/watcher/controller.go
@@ -10,7 +10,6 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
-	"github.com/stolostron/multicluster-observability-addon/internal/analytics/rightsizing"
 	mconfig "github.com/stolostron/multicluster-observability-addon/internal/metrics/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -108,7 +107,6 @@ func (r *WatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Secret{}, r.enqueueForConfigResource(), builder.OnlyMetadata).
 		Watches(&corev1.ConfigMap{}, r.enqueueForConfigResource(), builder.OnlyMetadata).
 		Watches(&corev1.ConfigMap{}, r.enqueueForAllManagedClusters(), builder.WithPredicates(imagesConfigMapPredicate), builder.OnlyMetadata).
-		Watches(&corev1.ConfigMap{}, r.enqueueForAllManagedClusters(), builder.WithPredicates(rsPlacementConfigMapPredicate), builder.OnlyMetadata).
 		Watches(&hyperv1.HostedCluster{}, r.enqueueForLocalCluster(), hostedClusterPredicate).
 		Watches(&prometheusv1.ServiceMonitor{}, r.enqueueForLocalCluster(), hypershiftServiceMonitorsPredicate(r.Log), builder.OnlyMetadata).
 		Complete(r)
@@ -275,26 +273,6 @@ var hostedClusterPredicate = builder.WithPredicates(predicate.Funcs{
 	DeleteFunc:  func(e event.DeleteEvent) bool { return true },
 	GenericFunc: func(e event.GenericEvent) bool { return false },
 })
-
-var rsPlacementConfigMapPredicate = predicate.Funcs{
-	CreateFunc: func(e event.CreateEvent) bool {
-		return isRSPlacementConfigMap(e.Object.GetNamespace(), e.Object.GetName())
-	},
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		return isRSPlacementConfigMap(e.ObjectNew.GetNamespace(), e.ObjectNew.GetName())
-	},
-	DeleteFunc: func(e event.DeleteEvent) bool {
-		return isRSPlacementConfigMap(e.Object.GetNamespace(), e.Object.GetName())
-	},
-	GenericFunc: func(e event.GenericEvent) bool { return false },
-}
-
-func isRSPlacementConfigMap(namespace, name string) bool {
-	if namespace != addoncfg.InstallNamespace {
-		return false
-	}
-	return name == rightsizing.NamespacePlacementCMName || name == rightsizing.VirtualizationPlacementCMName
-}
 
 var imagesConfigMapPredicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {

--- a/internal/controllers/watcher/controller.go
+++ b/internal/controllers/watcher/controller.go
@@ -10,6 +10,7 @@ import (
 	hyperv1 "github.com/openshift/hypershift/api/hypershift/v1beta1"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
+	rshandlers "github.com/stolostron/multicluster-observability-addon/internal/analytics/rightsizing/handlers"
 	mconfig "github.com/stolostron/multicluster-observability-addon/internal/metrics/config"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -107,6 +108,7 @@ func (r *WatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Secret{}, r.enqueueForConfigResource(), builder.OnlyMetadata).
 		Watches(&corev1.ConfigMap{}, r.enqueueForConfigResource(), builder.OnlyMetadata).
 		Watches(&corev1.ConfigMap{}, r.enqueueForAllManagedClusters(), builder.WithPredicates(imagesConfigMapPredicate), builder.OnlyMetadata).
+		Watches(&corev1.ConfigMap{}, r.enqueueForAllManagedClusters(), builder.WithPredicates(rshandlers.RSConfigMapPredicate()), builder.OnlyMetadata).
 		Watches(&hyperv1.HostedCluster{}, r.enqueueForLocalCluster(), hostedClusterPredicate).
 		Watches(&prometheusv1.ServiceMonitor{}, r.enqueueForLocalCluster(), hypershiftServiceMonitorsPredicate(r.Log), builder.OnlyMetadata).
 		Complete(r)

--- a/internal/perses/dashboards/rightsizing/namespace-rightsizing.go
+++ b/internal/perses/dashboards/rightsizing/namespace-rightsizing.go
@@ -10,63 +10,47 @@ import (
 	"github.com/perses/community-mixins/pkg/dashboards"
 	"github.com/perses/community-mixins/pkg/promql"
 	"github.com/perses/perses/go-sdk/dashboard"
-	panelgroup "github.com/perses/perses/go-sdk/panel-group"
 	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
 	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
 	staticListVar "github.com/perses/plugins/staticlistvariable/sdk/go"
+	acmHelpers "github.com/stolostron/multicluster-observability-addon/internal/perses/dashboards/acm"
 	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/rightsizing"
 )
 
-func withCPUStatsAndChart(datasource string) dashboard.Option {
-	return dashboard.AddPanelGroup("",
-		panelgroup.PanelsPerLine(4),
-		panelgroup.PanelHeight(4),
+func withCPUSection(datasource string) dashboard.Option {
+	return acmHelpers.AddCustomPanelGroup("CPU",
+		[]acmHelpers.GridItem{
+			{X: 0, Y: 0, W: 6, H: 4},
+			{X: 0, Y: 4, W: 6, H: 4},
+			{X: 0, Y: 8, W: 6, H: 4},
+			{X: 0, Y: 12, W: 6, H: 4},
+			{X: 6, Y: 0, W: 18, H: 16},
+			{X: 0, Y: 16, W: 24, H: 10},
+		},
 		panels.CPURecommendationPanel(datasource),
 		panels.CPUUsagePanel(datasource),
 		panels.CPURequestPanel(datasource),
 		panels.CPUUtilizationPanel(datasource),
-	)
-}
-
-func withCPUTopNamespaces(datasource string) dashboard.Option {
-	return dashboard.AddPanelGroup("",
-		panelgroup.PanelsPerLine(1),
-		panelgroup.PanelHeight(12),
 		panels.CPUTopNamespacesPanel(datasource),
-	)
-}
-
-func withCPUQuotaTable(datasource string) dashboard.Option {
-	return dashboard.AddPanelGroup("",
-		panelgroup.PanelsPerLine(1),
-		panelgroup.PanelHeight(8),
 		panels.CPUQuotaTablePanel(datasource),
 	)
 }
 
-func withMemStatsAndChart(datasource string) dashboard.Option {
-	return dashboard.AddPanelGroup("",
-		panelgroup.PanelsPerLine(4),
-		panelgroup.PanelHeight(4),
+func withMemSection(datasource string) dashboard.Option {
+	return acmHelpers.AddCustomPanelGroup("Memory",
+		[]acmHelpers.GridItem{
+			{X: 0, Y: 0, W: 6, H: 4},
+			{X: 0, Y: 4, W: 6, H: 4},
+			{X: 0, Y: 8, W: 6, H: 4},
+			{X: 0, Y: 12, W: 6, H: 4},
+			{X: 6, Y: 0, W: 18, H: 16},
+			{X: 0, Y: 16, W: 24, H: 10},
+		},
 		panels.MemRecommendationPanel(datasource),
 		panels.MemUsagePanel(datasource),
 		panels.MemRequestPanel(datasource),
 		panels.MemUtilizationPanel(datasource),
-	)
-}
-
-func withMemTopNamespaces(datasource string) dashboard.Option {
-	return dashboard.AddPanelGroup("",
-		panelgroup.PanelsPerLine(1),
-		panelgroup.PanelHeight(12),
 		panels.MemTopNamespacesPanel(datasource),
-	)
-}
-
-func withMemQuotaTable(datasource string) dashboard.Option {
-	return dashboard.AddPanelGroup("",
-		panelgroup.PanelsPerLine(1),
-		panelgroup.PanelHeight(8),
 		panels.MemQuotaTablePanel(datasource),
 	)
 }
@@ -124,11 +108,7 @@ func BuildNamespaceRightSizing(project string, datasource string, clusterLabelNa
 			),
 		),
 
-		withCPUStatsAndChart(datasource),
-		withCPUTopNamespaces(datasource),
-		withCPUQuotaTable(datasource),
-		withMemStatsAndChart(datasource),
-		withMemTopNamespaces(datasource),
-		withMemQuotaTable(datasource),
+		withCPUSection(datasource),
+		withMemSection(datasource),
 	)
 }

--- a/internal/perses/dashboards/rightsizing/rightsizing_test.go
+++ b/internal/perses/dashboards/rightsizing/rightsizing_test.go
@@ -38,7 +38,7 @@ func TestBuildNamespaceRightSizing(t *testing.T) {
 	})
 
 	t.Run("has expected panel groups", func(t *testing.T) {
-		require.Len(t, spec.Layouts, 6, "CPU stats/chart + CPU topK + CPU table + Mem stats/chart + Mem topK + Mem table")
+		require.Len(t, spec.Layouts, 2, "CPU section + Memory section")
 	})
 
 	t.Run("panels reference the datasource", func(t *testing.T) {
@@ -154,7 +154,7 @@ func TestBuildVMOverestimation(t *testing.T) {
 	})
 
 	t.Run("has expected panel groups", func(t *testing.T) {
-		require.Len(t, spec.Layouts, 5, "back-to-main + CPU stats + CPU timeseries + Mem stats + Mem timeseries")
+		require.Len(t, spec.Layouts, 3, "back-to-main + CPU stats+chart + Mem stats+chart")
 	})
 
 	t.Run("contains back to main dashboard link", func(t *testing.T) {
@@ -207,7 +207,7 @@ func TestBuildVMUnderestimation(t *testing.T) {
 	})
 
 	t.Run("has expected panel groups", func(t *testing.T) {
-		require.Len(t, spec.Layouts, 5, "back-to-main + CPU stats + CPU timeseries + Mem stats + Mem timeseries")
+		require.Len(t, spec.Layouts, 3, "back-to-main + CPU stats+chart + Mem stats+chart")
 	})
 
 	t.Run("contains back to main dashboard link", func(t *testing.T) {

--- a/internal/perses/dashboards/rightsizing/vm-overestimation.go
+++ b/internal/perses/dashboards/rightsizing/vm-overestimation.go
@@ -10,7 +10,6 @@ import (
 	"github.com/perses/community-mixins/pkg/dashboards"
 	"github.com/perses/community-mixins/pkg/promql"
 	"github.com/perses/perses/go-sdk/dashboard"
-	panelgroup "github.com/perses/perses/go-sdk/panel-group"
 	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
 	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
 	staticListVar "github.com/perses/plugins/staticlistvariable/sdk/go"
@@ -107,33 +106,33 @@ func BuildVMOverestimation(project string, datasource string, clusterLabelName s
 			panels.VMBackToMainDashboardPanel(datasource, project),
 		),
 
-		dashboard.AddPanelGroup("",
-			panelgroup.PanelsPerLine(4),
-			panelgroup.PanelHeight(4),
+		acmHelpers.AddCustomPanelGroup("CPU",
+			[]acmHelpers.GridItem{
+				{X: 0, Y: 0, W: 6, H: 4},
+				{X: 0, Y: 4, W: 6, H: 4},
+				{X: 0, Y: 8, W: 6, H: 4},
+				{X: 0, Y: 12, W: 6, H: 4},
+				{X: 6, Y: 0, W: 18, H: 16},
+			},
 			panels.VMCPUOverestimationStatPanel(datasource),
 			panels.VMCPUUsageStatPanel(datasource),
 			panels.VMCPURequestStatPanel(datasource),
 			panels.VMCPUUtilizationStatPanel(datasource),
-		),
-
-		dashboard.AddPanelGroup("",
-			panelgroup.PanelsPerLine(1),
-			panelgroup.PanelHeight(12),
 			panels.VMCPUUtilizationTimeSeriesPanel(datasource),
 		),
 
-		dashboard.AddPanelGroup("",
-			panelgroup.PanelsPerLine(4),
-			panelgroup.PanelHeight(4),
+		acmHelpers.AddCustomPanelGroup("Memory",
+			[]acmHelpers.GridItem{
+				{X: 0, Y: 0, W: 6, H: 4},
+				{X: 0, Y: 4, W: 6, H: 4},
+				{X: 0, Y: 8, W: 6, H: 4},
+				{X: 0, Y: 12, W: 6, H: 4},
+				{X: 6, Y: 0, W: 18, H: 16},
+			},
 			panels.VMMemoryOverestimationStatPanel(datasource),
 			panels.VMMemoryUsageStatPanel(datasource),
 			panels.VMMemoryRequestStatPanel(datasource),
 			panels.VMMemoryUtilizationStatPanel(datasource),
-		),
-
-		dashboard.AddPanelGroup("",
-			panelgroup.PanelsPerLine(1),
-			panelgroup.PanelHeight(12),
 			panels.VMMemoryUtilizationTimeSeriesPanel(datasource),
 		),
 	)

--- a/internal/perses/dashboards/rightsizing/vm-overview.go
+++ b/internal/perses/dashboards/rightsizing/vm-overview.go
@@ -31,7 +31,7 @@ func withVMOverviewStatsGroup(datasource string) dashboard.Option {
 func withVMCPUOverestimationTableGroup(datasource string, project string) dashboard.Option {
 	return dashboard.AddPanelGroup("",
 		panelgroup.PanelsPerLine(1),
-		panelgroup.PanelHeight(8),
+		panelgroup.PanelHeight(10),
 		panels.VMCPUOverestimationTablePanel(datasource, project),
 	)
 }
@@ -39,7 +39,7 @@ func withVMCPUOverestimationTableGroup(datasource string, project string) dashbo
 func withVMCPUUnderestimationTableGroup(datasource string, project string) dashboard.Option {
 	return dashboard.AddPanelGroup("",
 		panelgroup.PanelsPerLine(1),
-		panelgroup.PanelHeight(8),
+		panelgroup.PanelHeight(10),
 		panels.VMCPUUnderestimationTablePanel(datasource, project),
 	)
 }
@@ -47,7 +47,7 @@ func withVMCPUUnderestimationTableGroup(datasource string, project string) dashb
 func withVMMemOverestimationTableGroup(datasource string, project string) dashboard.Option {
 	return dashboard.AddPanelGroup("",
 		panelgroup.PanelsPerLine(1),
-		panelgroup.PanelHeight(8),
+		panelgroup.PanelHeight(10),
 		panels.VMMemOverestimationTablePanel(datasource, project),
 	)
 }
@@ -55,7 +55,7 @@ func withVMMemOverestimationTableGroup(datasource string, project string) dashbo
 func withVMMemUnderestimationTableGroup(datasource string, project string) dashboard.Option {
 	return dashboard.AddPanelGroup("",
 		panelgroup.PanelsPerLine(1),
-		panelgroup.PanelHeight(8),
+		panelgroup.PanelHeight(10),
 		panels.VMMemUnderestimationTablePanel(datasource, project),
 	)
 }

--- a/internal/perses/dashboards/rightsizing/vm-underestimation.go
+++ b/internal/perses/dashboards/rightsizing/vm-underestimation.go
@@ -10,7 +10,6 @@ import (
 	"github.com/perses/community-mixins/pkg/dashboards"
 	"github.com/perses/community-mixins/pkg/promql"
 	"github.com/perses/perses/go-sdk/dashboard"
-	panelgroup "github.com/perses/perses/go-sdk/panel-group"
 	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
 	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
 	staticListVar "github.com/perses/plugins/staticlistvariable/sdk/go"
@@ -107,33 +106,33 @@ func BuildVMUnderestimation(project string, datasource string, clusterLabelName 
 			panels.VMBackToMainDashboardPanel(datasource, project),
 		),
 
-		dashboard.AddPanelGroup("",
-			panelgroup.PanelsPerLine(4),
-			panelgroup.PanelHeight(4),
+		acmHelpers.AddCustomPanelGroup("CPU",
+			[]acmHelpers.GridItem{
+				{X: 0, Y: 0, W: 6, H: 4},
+				{X: 0, Y: 4, W: 6, H: 4},
+				{X: 0, Y: 8, W: 6, H: 4},
+				{X: 0, Y: 12, W: 6, H: 4},
+				{X: 6, Y: 0, W: 18, H: 16},
+			},
 			panels.VMCPUUnderestimationStatPanel(datasource),
 			panels.VMCPUUsageStatPanel(datasource),
 			panels.VMCPURequestStatPanel(datasource),
 			panels.VMCPUUtilizationStatPanel(datasource),
-		),
-
-		dashboard.AddPanelGroup("",
-			panelgroup.PanelsPerLine(1),
-			panelgroup.PanelHeight(12),
 			panels.VMCPUUtilizationTimeSeriesPanel(datasource),
 		),
 
-		dashboard.AddPanelGroup("",
-			panelgroup.PanelsPerLine(4),
-			panelgroup.PanelHeight(4),
+		acmHelpers.AddCustomPanelGroup("Memory",
+			[]acmHelpers.GridItem{
+				{X: 0, Y: 0, W: 6, H: 4},
+				{X: 0, Y: 4, W: 6, H: 4},
+				{X: 0, Y: 8, W: 6, H: 4},
+				{X: 0, Y: 12, W: 6, H: 4},
+				{X: 6, Y: 0, W: 18, H: 16},
+			},
 			panels.VMMemoryUnderestimationStatPanel(datasource),
 			panels.VMMemoryUsageStatPanel(datasource),
 			panels.VMMemoryRequestStatPanel(datasource),
 			panels.VMMemoryUtilizationStatPanel(datasource),
-		),
-
-		dashboard.AddPanelGroup("",
-			panelgroup.PanelsPerLine(1),
-			panelgroup.PanelHeight(12),
 			panels.VMMemoryUtilizationTimeSeriesPanel(datasource),
 		),
 	)

--- a/internal/perses/panels/rightsizing/common.go
+++ b/internal/perses/panels/rightsizing/common.go
@@ -29,6 +29,7 @@ type StatPanelConfig struct {
 // This provides a reusable way to create consistent stat panels across dashboards.
 func BuildStatPanel(datasourceName string, cfg StatPanelConfig) panelgroup.Option {
 	opts := []statPanel.Option{
+		statPanel.Calculation("last-number"),
 		statPanel.Format(commonSdk.Format{
 			Unit:          cfg.Unit,
 			DecimalPlaces: cfg.Decimals,

--- a/internal/perses/panels/rightsizing/namespace-panels.go
+++ b/internal/perses/panels/rightsizing/namespace-panels.go
@@ -31,21 +31,17 @@ func nsTblCol(name, header string, align tablePanel.Align, format *commonSdk.For
 	return c
 }
 
-var greenThreshold = &commonSdk.Thresholds{
+var nsStatThreshold = &commonSdk.Thresholds{
 	Steps: []commonSdk.StepOption{
-		{Value: 0, Color: "#73BF69"},
+		{Value: 0, Color: "#0066cc"},
 	},
 }
 
-var grayThreshold = &commonSdk.Thresholds{
+var nsUtilizationThreshold = &commonSdk.Thresholds{
 	Steps: []commonSdk.StepOption{
-		{Value: 0, Color: "#808080"},
-	},
-}
-
-var percentThreshold = &commonSdk.Thresholds{
-	Steps: []commonSdk.StepOption{
-		{Value: 0, Color: "#808080"},
+		{Value: 0, Color: "#E02F44"},
+		{Value: 0.8, Color: "#73BF69"},
+		{Value: 1.0, Color: "#E0B400"},
 	},
 }
 
@@ -56,8 +52,8 @@ func CPURecommendationPanel(datasourceName string) panelgroup.Option {
 		Query:       `max_over_time(sum by (cluster)(acm_rs:cluster:cpu_recommendation{cluster="$cluster", profile="$profile"})[$days:])`,
 		Unit:        &dashboards.DecimalUnit,
 		Decimals:    2,
-		FontSize:    48,
-		Thresholds:  greenThreshold,
+		FontSize:    40,
+		Thresholds:  nsStatThreshold,
 	})
 }
 
@@ -68,8 +64,8 @@ func CPUUsagePanel(datasourceName string) panelgroup.Option {
 		Query:       `max_over_time(sum by (cluster)(acm_rs:cluster:cpu_usage{cluster="$cluster", profile="$profile"})[$days:])`,
 		Unit:        &dashboards.DecimalUnit,
 		Decimals:    2,
-		FontSize:    48,
-		Thresholds:  grayThreshold,
+		FontSize:    40,
+		Thresholds:  nsStatThreshold,
 	})
 }
 
@@ -80,8 +76,8 @@ func CPURequestPanel(datasourceName string) panelgroup.Option {
 		Query:       `max_over_time(sum by (cluster)(acm_rs:cluster:cpu_request{cluster="$cluster", profile="$profile"})[$days:])`,
 		Unit:        &dashboards.DecimalUnit,
 		Decimals:    2,
-		FontSize:    48,
-		Thresholds:  grayThreshold,
+		FontSize:    40,
+		Thresholds:  nsStatThreshold,
 	})
 }
 
@@ -92,56 +88,56 @@ func CPUUtilizationPanel(datasourceName string) panelgroup.Option {
 		Query:       `max_over_time(sum by (cluster)(acm_rs:cluster:cpu_usage{cluster="$cluster", profile="$profile"})[$days:]) / max_over_time(sum by (cluster)(acm_rs:cluster:cpu_request{cluster="$cluster", profile="$profile"})[$days:])`,
 		Unit:        &dashboards.PercentDecimalUnit,
 		Decimals:    1,
-		FontSize:    48,
-		Thresholds:  percentThreshold,
+		FontSize:    40,
+		Thresholds:  nsUtilizationThreshold,
 	})
 }
 
 func MemRecommendationPanel(datasourceName string) panelgroup.Option {
 	return BuildStatPanel(datasourceName, StatPanelConfig{
-		Title:       "Mem Recommendation",
+		Title:       "Memory Recommendation",
 		Description: "Memory recommendation for the selected cluster",
 		Query:       `max_over_time(sum by (cluster)(acm_rs:cluster:memory_recommendation{cluster="$cluster", profile="$profile"})[$days:])`,
 		Unit:        &dashboards.BytesUnit,
 		Decimals:    1,
 		FontSize:    40,
-		Thresholds:  greenThreshold,
+		Thresholds:  nsStatThreshold,
 	})
 }
 
 func MemUsagePanel(datasourceName string) panelgroup.Option {
 	return BuildStatPanel(datasourceName, StatPanelConfig{
-		Title:       "Mem Usage",
+		Title:       "Memory Usage",
 		Description: "Memory usage for the selected cluster",
 		Query:       `max_over_time(sum by (cluster)(acm_rs:cluster:memory_usage{cluster="$cluster", profile="$profile"})[$days:])`,
 		Unit:        &dashboards.BytesUnit,
 		Decimals:    1,
 		FontSize:    40,
-		Thresholds:  grayThreshold,
+		Thresholds:  nsStatThreshold,
 	})
 }
 
 func MemRequestPanel(datasourceName string) panelgroup.Option {
 	return BuildStatPanel(datasourceName, StatPanelConfig{
-		Title:       "Mem Request",
+		Title:       "Memory Request",
 		Description: "Memory request for the selected cluster",
 		Query:       `max_over_time(sum by (cluster)(acm_rs:cluster:memory_request{cluster="$cluster", profile="$profile"})[$days:])`,
 		Unit:        &dashboards.BytesUnit,
 		Decimals:    1,
 		FontSize:    40,
-		Thresholds:  grayThreshold,
+		Thresholds:  nsStatThreshold,
 	})
 }
 
 func MemUtilizationPanel(datasourceName string) panelgroup.Option {
 	return BuildStatPanel(datasourceName, StatPanelConfig{
-		Title:       "Mem Utilization",
+		Title:       "Memory Utilization",
 		Description: "Memory utilization percentage for the selected cluster",
 		Query:       `max_over_time(sum by (cluster)(acm_rs:cluster:memory_usage{cluster="$cluster", profile="$profile"})[$days:]) / max_over_time(sum by (cluster)(acm_rs:cluster:memory_request{cluster="$cluster", profile="$profile"})[$days:])`,
 		Unit:        &dashboards.PercentDecimalUnit,
 		Decimals:    1,
 		FontSize:    40,
-		Thresholds:  percentThreshold,
+		Thresholds:  nsUtilizationThreshold,
 	})
 }
 

--- a/internal/perses/panels/rightsizing/namespace-panels.go
+++ b/internal/perses/panels/rightsizing/namespace-panels.go
@@ -233,6 +233,7 @@ func CPUQuotaTablePanel(datasourceName string) panelgroup.Option {
 			},
 			Transforms: []commonSdk.Transform{
 				{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+				{Kind: commonSdk.JoinByColumValueKind, Spec: commonSdk.JoinByColumnValueSpec{Columns: []string{"namespace"}}},
 			},
 			EnableFiltering: true,
 		}),
@@ -293,6 +294,7 @@ func MemQuotaTablePanel(datasourceName string) panelgroup.Option {
 			},
 			Transforms: []commonSdk.Transform{
 				{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+				{Kind: commonSdk.JoinByColumValueKind, Spec: commonSdk.JoinByColumnValueSpec{Columns: []string{"namespace"}}},
 			},
 			EnableFiltering: true,
 		}),

--- a/internal/perses/panels/rightsizing/vm-panels.go
+++ b/internal/perses/panels/rightsizing/vm-panels.go
@@ -79,7 +79,7 @@ func VMTotalCPUOverestimationPanel(datasourceName string) panelgroup.Option {
 			"\n" + `)[$days:])))>0)`,
 		Unit:       &dashboards.DecimalUnit,
 		Decimals:   0,
-		FontSize:   48,
+		FontSize:   40,
 		Thresholds: overestRedThreshold,
 	})
 }
@@ -96,7 +96,7 @@ func VMTotalCPUUnderestimationPanel(datasourceName string) panelgroup.Option {
 			"\n" + `)[$days:])))<0) * (-1)`,
 		Unit:       &dashboards.DecimalUnit,
 		Decimals:   0,
-		FontSize:   48,
+		FontSize:   40,
 		Thresholds: cpuUnderestYellowThreshold,
 	})
 }
@@ -398,7 +398,7 @@ func VMCPUOverestimationStatPanel(datasourceName string) panelgroup.Option {
 		Query:       `max by (cluster, profile, namespace, name)(floor(max_over_time(acm_rs_vm:namespace:cpu_request{cluster="$cluster", profile="$profile", namespace=~"$namespace", name=~"$vm"}[$days:])-` + "\n" + `max_over_time(acm_rs_vm:namespace:cpu_recommendation{cluster="$cluster", profile="$profile", namespace=~"$namespace", name=~"$vm"}[$days:])))`,
 		Unit:        &dashboards.DecimalUnit,
 		Decimals:    0,
-		FontSize:    48,
+		FontSize:    40,
 		Thresholds:  overestDetailRedThreshold,
 	})
 }
@@ -410,7 +410,7 @@ func VMCPUUsageStatPanel(datasourceName string) panelgroup.Option {
 		Query:       `max by (cluster, profile, namespace, name)(max_over_time(acm_rs_vm:namespace:cpu_usage{cluster="$cluster", profile="$profile", namespace=~"$namespace", name=~"$vm"}[$days:]))`,
 		Unit:        &dashboards.DecimalUnit,
 		Decimals:    0,
-		FontSize:    48,
+		FontSize:    40,
 		Thresholds:  detailGrayThreshold,
 	})
 }
@@ -422,7 +422,7 @@ func VMCPURequestStatPanel(datasourceName string) panelgroup.Option {
 		Query:       `max by (cluster, profile, namespace, name)(max_over_time(acm_rs_vm:namespace:cpu_request{cluster="$cluster", profile="$profile", namespace=~"$namespace", name=~"$vm"}[$days:]))`,
 		Unit:        &dashboards.DecimalUnit,
 		Decimals:    0,
-		FontSize:    48,
+		FontSize:    40,
 		Thresholds:  detailGrayThreshold,
 	})
 }
@@ -434,7 +434,7 @@ func VMCPUUtilizationStatPanel(datasourceName string) panelgroup.Option {
 		Query:       `max by (cluster, profile, namespace, name)(max_over_time(acm_rs_vm:namespace:cpu_usage{cluster="$cluster", profile="$profile", namespace=~"$namespace", name=~"$vm"}[$days:]) / max_over_time(acm_rs_vm:namespace:cpu_request{cluster="$cluster", profile="$profile", namespace=~"$namespace", name=~"$vm"}[$days:]))`,
 		Unit:        &dashboards.PercentDecimalUnit,
 		Decimals:    0,
-		FontSize:    48,
+		FontSize:    40,
 		Thresholds:  detailPercentThreshold,
 	})
 }
@@ -554,7 +554,7 @@ func VMCPUUnderestimationStatPanel(datasourceName string) panelgroup.Option {
 		Query:       `max by (cluster, profile, namespace, name)(floor(max_over_time(acm_rs_vm:namespace:cpu_request{cluster="$cluster", profile="$profile", namespace=~"$namespace", name=~"$vm"}[$days:])-` + "\n" + `max_over_time(acm_rs_vm:namespace:cpu_recommendation{cluster="$cluster", profile="$profile", namespace=~"$namespace", name=~"$vm"}[$days:]))* (-1))`,
 		Unit:        &dashboards.DecimalUnit,
 		Decimals:    0,
-		FontSize:    48,
+		FontSize:    40,
 		Thresholds:  underestDetailYellowThreshold,
 	})
 }


### PR DESCRIPTION
Remove unnecessary placement ConfigMaps and fix Perses dashboard rendering

Removes the dedicated placement ConfigMaps (rs-namespace-placement, rs-virt-placement) that were created under the incorrect assumption that MCO overwrites the main RS ConfigMaps. Both MCO and MCOA use a "create if not exists" pattern, so placement predicates in rs-namespace-config / rs-virt-config are already preserved across mode switches. Also fixes Namespace Perses dashboard stat panels to use last-number calculation and adds JoinByColumnValue transform to quota tables for correct row merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster placement evaluation simplified to use embedded placement config only (no separate placement overrides).

* **Refactor**
  * Removed separate placement config artifacts and related constants; cleanup now targets only primary right-sizing configs.
  * Controller watch now uses the centralized rightsizing config predicate.
  * Dashboards reorganized to CPU/Memory custom sections (fewer panel groups).

* **UI Improvements**
  * Stat panels use a "last-number" calculation and reduced font size for consistency.
  * Table panels join series by namespace; memory stat titles expanded for clarity; some panel heights increased.

* **Tests**
  * Unit tests updated to reflect removal of placement override behavior and new dashboard layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->