### PR TITLE
fix: deduplicate left-side vectors in time-in-status group_left joins

### DIFF
--- a/pkg/perses/panels/virtualization/vm-by-time-in-status-queries.go
+++ b/pkg/perses/panels/virtualization/vm-by-time-in-status-queries.go
@@ -82,23 +82,23 @@ const vmByTimeInStatusStatusJoin = `
   (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"$status"} > 0)`
 
 const vmByTimeInStatusTotalAllocatedCPUStatQuery = `sum (
-(` + allocatedCPUMultiVMExpr + `)
+max by (cluster, namespace, name)(` + allocatedCPUMultiVMExpr + `)
 ` + vmByTimeInStatusStatusJoin + `
 ) or vector(0)`
 
 const vmByTimeInStatusTotalAllocatedMemoryStatQuery = `sum(
 max by (cluster, namespace, name, status)(
-  (` + allocatedMemoryMultiVMExpr + `)
+  max by (cluster, namespace, name)(` + allocatedMemoryMultiVMExpr + `)
 ` + vmByTimeInStatusStatusJoin + `
 )) or vector(0)`
 
 const vmByTimeInStatusTotalAllocatedDiskStatQuery = `sum (
-  (kubevirt_vm_disk_allocated_size_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})
+  sum by (cluster, namespace, name)(kubevirt_vm_disk_allocated_size_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})
 ` + vmByTimeInStatusStatusJoin + `
 ) or vector(0)`
 
 const vmByTimeInStatusTableDiskQuery = `sum by (cluster, namespace, name, status)(
-  (kubevirt_vm_disk_allocated_size_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})
+  sum by (cluster, namespace, name)(kubevirt_vm_disk_allocated_size_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})
 ` + vmByTimeInStatusStatusJoin + `
 )`
 
@@ -171,9 +171,11 @@ const vmByTimeInStatusTableMigrationEndMsQuery = `sum by (cluster, namespace, na
 )`
 
 const vmByTimeInStatusTableMemoryQuery = `max by (cluster, namespace, name, status)(
-  (` + allocatedMemoryMultiVMExpr + `)
+  max by (cluster, namespace, name)(` + allocatedMemoryMultiVMExpr + `)
 ` + vmByTimeInStatusStatusJoin + `
 )`
 
-const vmByTimeInStatusTableCPUQuery = `(` + allocatedCPUMultiVMExpr + `)
-` + vmByTimeInStatusStatusJoin
+const vmByTimeInStatusTableCPUQuery = `max by (cluster, namespace, name, status)(
+  max by (cluster, namespace, name)(` + allocatedCPUMultiVMExpr + `)
+` + vmByTimeInStatusStatusJoin + `
+)`


### PR DESCRIPTION
Convert the Grafana "KubeVirt / Infrastructure
Resources / Top Consumers" dashboard to the
Perses Go SDK.

Seven resource categories (memory, CPU, storage
traffic, storage IOPS, network traffic, vCPU
wait, memory swap) each rendered as a paired
table + time-series in collapsible groups.

Key design decisions:
- Table panels omit topk() to avoid Thanos
  duplicate-labelset errors on instant queries;
  interactive column sorting replaces it.
- Time-series panels use topk($topn, ...) with a
  configurable Top N variable (5/10/20/50).
- CPU uses kubevirt_vmi_cpu_usage_seconds_total
  (cores) instead of container_cpu_usage for
  VM-level consistency.
- Memory uses kubevirt_vmi_memory_used_bytes
  (MCO allowlisted, no guest agent required).
- Base PromQL expressions are shared vars for
  reuse across table and time-series queries.

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved virtualization panel performance and accuracy by reducing metric series cardinality before status joins. Allocation metrics for CPU, memory, and disk now use adjusted aggregation logic and expression handling, lowering data processing overhead and delivering faster panel loads and more reliable VM status visualizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->