### PR TITLE
fix time-in-status PromQL value inflation

### DIFF
--- a/pkg/perses/panels/virtualization/vm-by-time-in-status-queries.go
+++ b/pkg/perses/panels/virtualization/vm-by-time-in-status-queries.go
@@ -13,7 +13,7 @@ const (
 
 const vmByTimeInStatusStatusJoin = `
   + on(cluster, name, namespace) group_left(status)
-  (
+  (0 * (
     (
       (
         (time() - ` + vmStartingLastTransitionExpr + `)
@@ -79,7 +79,7 @@ const vmByTimeInStatusStatusJoin = `
       (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|running|non_running|error"} > 0)
     )
   ) and on(cluster, name, namespace)
-  (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"$status"} > 0)`
+  (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"$status"} > 0))`
 
 const vmByTimeInStatusTotalAllocatedCPUStatQuery = `sum (
 (` + allocatedCPUMultiVMExpr + `)


### PR DESCRIPTION
## Summary

- Fix incorrect arithmetic in the time-in-status dashboard status join expression
- The `+ on(cluster, name, namespace) group_left(status)` operator was adding elapsed seconds into resource metric values, inflating stat panel results
- Wrap the RHS with `0 * (...)` so the addition contributes zero while still propagating the `status` label via `group_left`

## Problem

The `vmByTimeInStatusStatusJoin` constant uses `+ on(...) group_left(status)` to attach the `status` label from the time-elapsed subquery to resource metrics (vCPU, memory). Since `+` is arithmetic addition in PromQL, the elapsed-seconds value from the RHS was being added to the LHS resource values, causing stat panels to display inflated numbers.

## Fix

```promql
# Before (adds elapsed seconds to resource values):
<resource_metric>
  + on(cluster, name, namespace) group_left(status)
  (<time_elapsed_expression>)

# After (adds 0, preserving label propagation):
<resource_metric>
  + on(cluster, name, namespace) group_left(status)
  (0 * (<time_elapsed_expression>))
```

This is the standard PromQL idiom for attaching labels from a subquery without affecting the numeric value.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted metric calculations for virtualization status tracking queries to ensure accurate value computation while maintaining existing filtering and matching conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->