### PR TITLE
fix(perses): use scalar() for overcommit percentage in max VM memory query

### DIFF
--- a/pkg/perses/panels/virtualization/node-memory-queries.go
+++ b/pkg/perses/panels/virtualization/node-memory-queries.go
@@ -43,7 +43,7 @@ sum(kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster", node=~"$node"})`
 -
 (sum((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})) - sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})))`
 
-	nodeMemoryClusterUtilizationHistorySummaryPlanMaxVMAssigned = `(kubevirt_hco_memory_overcommit_percentage{cluster=~"$cluster"} / 100)
+	nodeMemoryClusterUtilizationHistorySummaryPlanMaxVMAssigned = `scalar(kubevirt_hco_memory_overcommit_percentage{cluster=~"$cluster"} / 100)
 
 *
 


### PR DESCRIPTION
The "Plan - Maximum VM assigned virtual memory" query in the
Cluster Utilization panel multiplied a labeled vector
(`kubevirt_hco_memory_overcommit_percentage`) by a label-less
`sum()` vector. PromQL binary ops require matching labels,
so the result was always empty.

Wrap the overcommit metric in `scalar()` to convert it to a
plain number, allowing the multiplication to succeed.

Signed-off-by: Shirly Radco <sradco@redhat.com>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory metric calculation in virtualization monitoring to ensure proper result type handling for accurate memory utilization reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->