### PR TITLE
Add cnv-observability team to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,9 +5,11 @@ approvers:
 - team-logging # Defined in OWNERS_ALIASES
 - team-tracing # Defined in OWNERS_ALIASES
 - observability-intelligence # Defined in OWNERS_ALIASES
+- cnv-observability # Defined in OWNERS_ALIASES
 
 reviewers:
 - multicluster-observability # Defined in OWNERS_ALIASES
 - team-logging # Defined in OWNERS_ALIASES
 - team-tracing # Defined in OWNERS_ALIASES
 - observability-intelligence # Defined in OWNERS_ALIASES
+- cnv-observability # Defined in OWNERS_ALIASES

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -26,5 +26,7 @@ aliases:
   #   - frzifus
   #   - rubenvp8510
   #   - andreasgerstmayr
+  cnv-observability:
+    - sradco
   observability-intelligence:
     - tremes 


### PR DESCRIPTION
Allow the CNV observability team (sradco) to review and
approve virtualization dashboard PRs.

Signed-off-by: Shirly Radco <sradco@redhat.com>

Made with [Cursor](https://cursor.com)