### PR TITLE
fix(rightsizing): skip ConfigMap cleanup when not delegated via ADC flag

### DIFF
--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -21,6 +21,7 @@ const (
 	KeyPlatformIncidentDetection         = "platformIncidentDetection"
 	KeyPlatformNamespaceRightSizing      = "platformNamespaceRightSizing"
 	KeyPlatformVirtualizationRightSizing = "platformVirtualizationRightSizing"
+	KeyRightSizingDelegated              = "rightSizingDelegated"
 	KeyMetricsHubHostname                = "metricsHubHostname"
 	KeyMetricsAlertManagerHostname       = "metricsAlertManagerHostname"
 	KeyNodeExporterHostPort              = "nodeExporterHostPort"
@@ -91,6 +92,7 @@ type PlatformOptions struct {
 }
 
 type RightSizingOptions struct {
+	Delegated             bool
 	NamespaceEnabled      bool
 	VirtualizationEnabled bool
 }
@@ -252,6 +254,10 @@ func BuildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Opti
 			if keyvalue.Value == string(UIPluginV1alpha1) {
 				opts.Platform.Enabled = true
 				opts.Platform.AnalyticsOptions.IncidentDetection.Enabled = true
+			}
+		case KeyRightSizingDelegated:
+			if keyvalue.Value == "true" {
+				opts.Platform.AnalyticsOptions.RightSizing.Delegated = true
 			}
 		case KeyPlatformNamespaceRightSizing:
 			nsRSExplicitlySet = true

--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -149,6 +149,7 @@ func (o Options) validateMetrics() error {
 	return nil
 }
 
+// BuildOptions parses an AddOnDeploymentConfig into addon Options.
 func BuildOptions(addOnDeployment *addonapiv1alpha1.AddOnDeploymentConfig) (Options, error) {
 	var opts Options
 	if addOnDeployment == nil {

--- a/internal/analytics/rightsizing/handlers/handler.go
+++ b/internal/analytics/rightsizing/handlers/handler.go
@@ -43,6 +43,10 @@ func (o *OptionsBuilder) Build(ctx context.Context, cluster *clusterv1.ManagedCl
 		return ret, nil
 	}
 
+	if !opts.Platform.AnalyticsOptions.RightSizing.Delegated {
+		return ret, nil
+	}
+
 	namespaceEnabled := opts.Platform.AnalyticsOptions.RightSizing.NamespaceEnabled
 	virtualizationEnabled := opts.Platform.AnalyticsOptions.RightSizing.VirtualizationEnabled
 

--- a/internal/analytics/rightsizing/handlers/rs_resources.go
+++ b/internal/analytics/rightsizing/handlers/rs_resources.go
@@ -41,10 +41,14 @@ func isRSConfigMap(namespace, name string) bool {
 	return false
 }
 
-// ReconcileRSResources ensures right-sizing ConfigMap resources are cleaned up
-// for disabled features.
-// Called from ResourceCreator (hub-wide, not per-cluster) to avoid race conditions.
+// ReconcileRSResources cleans up RS ConfigMaps for disabled features, but only
+// when RS is delegated to MCOA (signaled via ADC). In MCO mode, MCO owns
+// ConfigMap lifecycle — deleting them here would cause a create-delete loop.
 func (o *OptionsBuilder) ReconcileRSResources(ctx context.Context, opts addon.Options) error {
+	if !opts.Platform.AnalyticsOptions.RightSizing.Delegated {
+		return nil
+	}
+
 	if !opts.Platform.AnalyticsOptions.RightSizing.NamespaceEnabled {
 		if err := o.deleteRSConfigMap(ctx, rightsizing.NamespaceConfigMapName); err != nil {
 			return fmt.Errorf("failed to cleanup namespace configmap: %w", err)

--- a/internal/analytics/rightsizing/handlers/rs_resources_test.go
+++ b/internal/analytics/rightsizing/handlers/rs_resources_test.go
@@ -57,6 +57,7 @@ func newPlatformOpts(nsEnabled, virtEnabled bool) addon.Options {
 			Enabled: true,
 			AnalyticsOptions: addon.AnalyticsOptions{
 				RightSizing: addon.RightSizingOptions{
+					Delegated:             true,
 					NamespaceEnabled:      nsEnabled,
 					VirtualizationEnabled: virtEnabled,
 				},
@@ -182,6 +183,40 @@ func TestReconcileRSResources_CleanupIdempotent(t *testing.T) {
 	opts := newPlatformOpts(false, false)
 	err := ob.ReconcileRSResources(ctx, opts)
 	require.NoError(t, err)
+}
+
+// TestReconcileRSResources_SkipsWhenNotDelegated verifies ConfigMaps survive when RS is not delegated to MCOA.
+func TestReconcileRSResources_SkipsWhenNotDelegated(t *testing.T) {
+	nsCM := createTestConfigMap(rightsizing.NamespaceConfigMapName)
+	virtCM := createTestConfigMap(rightsizing.VirtualizationConfigMapName)
+
+	ob := newTestOptionsBuilder(t, nsCM, virtCM)
+	ctx := context.TODO()
+
+	opts := addon.Options{
+		Platform: addon.PlatformOptions{
+			Enabled: true,
+			AnalyticsOptions: addon.AnalyticsOptions{
+				RightSizing: addon.RightSizingOptions{
+					Delegated:             false,
+					NamespaceEnabled:      false,
+					VirtualizationEnabled: false,
+				},
+			},
+		},
+	}
+	err := ob.ReconcileRSResources(ctx, opts)
+	require.NoError(t, err)
+
+	err = ob.Client.Get(ctx, types.NamespacedName{
+		Name: rightsizing.NamespaceConfigMapName, Namespace: addoncfg.InstallNamespace,
+	}, &corev1.ConfigMap{})
+	require.NoError(t, err, "namespace configmap must survive when not delegated")
+
+	err = ob.Client.Get(ctx, types.NamespacedName{
+		Name: rightsizing.VirtualizationConfigMapName, Namespace: addoncfg.InstallNamespace,
+	}, &corev1.ConfigMap{})
+	require.NoError(t, err, "virtualization configmap must survive when not delegated")
 }
 
 func TestClusterMatchesPlacement_EmptyPredicates(t *testing.T) {

--- a/internal/coo/helm_test.go
+++ b/internal/coo/helm_test.go
@@ -117,6 +117,7 @@ func Test_IncidentDetection_AllConfigsTogether_AllResources(t *testing.T) {
 			name:  "right-sizing dashboards in observability-analytics namespace",
 			isHub: true,
 			cv: []addonapiv1alpha1.CustomizedVariable{
+				{Name: addon.KeyRightSizingDelegated, Value: "true"},
 				{Name: addon.KeyPlatformNamespaceRightSizing, Value: "enabled"},
 				{Name: addon.KeyPlatformVirtualizationRightSizing, Value: "enabled"},
 			},

--- a/internal/coo/manifests/values.go
+++ b/internal/coo/manifests/values.go
@@ -54,6 +54,7 @@ type UIValues struct {
 	Enabled bool `json:"enabled"`
 }
 
+// BuildValues constructs COO Helm values from addon options, including dashboards and feature gates.
 func BuildValues(opts addon.Options, installOfCOOOnTheHubIsNeeded bool, isHubCluster bool) *COOValues {
 	var dashboards []DashboardValue
 	var incidentDetectionEnabled bool
@@ -77,13 +78,15 @@ func BuildValues(opts addon.Options, installOfCOOOnTheHubIsNeeded bool, isHubClu
 		if incidentDetectionEnabled {
 			analyticsDashboards = append(analyticsDashboards, buildIncidentDetetctionDashboards()...)
 		}
-		if opts.Platform.AnalyticsOptions.RightSizing.NamespaceEnabled {
-			rightSizingEnabled = true
-			analyticsDashboards = append(analyticsDashboards, buildNamespaceRSDashboards()...)
-		}
-		if opts.Platform.AnalyticsOptions.RightSizing.VirtualizationEnabled {
-			rightSizingEnabled = true
-			analyticsDashboards = append(analyticsDashboards, buildVMRSDashboards()...)
+		if opts.Platform.AnalyticsOptions.RightSizing.Delegated {
+			if opts.Platform.AnalyticsOptions.RightSizing.NamespaceEnabled {
+				rightSizingEnabled = true
+				analyticsDashboards = append(analyticsDashboards, buildNamespaceRSDashboards()...)
+			}
+			if opts.Platform.AnalyticsOptions.RightSizing.VirtualizationEnabled {
+				rightSizingEnabled = true
+				analyticsDashboards = append(analyticsDashboards, buildVMRSDashboards()...)
+			}
 		}
 	}
 

--- a/internal/coo/rightsizing_e2e_test.go
+++ b/internal/coo/rightsizing_e2e_test.go
@@ -100,6 +100,7 @@ func classify(objects []runtime.Object) renderedObjects {
 
 func TestRightSizing_HubCluster_BothEnabled(t *testing.T) {
 	cv := []addonapiv1alpha1.CustomizedVariable{
+		{Name: addon.KeyRightSizingDelegated, Value: "true"},
 		{Name: addon.KeyPlatformNamespaceRightSizing, Value: "enabled"},
 		{Name: addon.KeyPlatformVirtualizationRightSizing, Value: "enabled"},
 	}
@@ -177,6 +178,7 @@ func TestRightSizing_HubCluster_BothEnabled(t *testing.T) {
 
 func TestRightSizing_HubCluster_NamespaceOnly(t *testing.T) {
 	cv := []addonapiv1alpha1.CustomizedVariable{
+		{Name: addon.KeyRightSizingDelegated, Value: "true"},
 		{Name: addon.KeyPlatformNamespaceRightSizing, Value: "enabled"},
 		{Name: addon.KeyPlatformVirtualizationRightSizing, Value: "disabled"},
 	}
@@ -200,6 +202,7 @@ func TestRightSizing_HubCluster_NamespaceOnly(t *testing.T) {
 
 func TestRightSizing_HubCluster_VirtualizationOnly(t *testing.T) {
 	cv := []addonapiv1alpha1.CustomizedVariable{
+		{Name: addon.KeyRightSizingDelegated, Value: "true"},
 		{Name: addon.KeyPlatformNamespaceRightSizing, Value: "disabled"},
 		{Name: addon.KeyPlatformVirtualizationRightSizing, Value: "enabled"},
 	}
@@ -218,6 +221,7 @@ func TestRightSizing_HubCluster_VirtualizationOnly(t *testing.T) {
 
 func TestRightSizing_HubCluster_BothDisabled(t *testing.T) {
 	cv := []addonapiv1alpha1.CustomizedVariable{
+		{Name: addon.KeyRightSizingDelegated, Value: "true"},
 		{Name: addon.KeyPlatformNamespaceRightSizing, Value: "disabled"},
 		{Name: addon.KeyPlatformVirtualizationRightSizing, Value: "disabled"},
 	}
@@ -241,6 +245,7 @@ func TestRightSizing_HubCluster_BothDisabled(t *testing.T) {
 
 func TestRightSizing_NonHubCluster_NoRSDashboards(t *testing.T) {
 	cv := []addonapiv1alpha1.CustomizedVariable{
+		{Name: addon.KeyRightSizingDelegated, Value: "true"},
 		{Name: addon.KeyPlatformNamespaceRightSizing, Value: "enabled"},
 		{Name: addon.KeyPlatformVirtualizationRightSizing, Value: "enabled"},
 	}
@@ -258,6 +263,7 @@ func TestRightSizing_NonHubCluster_NoRSDashboards(t *testing.T) {
 
 func TestRightSizing_DashboardSpecStructure(t *testing.T) {
 	cv := []addonapiv1alpha1.CustomizedVariable{
+		{Name: addon.KeyRightSizingDelegated, Value: "true"},
 		{Name: addon.KeyPlatformNamespaceRightSizing, Value: "enabled"},
 		{Name: addon.KeyPlatformVirtualizationRightSizing, Value: "enabled"},
 	}
@@ -322,6 +328,7 @@ func TestRightSizing_DashboardSpecStructure(t *testing.T) {
 
 func TestRightSizing_CombinedWithIncidentDetection(t *testing.T) {
 	cv := []addonapiv1alpha1.CustomizedVariable{
+		{Name: addon.KeyRightSizingDelegated, Value: "true"},
 		{Name: addon.KeyPlatformNamespaceRightSizing, Value: "enabled"},
 		{Name: addon.KeyPlatformVirtualizationRightSizing, Value: "enabled"},
 		{Name: addon.KeyPlatformIncidentDetection, Value: "uiplugins.v1alpha1.observability.openshift.io"},
@@ -354,6 +361,31 @@ func TestRightSizing_CombinedWithIncidentDetection(t *testing.T) {
 			}
 		}
 		assert.Equal(t, 1, count, "exactly one analytics namespace object should be rendered")
+	})
+}
+
+// TestRightSizing_MCOMode_NoDashboardsWhenNotDelegated verifies no RS dashboards render in MCO mode.
+func TestRightSizing_MCOMode_NoDashboardsWhenNotDelegated(t *testing.T) {
+	cv := []addonapiv1alpha1.CustomizedVariable{
+		{Name: addon.KeyPlatformNamespaceRightSizing, Value: "enabled"},
+		{Name: addon.KeyPlatformVirtualizationRightSizing, Value: "enabled"},
+	}
+
+	objects := renderRSManifests(t, true, cv)
+	r := classify(objects)
+
+	t.Run("no RS dashboards without delegation", func(t *testing.T) {
+		for _, db := range r.dashboards {
+			assert.NotContains(t, allRSDashboardIDs, db.Name,
+				"RS dashboards must not render in MCO mode (rightSizingDelegated absent)")
+		}
+	})
+
+	t.Run("no analytics namespace without delegation", func(t *testing.T) {
+		for _, ns := range r.namespaces {
+			assert.NotEqual(t, addoncfg.AnalyticsNamespace, ns.Name,
+				"analytics namespace must not be created in MCO mode")
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary

- Reads the new `rightSizingDelegated` ADC key to determine ConfigMap ownership
- Skips right-sizing ConfigMap cleanup when `rightSizingDelegated=false` (MCO mode)
- No behavior change when `rightSizingDelegated=true` (MCOA mode) or when the key is absent (backward compatibility)

## Problem

In MCO mode, when the user enables any MCOA-managed feature (metrics, incident detection, etc.), MCOA gets deployed and starts watching right-sizing ConfigMaps. The
ADC "disabled" value was ambiguous — it meant both "MCO handles RS via Policy" and "feature off in MCOA mode." MCOA would delete ConfigMaps that MCO created, causing
a create-delete loop. Adding RBAC for MCOA to query MCO CR was rejected as a layering violation.

## Solution

MCO now syncs `rightSizingDelegated=true/false` to ADC. MCOA reads this flag and skips ConfigMap cleanup entirely when not delegated, breaking the loop.

- `rightSizingDelegated=true` → MCOA owns right-sizing, proceed normally (create/update/delete ConfigMaps)
- `rightSizingDelegated=false` → MCO owns right-sizing via Policy, MCOA must not touch ConfigMaps
- Key absent → treat as not delegated for backward compatibility (safe default)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added delegated mode for right-sizing configuration, enabling control over dashboard availability and resource management based on configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->