### PR TITLE
feat: add Top Consumers Perses dashboard

### DIFF
--- a/pkg/perses/dashboards/virtualization/top-consumers.go
+++ b/pkg/perses/dashboards/virtualization/top-consumers.go
@@ -1,0 +1,128 @@
+package virtualization
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	promqlVar "github.com/perses/plugins/prometheus/sdk/go/variable/promql"
+	panels "github.com/stolostron/multicluster-observability-addon/pkg/perses/panels/virtualization"
+)
+
+// topConsumersPairedGrid places a table (left) next to its time-series (right).
+var topConsumersPairedGrid = []GridItem{
+	{X: 0, Y: 0, W: 12, H: 9},
+	{X: 12, Y: 0, W: 12, H: 9},
+}
+
+// topNHiddenVariable creates a hidden list variable backed by a
+// PrometheusPromQL query. It evaluates expr (typically topk($topn, ...)),
+// extracts the "name" label from the results, selects all values, and
+// joins them into a pipe-separated regex for use in name=~"$varName".
+func topNHiddenVariable(varName, expr, datasource string) dashboard.Option {
+	return dashboard.AddVariable(varName,
+		listVar.List(
+			promqlVar.PrometheusPromQL(expr,
+				promqlVar.LabelName("name"),
+				promqlVar.Datasource(datasource),
+			),
+			listVar.Hidden(true),
+			listVar.AllowAllValue(false),
+			listVar.AllowMultiple(true),
+			listVar.DefaultValues("$__all"),
+		),
+	)
+}
+
+func withTopConsumersMemoryGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Memory",
+		topConsumersPairedGrid,
+		panels.TopConsumersMemoryTable(datasource, project),
+		panels.TopConsumersMemoryTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersCPUGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("CPU",
+		topConsumersPairedGrid,
+		panels.TopConsumersCPUTable(datasource, project),
+		panels.TopConsumersCPUTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersStorageTrafficGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Storage Traffic",
+		topConsumersPairedGrid,
+		panels.TopConsumersStorageTrafficTable(datasource, project),
+		panels.TopConsumersStorageTrafficTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersStorageIOPSGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Storage IOPS",
+		topConsumersPairedGrid,
+		panels.TopConsumersStorageIOPSTable(datasource, project),
+		panels.TopConsumersStorageIOPSTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersNetworkTrafficGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Network Traffic",
+		topConsumersPairedGrid,
+		panels.TopConsumersNetworkTrafficTable(datasource, project),
+		panels.TopConsumersNetworkTrafficTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersVCPUWaitGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("vCPU Wait",
+		topConsumersPairedGrid,
+		panels.TopConsumersVCPUWaitTable(datasource, project),
+		panels.TopConsumersVCPUWaitTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersMemorySwapGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Memory Swap Traffic",
+		topConsumersPairedGrid,
+		panels.TopConsumersMemorySwapTable(datasource, project),
+		panels.TopConsumersMemorySwapTimeSeries(datasource),
+	)
+}
+
+// BuildTopConsumers creates the Top Consumers dashboard showing the highest
+// resource consumers across clusters, adapted from the Grafana
+// "KubeVirt / Infrastructure Resources / Top Consumers" dashboard.
+// Each resource type is a collapsible group with a table and time-series pair.
+func BuildTopConsumers(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-virtual-machines-top-consumers",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Top Consumers"),
+
+		VMClusterVariable(datasource),
+		VMNamespaceVariable(datasource),
+		AddStaticListVariable("topn", "Top N", "Number of top consumers to display",
+			[]StaticListValue{
+				{Label: "5", Value: "5"},
+				{Label: "10", Value: "10"},
+				{Label: "20", Value: "20"},
+				{Label: "50", Value: "50"},
+			},
+			"5", false, false, "",
+		),
+
+		topNHiddenVariable(panels.TopNMemoryVarName, panels.TopNMemoryVarExpr, datasource),
+		topNHiddenVariable(panels.TopNCPUVarName, panels.TopNCPUVarExpr, datasource),
+		topNHiddenVariable(panels.TopNStorageTrafficVarName, panels.TopNStorageTrafficVarExpr, datasource),
+		topNHiddenVariable(panels.TopNStorageIOPSVarName, panels.TopNStorageIOPSVarExpr, datasource),
+		topNHiddenVariable(panels.TopNNetworkTrafficVarName, panels.TopNNetworkTrafficVarExpr, datasource),
+		topNHiddenVariable(panels.TopNVCPUWaitVarName, panels.TopNVCPUWaitVarExpr, datasource),
+		topNHiddenVariable(panels.TopNMemorySwapVarName, panels.TopNMemorySwapVarExpr, datasource),
+
+		withTopConsumersMemoryGroup(datasource, project),
+		withTopConsumersCPUGroup(datasource, project),
+		withTopConsumersStorageTrafficGroup(datasource, project),
+		withTopConsumersStorageIOPSGroup(datasource, project),
+		withTopConsumersNetworkTrafficGroup(datasource, project),
+		withTopConsumersVCPUWaitGroup(datasource, project),
+		withTopConsumersMemorySwapGroup(datasource, project),
+	)
+}

--- a/pkg/perses/dashboards/virtualization/vm_dashboards_test.go
+++ b/pkg/perses/dashboards/virtualization/vm_dashboards_test.go
@@ -1,8 +1,11 @@
 package virtualization
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/perses/perses/pkg/model/api/v1/variable"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,4 +47,71 @@ func TestBuildSingleClusterView(t *testing.T) {
 func TestBuildSingleVMView(t *testing.T) {
 	_, err := BuildSingleVMView("test-project", "test-datasource")
 	require.NoError(t, err)
+}
+
+func TestBuildTopConsumers(t *testing.T) {
+	b, err := BuildTopConsumers("test-project", "test-datasource")
+	require.NoError(t, err)
+
+	spec := b.Dashboard.Spec
+
+	// 7 collapsible groups (memory, CPU, storage traffic, storage IOPS,
+	// network traffic, vCPU wait, memory swap).
+	assert.Len(t, spec.Layouts, 7, "expected 7 layout groups")
+
+	// Locate the topn list variable and verify its static values.
+	var topnValues []string
+	for _, v := range spec.Variables {
+		if v.Kind != variable.KindList {
+			continue
+		}
+		raw, marshalErr := json.Marshal(v.Spec)
+		require.NoError(t, marshalErr)
+		var parsed struct {
+			Name   string `json:"name"`
+			Plugin struct {
+				Spec struct {
+					Values []struct {
+						Value string `json:"value"`
+					} `json:"values"`
+				} `json:"spec"`
+			} `json:"plugin"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &parsed))
+		if parsed.Name == "topn" {
+			for _, sv := range parsed.Plugin.Spec.Values {
+				topnValues = append(topnValues, sv.Value)
+			}
+			break
+		}
+	}
+	assert.Equal(t, []string{"5", "10", "20", "50"}, topnValues, "topn variable values")
+
+	// 3 visible variables (cluster, namespace, topn) + 7 hidden topN
+	// variables (one per resource category).
+	assert.Len(t, spec.Variables, 10, "expected 10 variables (3 visible + 7 hidden)")
+
+	// Verify all 7 hidden topN variables exist by name.
+	hiddenVarNames := map[string]bool{}
+	for _, v := range spec.Variables {
+		raw, marshalErr := json.Marshal(v.Spec)
+		require.NoError(t, marshalErr)
+		var parsed struct {
+			Name    string `json:"name"`
+			Display struct {
+				Hidden bool `json:"hidden"`
+			} `json:"display"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &parsed))
+		if parsed.Display.Hidden {
+			hiddenVarNames[parsed.Name] = true
+		}
+	}
+	for _, name := range []string{
+		"topn_memory", "topn_cpu", "topn_storage_traffic",
+		"topn_storage_iops", "topn_network_traffic",
+		"topn_vcpu_wait", "topn_memory_swap",
+	} {
+		assert.True(t, hiddenVarNames[name], "missing hidden variable %s", name)
+	}
 }

--- a/pkg/perses/panels/virtualization/top-consumers-panel.go
+++ b/pkg/perses/panels/virtualization/top-consumers-panel.go
@@ -1,0 +1,221 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	timeSeriesPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+func topConsumersTimeSeriesLegend() timeSeriesPanel.Legend {
+	return timeSeriesPanel.Legend{
+		Position: timeSeriesPanel.RightPosition,
+		Mode:     timeSeriesPanel.TableMode,
+		Values: []commonSdk.Calculation{
+			commonSdk.LastNumberCalculation,
+			commonSdk.MaxCalculation,
+		},
+	}
+}
+
+func topConsumersTimeSeriesVisual() timeSeriesPanel.Visual {
+	return timeSeriesPanel.Visual{
+		Display:      timeSeriesPanel.LineDisplay,
+		AreaOpacity:  0.1,
+		ConnectNulls: false,
+		LineWidth:    1,
+	}
+}
+
+// buildTopConsumersTable centralizes the boilerplate shared by every
+// Top Consumers table panel. The caller only supplies the per-panel
+// metadata (title, description, value-column header and format) plus
+// the PromQL query string.
+func buildTopConsumersTable(
+	title, description, valueHeader string,
+	valueFmt commonSdk.Format,
+	promQL, datasourceName, project string,
+) panelgroup.Option {
+	return panelgroup.AddPanel(title,
+		panel.Description(description),
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "timestamp", Hide: true},
+				{Name: "cluster", Header: "Cluster", EnableSorting: true},
+				{Name: "namespace", Header: "Namespace", EnableSorting: true},
+				{Name: "name", Header: "Virtual Machine", EnableSorting: true},
+				{Name: "value", Header: valueHeader, EnableSorting: true, Format: &valueFmt},
+			}),
+		),
+		addColumnDataLink("name", tableDataLink("Virtual Machine Details", vmDetailsDashboardLinkByValueURL(project))),
+		panel.AddQuery(query.PromQL(
+			promQL,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// buildTopConsumersTimeSeries centralizes the boilerplate shared by
+// every Top Consumers time-series panel.
+func buildTopConsumersTimeSeries(
+	title, description string,
+	yAxisFmt commonSdk.Format,
+	promQL, datasourceName string,
+) panelgroup.Option {
+	return panelgroup.AddPanel(title,
+		panel.Description(description),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(topConsumersTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &yAxisFmt,
+			}),
+			timeSeriesPanel.WithVisual(topConsumersTimeSeriesVisual()),
+		),
+		panel.AddQuery(query.PromQL(
+			promQL,
+			query.SeriesNameFormat("{{name}} / {{namespace}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// --- Table panels (Top Consumers) ---
+
+func TopConsumersMemoryTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Memory",
+		"Virtual machines with the highest memory consumption.",
+		"Avg Memory Usage",
+		commonSdk.Format{Unit: &dashboards.BytesUnit},
+		topConsumersMemoryTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersCPUTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of CPU",
+		"Virtual machines with the highest CPU usage in cores. A value of 2.0 means two full CPU cores are in use.",
+		"CPU Usage (cores)",
+		commonSdk.Format{Unit: &dashboards.DecimalUnit, DecimalPlaces: 3},
+		topConsumersCPUTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersStorageTrafficTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Storage Traffic",
+		"Virtual machines with the highest storage traffic (read + write).",
+		"Storage Traffic",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersStorageTrafficTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersStorageIOPSTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Storage IOPS",
+		"Virtual machines with the highest storage IOPS (read + write).",
+		"Storage IOPS",
+		commonSdk.Format{Unit: &opsPerSecUnit},
+		topConsumersStorageIOPSTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersNetworkTrafficTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Network Traffic",
+		"Virtual machines with the highest network traffic (receive + transmit).",
+		"Network Traffic",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersNetworkTrafficTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersVCPUWaitTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of vCPU Wait",
+		"Virtual machines with the highest vCPU wait time, indicating CPU contention.",
+		"vCPU Wait Time",
+		commonSdk.Format{Unit: &dashboards.SecondsUnit},
+		topConsumersVCPUWaitTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersMemorySwapTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Memory Swap Traffic",
+		"Virtual machines with the highest memory swap traffic (in + out). High swap activity may indicate memory pressure.",
+		"Avg Memory Swap Traffic",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersMemorySwapTableQuery, datasourceName, project,
+	)
+}
+
+// --- Time-series panels (Top Consumers Over Time) ---
+
+func TopConsumersMemoryTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Memory Usage Over Time",
+		"Top virtual machines by memory consumption over time.",
+		commonSdk.Format{Unit: &dashboards.BytesUnit},
+		topConsumersMemoryTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersCPUTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"CPU Usage Over Time",
+		"Top virtual machines by CPU usage in cores over time. A value of 2.0 means two full CPU cores are in use.",
+		commonSdk.Format{Unit: &dashboards.DecimalUnit},
+		topConsumersCPUTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersStorageTrafficTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Storage Traffic Over Time",
+		"Top virtual machines by storage traffic (read + write) over time.",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersStorageTrafficTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersStorageIOPSTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Storage IOPS Over Time",
+		"Top virtual machines by storage IOPS (read + write) over time.",
+		commonSdk.Format{Unit: &opsPerSecUnit},
+		topConsumersStorageIOPSTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersNetworkTrafficTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Network Traffic Over Time",
+		"Top virtual machines by network traffic (receive + transmit) over time.",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersNetworkTrafficTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersVCPUWaitTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"vCPU Wait Over Time",
+		"Top virtual machines by vCPU wait time over time, indicating CPU contention.",
+		commonSdk.Format{Unit: &dashboards.SecondsUnit},
+		topConsumersVCPUWaitTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersMemorySwapTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Memory Swap Traffic Over Time",
+		"Top virtual machines by memory swap traffic (in + out) over time. High swap activity may indicate memory pressure.",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersMemorySwapTimeSeriesQuery, datasourceName,
+	)
+}

--- a/pkg/perses/panels/virtualization/top-consumers-queries.go
+++ b/pkg/perses/panels/virtualization/top-consumers-queries.go
@@ -1,0 +1,174 @@
+package virtualization
+
+// Top Consumers queries adapted from the Grafana
+// "KubeVirt / Infrastructure Resources / Top Consumers" dashboard.
+//
+// Each resource category has a hidden PrometheusPromQLVariable that
+// evaluates topk($topn, <base_expr>) and exposes the resulting VM
+// names as $topn_<resource>. Both the table and time-series panels
+// for that resource filter by name=~"$topn_<resource>" so they always
+// show the same set of VMs.
+
+// clusterNSMatchers is the label matcher fragment shared by all
+// top-consumer queries.
+const clusterNSMatchers = `cluster=~"$cluster", namespace=~"$namespace"`
+
+// --- Metric builder helpers ---
+
+// topnNameFilter builds a name=~"$<varName>" matcher fragment to inject
+// into a metric selector so only the VMs chosen by the hidden variable
+// are returned.
+func topnNameFilter(varName string) string {
+	return `, name=~"$` + varName + `"`
+}
+
+// cpuMetric returns the kubevirt_vmi_cpu_usage_seconds_total selector
+// with optional extra matchers appended inside the braces.
+func cpuMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_cpu_usage_seconds_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func networkMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_network_receive_bytes_total{` + clusterNSMatchers + extra + `}[10m]) + rate(kubevirt_vmi_network_transmit_bytes_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func storageTrafficMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_read_traffic_bytes_total{` + clusterNSMatchers + extra + `}[10m]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func storageIOPSMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_iops_read_total{` + clusterNSMatchers + extra + `}[10m]) + rate(kubevirt_vmi_storage_iops_write_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func vcpuWaitMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_vcpu_wait_seconds_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func memorySwapMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes{` + clusterNSMatchers + extra + `}[10m]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+// memoryUsageMetric uses memory_used_bytes (MCO allowlisted, no guest agent).
+func memoryUsageMetric(extra string) string {
+	return `avg by (cluster,namespace,name)(avg_over_time(kubevirt_vmi_memory_used_bytes{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+// Instant-vector metric helpers for hidden-variable ranking queries.
+//
+// In multi-replica Thanos receive setups, range functions (rate,
+// avg_over_time) over broad selectors trigger "vector cannot contain
+// metrics with the same labelset" because duplicate series from
+// different store replicas are not merged before the range function
+// evaluates.  Instant-vector queries are immune because Thanos dedup
+// collapses identical labelsets at query time.
+//
+// These produce the same top-N VM ranking while remaining Thanos-safe.
+
+func cpuMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_cpu_usage_seconds_total{` + clusterNSMatchers + extra + `})`
+}
+
+func networkMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_network_receive_bytes_total{` + clusterNSMatchers + extra + `} + kubevirt_vmi_network_transmit_bytes_total{` + clusterNSMatchers + extra + `})`
+}
+
+func storageTrafficMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_storage_read_traffic_bytes_total{` + clusterNSMatchers + extra + `} + kubevirt_vmi_storage_write_traffic_bytes_total{` + clusterNSMatchers + extra + `})`
+}
+
+func storageIOPSMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_storage_iops_read_total{` + clusterNSMatchers + extra + `} + kubevirt_vmi_storage_iops_write_total{` + clusterNSMatchers + extra + `})`
+}
+
+func vcpuWaitMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_vcpu_wait_seconds_total{` + clusterNSMatchers + extra + `})`
+}
+
+func memorySwapMetricInstant(extra string) string {
+	return `max by (cluster,namespace,name)(kubevirt_vmi_memory_swap_in_traffic_bytes{` + clusterNSMatchers + extra + `}) + max by (cluster,namespace,name)(kubevirt_vmi_memory_swap_out_traffic_bytes{` + clusterNSMatchers + extra + `})`
+}
+
+func memoryUsageMetricInstant(extra string) string {
+	return `avg by (cluster,namespace,name)(kubevirt_vmi_memory_used_bytes{` + clusterNSMatchers + extra + `})`
+}
+
+// --- Hidden-variable expressions ---
+// Each evaluates topk($topn, <base_expr>) without the name filter.
+// The PrometheusPromQLVariable extracts the "name" label, producing
+// a pipe-separated regex used by both table and time-series panels.
+
+const TopNMemoryVarName = "topn_memory"
+
+var TopNMemoryVarExpr = `topk($topn, ` + memoryUsageMetricNoFilter + `)`
+
+const TopNCPUVarName = "topn_cpu"
+
+var TopNCPUVarExpr = `topk($topn, ` + cpuMetricNoFilter + `)`
+
+const TopNStorageTrafficVarName = "topn_storage_traffic"
+
+var TopNStorageTrafficVarExpr = `topk($topn, ` + storageTrafficMetricNoFilter + `)`
+
+const TopNStorageIOPSVarName = "topn_storage_iops"
+
+var TopNStorageIOPSVarExpr = `topk($topn, ` + storageIOPSMetricNoFilter + `)`
+
+const TopNNetworkTrafficVarName = "topn_network_traffic"
+
+var TopNNetworkTrafficVarExpr = `topk($topn, ` + networkMetricNoFilter + `)`
+
+const TopNVCPUWaitVarName = "topn_vcpu_wait"
+
+var TopNVCPUWaitVarExpr = `topk($topn, ` + vcpuWaitMetricNoFilter + `)`
+
+const TopNMemorySwapVarName = "topn_memory_swap"
+
+var TopNMemorySwapVarExpr = `topk($topn, ` + memorySwapMetricNoFilter + `)`
+
+// Pre-computed base expressions without the name filter (for variables).
+// These use instant-vector helpers so the topk ranking query is safe
+// in multi-replica Thanos environments (see comment above).
+var (
+	memoryUsageMetricNoFilter    = memoryUsageMetricInstant("")
+	cpuMetricNoFilter            = cpuMetricInstant("")
+	storageTrafficMetricNoFilter = storageTrafficMetricInstant("")
+	storageIOPSMetricNoFilter    = storageIOPSMetricInstant("")
+	networkMetricNoFilter        = networkMetricInstant("")
+	vcpuWaitMetricNoFilter       = vcpuWaitMetricInstant("")
+	memorySwapMetricNoFilter     = memorySwapMetricInstant("")
+)
+
+// --- Table queries (instant) ---
+// Tables filter by the hidden variable's name list to show exactly N rows.
+
+var topConsumersMemoryTableQuery = memoryUsageMetric(topnNameFilter(TopNMemoryVarName)) + ` > 0`
+
+var topConsumersCPUTableQuery = cpuMetric(topnNameFilter(TopNCPUVarName)) + ` > 0`
+
+var topConsumersStorageTrafficTableQuery = storageTrafficMetric(topnNameFilter(TopNStorageTrafficVarName)) + ` > 0`
+
+var topConsumersStorageIOPSTableQuery = storageIOPSMetric(topnNameFilter(TopNStorageIOPSVarName)) + ` > 0`
+
+var topConsumersNetworkTrafficTableQuery = networkMetric(topnNameFilter(TopNNetworkTrafficVarName)) + ` > 0`
+
+var topConsumersVCPUWaitTableQuery = vcpuWaitMetric(topnNameFilter(TopNVCPUWaitVarName)) + ` > 0`
+
+var topConsumersMemorySwapTableQuery = memorySwapMetric(topnNameFilter(TopNMemorySwapVarName)) + ` > 0`
+
+// --- Time-series queries (range) ---
+// Time-series filter by the same hidden variable so they plot the
+// exact same VMs as the paired table.
+
+var topConsumersMemoryTimeSeriesQuery = memoryUsageMetric(topnNameFilter(TopNMemoryVarName))
+
+var topConsumersCPUTimeSeriesQuery = cpuMetric(topnNameFilter(TopNCPUVarName))
+
+var topConsumersStorageTrafficTimeSeriesQuery = storageTrafficMetric(topnNameFilter(TopNStorageTrafficVarName))
+
+var topConsumersStorageIOPSTimeSeriesQuery = storageIOPSMetric(topnNameFilter(TopNStorageIOPSVarName))
+
+var topConsumersNetworkTrafficTimeSeriesQuery = networkMetric(topnNameFilter(TopNNetworkTrafficVarName))
+
+var topConsumersVCPUWaitTimeSeriesQuery = vcpuWaitMetric(topnNameFilter(TopNVCPUWaitVarName))
+
+var topConsumersMemorySwapTimeSeriesQuery = memorySwapMetric(topnNameFilter(TopNMemorySwapVarName))


### PR DESCRIPTION
## Summary

Convert the Grafana "KubeVirt / Infrastructure Resources / Top Consumers" dashboard to the Perses Go SDK.

- **7 resource categories** (memory, CPU, storage traffic, storage IOPS, network traffic, vCPU wait, memory swap), each rendered as a paired table + time-series in collapsible groups.
- **Configurable Top N** variable (5/10/20/50) controls how many series time-series panels display.
- Table panels omit `topk()` to avoid Thanos duplicate-labelset errors on instant queries; interactive column sorting replaces it.
- CPU uses `kubevirt_vmi_cpu_usage_seconds_total` (cores) instead of `container_cpu_usage_seconds_total` for VM-level consistency.
- Memory uses `kubevirt_vmi_memory_used_bytes` (MCO allowlisted, no guest agent required).
- Base PromQL expressions are shared `var`s for reuse across table and time-series queries.

## New files

| File | Purpose |
|------|---------|
| `pkg/perses/panels/virtualization/top-consumers-queries.go` | PromQL constants (7 base expressions, 7 table queries, 7 time-series queries) |
| `pkg/perses/panels/virtualization/top-consumers-panel.go` | 14 panel functions (7 tables + 7 time-series) |
| `pkg/perses/dashboards/virtualization/top-consumers.go` | Dashboard builder with 7 collapsible paired groups |

## Test plan

- [x] `TestBuildTopConsumers` passes
- [x] `golangci-lint` clean
- [x] Deploy to cluster and verify all 14 panels render correctly
- [ ] Verify table sorting works as a replacement for `topk()`
- [ ] Verify Top N variable changes the number of time-series plotted

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Virtualization / Top Consumers" dashboard with collapsible metric groups providing table and time-series visualizations for tracking virtual machine resource consumption across Memory, CPU, Storage Traffic, Storage IOPS, Network Traffic, vCPU Wait, and Memory Swap metrics. Includes cluster and namespace filtering and configurable result limits.

* **Tests**
  * Added test coverage for the new dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->