### PR TITLE
perf: consolidate managers, optimize resource usage

### DIFF
--- a/internal/addon/addon.go
+++ b/internal/addon/addon.go
@@ -18,11 +18,10 @@ import (
 	mconfig "github.com/stolostron/multicluster-observability-addon/internal/metrics/config"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"open-cluster-management.io/addon-framework/pkg/agent"
-	"open-cluster-management.io/addon-framework/pkg/utils"
+	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	v1 "open-cluster-management.io/api/cluster/v1"
 	workv1 "open-cluster-management.io/api/work/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -48,11 +47,11 @@ var (
 func NewRegistrationOption(agentName string) *agent.RegistrationOption {
 	return &agent.RegistrationOption{
 		Configurations:  agent.KubeClientSignerConfigurations(addoncfg.Name, agentName),
-		CSRApproveCheck: utils.DefaultCSRApprover(agentName),
+		CSRApproveCheck: addonutils.DefaultCSRApprover(agentName),
 	}
 }
 
-func HealthProber(k8s client.Client, logger logr.Logger) *agent.HealthProber {
+func HealthProber(getter addonutils.AddOnDeploymentConfigGetter, logger logr.Logger) *agent.HealthProber {
 	probeFields := []agent.ProbeField{}
 	probeFields = append(probeFields, getMetricsProbeFields()...)
 	probeFields = append(probeFields, getLogsProbeFields()...)
@@ -63,7 +62,7 @@ func HealthProber(k8s client.Client, logger logr.Logger) *agent.HealthProber {
 		WorkProber: &agent.WorkHealthProber{
 			ProbeFields: probeFields,
 			HealthChecker: func(fields []agent.FieldResult, mc *v1.ManagedCluster, mcao *addonapiv1beta1.ManagedClusterAddOn) error {
-				if err := healthChecker(k8s, fields, mc, mcao); err != nil {
+				if err := healthChecker(getter, fields, mc, mcao); err != nil {
 					logger.V(1).Info("Health check failed for managed cluster", "clusterName", mc.Name, "error", err.Error())
 					return fmt.Errorf("healthChecker failed: %w", err)
 				}
@@ -328,7 +327,7 @@ func ManifestConfigs() []workv1.ManifestConfigOption {
 	return manifestConfigs
 }
 
-func healthChecker(k8s client.Client, fields []agent.FieldResult, mc *v1.ManagedCluster, mcao *addonapiv1beta1.ManagedClusterAddOn) error {
+func healthChecker(getter addonutils.AddOnDeploymentConfigGetter, fields []agent.FieldResult, mc *v1.ManagedCluster, mcao *addonapiv1beta1.ManagedClusterAddOn) error {
 	if len(fields) == 0 {
 		return errMissingFields
 	}
@@ -336,7 +335,7 @@ func healthChecker(k8s client.Client, fields []agent.FieldResult, mc *v1.Managed
 	ctx, cancel := context.WithTimeout(context.Background(), addoncfg.DefaultContextTimeout)
 	defer cancel()
 
-	aodc, err := common.GetAddOnDeploymentConfig(ctx, k8s, mcao)
+	aodc, err := common.GetAddOnDeploymentConfig(ctx, getter, mcao)
 	if err != nil {
 		return fmt.Errorf("failed to get AddOnDeploymentConfig: %w", err)
 	}

--- a/internal/addon/addon_test.go
+++ b/internal/addon/addon_test.go
@@ -19,9 +19,16 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/agent"
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	workv1 "open-cluster-management.io/api/work/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func newTestGetter(aodc *addonapiv1beta1.AddOnDeploymentConfig) addonutils.AddOnDeploymentConfigGetter {
+	if aodc == nil {
+		return addonutils.NewAddOnDeploymentConfigGetter(fakeaddon.NewSimpleClientset())
+	}
+	return addonutils.NewAddOnDeploymentConfigGetter(fakeaddon.NewSimpleClientset(aodc))
+}
 
 func Test_AgentHealthProber_PPA(t *testing.T) {
 	managedCluster := addontesting.NewManagedCluster("cluster-1")
@@ -48,7 +55,7 @@ func Test_AgentHealthProber_PPA(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			healthProber := HealthProber(fake.NewClientBuilder().WithScheme(scheme).WithObjects(aodc).Build(), logr.Discard())
+			healthProber := HealthProber(newTestGetter(aodc), logr.Discard())
 			err := healthProber.WorkProber.HealthChecker(
 				[]agent.FieldResult{
 					{
@@ -120,7 +127,7 @@ func Test_AgentHealthProber_PPA_UserWorkload(t *testing.T) {
 			} else {
 				managedCluster.Labels["vendor"] = "Other"
 			}
-			healthProber := HealthProber(fake.NewClientBuilder().WithScheme(scheme).WithObjects(aodc).Build(), logr.Discard())
+			healthProber := HealthProber(newTestGetter(aodc), logr.Discard())
 			err := healthProber.WorkProber.HealthChecker(
 				[]agent.FieldResult{
 					{
@@ -178,7 +185,7 @@ func Test_AgentHealthProber_CLF(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			healthProber := HealthProber(fake.NewClientBuilder().WithScheme(scheme).WithObjects(aodc).Build(), logr.Discard())
+			healthProber := HealthProber(newTestGetter(aodc), logr.Discard())
 			err := healthProber.WorkProber.HealthChecker(
 				[]agent.FieldResult{
 					{
@@ -235,7 +242,7 @@ func Test_AgentHealthProber_OTELCol(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			healthProber := HealthProber(fake.NewClientBuilder().WithScheme(scheme).WithObjects(aodc).Build(), logr.Discard())
+			healthProber := HealthProber(newTestGetter(aodc), logr.Discard())
 			err := healthProber.WorkProber.HealthChecker([]agent.FieldResult{
 				{
 					ResourceIdentifier: workv1.ResourceIdentifier{
@@ -306,7 +313,7 @@ func Test_AgentHealthProber_UIPlugin(t *testing.T) {
 				managedCluster.Labels = map[string]string{}
 			}
 
-			healthProber := HealthProber(fake.NewClientBuilder().WithScheme(scheme).WithObjects(aodc).Build(), logr.Discard())
+			healthProber := HealthProber(newTestGetter(aodc), logr.Discard())
 			metricsStatus := "True"
 			err := healthProber.WorkProber.HealthChecker([]agent.FieldResult{
 				{
@@ -368,7 +375,7 @@ func Test_AgentHealthProber_MissingResources(t *testing.T) {
 		addPlatformMetricsCustomizedVariables(aodc)
 		addAODCConfigReference(managedClusterAddOn, aodc)
 
-		healthProber := HealthProber(fake.NewClientBuilder().WithScheme(scheme).WithObjects(aodc).Build(), logr.Discard())
+		healthProber := HealthProber(newTestGetter(aodc), logr.Discard())
 		err := healthProber.WorkProber.HealthChecker(
 			[]agent.FieldResult{scrapeConfigFieldResult()}, // Missing PPA
 			managedCluster, managedClusterAddOn)
@@ -380,7 +387,7 @@ func Test_AgentHealthProber_MissingResources(t *testing.T) {
 		addLoggingCustomizedVariables(aodc)
 		addAODCConfigReference(managedClusterAddOn, aodc)
 
-		healthProber := HealthProber(fake.NewClientBuilder().WithScheme(scheme).WithObjects(aodc).Build(), logr.Discard())
+		healthProber := HealthProber(newTestGetter(aodc), logr.Discard())
 		err := healthProber.WorkProber.HealthChecker(
 			// We pass an unrelated field to bypass the initial check for empty fields
 			// in the healthChecker function.
@@ -394,7 +401,7 @@ func Test_AgentHealthProber_MissingResources(t *testing.T) {
 		addTracingCustomizedVariables(aodc)
 		addAODCConfigReference(managedClusterAddOn, aodc)
 
-		healthProber := HealthProber(fake.NewClientBuilder().WithScheme(scheme).WithObjects(aodc).Build(), logr.Discard())
+		healthProber := HealthProber(newTestGetter(aodc), logr.Discard())
 		err := healthProber.WorkProber.HealthChecker(
 			// We pass an unrelated field to bypass the initial check for empty fields
 			// in the healthChecker function.
@@ -412,7 +419,7 @@ func Test_AgentHealthProber_MissingResources(t *testing.T) {
 		addUIPluginCustomizedVariables(aodc)
 		addAODCConfigReference(managedClusterAddOn, aodc)
 
-		healthProber := HealthProber(fake.NewClientBuilder().WithScheme(scheme).WithObjects(aodc).Build(), logr.Discard())
+		healthProber := HealthProber(newTestGetter(aodc), logr.Discard())
 		metricsStatus := "True"
 		err := healthProber.WorkProber.HealthChecker(
 			[]agent.FieldResult{

--- a/internal/addon/addon_test.go
+++ b/internal/addon/addon_test.go
@@ -25,8 +25,10 @@ import (
 
 func newTestGetter(aodc *addonapiv1beta1.AddOnDeploymentConfig) addonutils.AddOnDeploymentConfigGetter {
 	if aodc == nil {
+		//nolint:staticcheck // client.Apply is deprecated, but alternative requires ApplyConfigurations which we don't have
 		return addonutils.NewAddOnDeploymentConfigGetter(fakeaddon.NewSimpleClientset())
 	}
+	//nolint:staticcheck // client.Apply is deprecated, but alternative requires ApplyConfigurations which we don't have
 	return addonutils.NewAddOnDeploymentConfigGetter(fakeaddon.NewSimpleClientset(aodc))
 }
 

--- a/internal/addon/common/managedclusteraddon.go
+++ b/internal/addon/common/managedclusteraddon.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
@@ -12,7 +13,7 @@ import (
 
 var (
 	ErrMissingAODCRef  = errors.New("missing required AddOnDeploymentConfig reference in addon configuration")
-	ErrMultipleAODCRef = errors.New("addonmultiple AddOnDeploymentConfig references found - only one is supported")
+	ErrMultipleAODCRef = errors.New("multiple AddOnDeploymentConfig references found - only one is supported")
 )
 
 func GetObjectKeys(configRef []addonapiv1beta1.ConfigReference, group, resource string) []client.ObjectKey {
@@ -37,18 +38,19 @@ func GetObjectKeys(configRef []addonapiv1beta1.ConfigReference, group, resource 
 	return keys
 }
 
-func GetAddOnDeploymentConfig(ctx context.Context, k8s client.Client, mcAddon *addonapiv1beta1.ManagedClusterAddOn) (*addonapiv1beta1.AddOnDeploymentConfig, error) {
+func GetAddOnDeploymentConfig(ctx context.Context, getter addonutils.AddOnDeploymentConfigGetter, mcAddon *addonapiv1beta1.ManagedClusterAddOn) (*addonapiv1beta1.AddOnDeploymentConfig, error) {
 	aodc := &addonapiv1beta1.AddOnDeploymentConfig{}
 	keys := GetObjectKeys(mcAddon.Status.ConfigReferences, addonutils.AddOnDeploymentConfigGVR.Group, addoncfg.AddonDeploymentConfigResource)
 	switch {
 	case len(keys) == 0:
-		return aodc, ErrMissingAODCRef
+		return nil, ErrMissingAODCRef
 	case len(keys) > 1:
-		return aodc, ErrMultipleAODCRef
+		return nil, ErrMultipleAODCRef
 	}
-	if err := k8s.Get(ctx, keys[0], aodc, &client.GetOptions{}); err != nil {
-		// TODO(JoaoBraveCoding) Add proper error handling
-		return aodc, err
+
+	aodc, err := getter.Get(ctx, keys[0].Namespace, keys[0].Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AddOnDeploymentConfig %s/%s: %w", keys[0].Namespace, keys[0].Name, err)
 	}
 	return aodc, nil
 }

--- a/internal/addon/common/managedclusteraddon.go
+++ b/internal/addon/common/managedclusteraddon.go
@@ -39,7 +39,6 @@ func GetObjectKeys(configRef []addonapiv1beta1.ConfigReference, group, resource 
 }
 
 func GetAddOnDeploymentConfig(ctx context.Context, getter addonutils.AddOnDeploymentConfigGetter, mcAddon *addonapiv1beta1.ManagedClusterAddOn) (*addonapiv1beta1.AddOnDeploymentConfig, error) {
-	aodc := &addonapiv1beta1.AddOnDeploymentConfig{}
 	keys := GetObjectKeys(mcAddon.Status.ConfigReferences, addonutils.AddOnDeploymentConfigGVR.Group, addoncfg.AddonDeploymentConfigResource)
 	switch {
 	case len(keys) == 0:

--- a/internal/addon/common/managedclusteraddon_test.go
+++ b/internal/addon/common/managedclusteraddon_test.go
@@ -96,8 +96,10 @@ func TestGetAddOnDeploymentConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			//nolint:staticcheck // client.Apply is deprecated, but alternative requires ApplyConfigurations which we don't have
 			fakeAddonClient := fakeaddon.NewSimpleClientset()
 			if tt.existingAODC != nil {
+				//nolint:staticcheck // client.Apply is deprecated, but alternative requires ApplyConfigurations which we don't have
 				fakeAddonClient = fakeaddon.NewSimpleClientset(tt.existingAODC)
 			}
 			scheme := runtime.NewScheme()

--- a/internal/addon/common/managedclusteraddon_test.go
+++ b/internal/addon/common/managedclusteraddon_test.go
@@ -10,8 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetAddOnDeploymentConfig(t *testing.T) {
@@ -96,23 +96,22 @@ func TestGetAddOnDeploymentConfig(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a fake client with the existing AODC if provided
-			objs := []client.Object{}
+			fakeAddonClient := fakeaddon.NewSimpleClientset()
 			if tt.existingAODC != nil {
-				objs = append(objs, tt.existingAODC)
+				fakeAddonClient = fakeaddon.NewSimpleClientset(tt.existingAODC)
 			}
 			scheme := runtime.NewScheme()
 			require.NoError(t, addonapiv1beta1.Install(scheme))
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+			getter := addonutils.NewAddOnDeploymentConfigGetter(fakeAddonClient)
 
 			// Call the function
 			ctx := t.Context()
-			_, err := common.GetAddOnDeploymentConfig(ctx, fakeClient, tt.mcAddon)
+			_, err := common.GetAddOnDeploymentConfig(ctx, getter, tt.mcAddon)
 
 			// require the results
 			if tt.expectedErr != nil {
 				require.Error(t, err)
-				require.Equal(t, tt.expectedErr, err)
+				require.ErrorIs(t, err, tt.expectedErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/internal/addon/helm/values.go
+++ b/internal/addon/helm/values.go
@@ -18,6 +18,7 @@ import (
 	thandlers "github.com/stolostron/multicluster-observability-addon/internal/tracing/handlers"
 	tmanifests "github.com/stolostron/multicluster-observability-addon/internal/tracing/manifests"
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
+	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,7 +34,7 @@ type HelmChartValues struct {
 	ObsAPI      *omanifests.ObsAPIValues      `json:"obs-api,omitempty"`
 }
 
-func GetValuesFunc(ctx context.Context, k8s client.Client, logger logr.Logger) addonfactory.GetValuesFunc {
+func GetValuesFunc(ctx context.Context, k8s client.Client, getter addonutils.AddOnDeploymentConfigGetter, logger logr.Logger) addonfactory.GetValuesFunc {
 	return func(
 		cluster *clusterv1.ManagedCluster,
 		mcAddon *addonapiv1beta1.ManagedClusterAddOn,
@@ -41,7 +42,7 @@ func GetValuesFunc(ctx context.Context, k8s client.Client, logger logr.Logger) a
 		logger = logger.WithValues("cluster", cluster.Name)
 		logger.V(2).Info("reconciliation triggered")
 
-		aodc, err := common.GetAddOnDeploymentConfig(ctx, k8s, mcAddon)
+		aodc, err := common.GetAddOnDeploymentConfig(ctx, getter, mcAddon)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get AddOnDeploymentConfig: %w", err)
 		}

--- a/internal/addon/helm/values_test.go
+++ b/internal/addon/helm/values_test.go
@@ -21,7 +21,9 @@ import (
 	"open-cluster-management.io/addon-framework/pkg/addonfactory"
 	"open-cluster-management.io/addon-framework/pkg/addonmanager/addontesting"
 	"open-cluster-management.io/addon-framework/pkg/agent"
+	addonutils "open-cluster-management.io/addon-framework/pkg/utils"
 	addonapiv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	fakeaddon "open-cluster-management.io/api/client/addon/clientset/versioned/fake"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -36,6 +38,13 @@ var (
 	_ = apiextensionsv1.AddToScheme(scheme.Scheme)
 	_ = uiplugin.AddToScheme(scheme.Scheme)
 )
+
+func newTestGetter(aodc *addonapiv1beta1.AddOnDeploymentConfig) addonutils.AddOnDeploymentConfigGetter {
+	if aodc == nil {
+		return addonutils.NewAddOnDeploymentConfigGetter(fakeaddon.NewSimpleClientset())
+	}
+	return addonutils.NewAddOnDeploymentConfigGetter(fakeaddon.NewSimpleClientset(aodc))
+}
 
 func Test_Supported_Vendors(t *testing.T) {
 	for _, tc := range []struct {
@@ -190,7 +199,7 @@ func Test_Supported_Vendors(t *testing.T) {
 				Build()
 
 			loggingAgentAddon, err := addonfactory.NewAgentAddonFactory(addoncfg.Name, addon.FS, addoncfg.McoaChartDir).
-				WithGetValuesFuncs(GetValuesFunc(t.Context(), fakeKubeClient, logr.Discard())).
+				WithGetValuesFuncs(GetValuesFunc(t.Context(), fakeKubeClient, newTestGetter(addOnDeploymentConfig), logr.Discard())).
 				WithAgentRegistrationOption(&agent.RegistrationOption{}).
 				WithScheme(scheme.Scheme).
 				BuildHelmAgentAddon()
@@ -256,7 +265,7 @@ func TestRSOnlyBothDisabled_ManifestsNotEmpty(t *testing.T) {
 		Build()
 
 	agentAddon, err := addonfactory.NewAgentAddonFactory(addoncfg.Name, addon.FS, addoncfg.McoaChartDir).
-		WithGetValuesFuncs(GetValuesFunc(t.Context(), fakeKubeClient, logr.Discard())).
+		WithGetValuesFuncs(GetValuesFunc(t.Context(), fakeKubeClient, newTestGetter(addOnDeploymentConfig), logr.Discard())).
 		WithAgentRegistrationOption(&agent.RegistrationOption{}).
 		WithScheme(scheme.Scheme).
 		BuildHelmAgentAddon()

--- a/internal/addon/helm/values_test.go
+++ b/internal/addon/helm/values_test.go
@@ -41,8 +41,10 @@ var (
 
 func newTestGetter(aodc *addonapiv1beta1.AddOnDeploymentConfig) addonutils.AddOnDeploymentConfigGetter {
 	if aodc == nil {
+		//nolint:staticcheck // client.Apply is deprecated, but alternative requires ApplyConfigurations which we don't have
 		return addonutils.NewAddOnDeploymentConfigGetter(fakeaddon.NewSimpleClientset())
 	}
+	//nolint:staticcheck // client.Apply is deprecated, but alternative requires ApplyConfigurations which we don't have
 	return addonutils.NewAddOnDeploymentConfigGetter(fakeaddon.NewSimpleClientset(aodc))
 }
 

--- a/internal/controllers/addon/controller.go
+++ b/internal/controllers/addon/controller.go
@@ -4,6 +4,8 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"maps"
+	"net/http"
 	"slices"
 
 	"github.com/go-logr/logr"
@@ -16,7 +18,6 @@ import (
 	"github.com/stolostron/multicluster-observability-addon/internal/addon"
 	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
 	addonhelm "github.com/stolostron/multicluster-observability-addon/internal/addon/helm"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,13 +31,12 @@ import (
 	addonv1alpha1client "open-cluster-management.io/api/client/addon/clientset/versioned"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-func NewAddonManager(ctx context.Context, kubeConfig *rest.Config, scheme *runtime.Scheme, logger logr.Logger) (addonmanager.AddonManager, error) {
+func NewAddonManager(ctx context.Context, kubeConfig *rest.Config, scheme *runtime.Scheme, logger logr.Logger, httpClient *http.Client, mapper meta.RESTMapper) (addonmanager.AddonManager, error) {
 	logger = logger.WithName("addon")
 
-	addonClient, err := addonv1alpha1client.NewForConfig(kubeConfig)
+	addonClient, err := addonv1alpha1client.NewForConfigAndClient(kubeConfig, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create addonv1alpha1 client: %w", err)
 	}
@@ -47,16 +47,6 @@ func NewAddonManager(ctx context.Context, kubeConfig *rest.Config, scheme *runti
 	}
 
 	registrationOption := addon.NewRegistrationOption(utilrand.String(5))
-
-	httpClient, err := rest.HTTPClientFor(kubeConfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP client for kubeConfig: %w", err)
-	}
-
-	mapper, err := apiutil.NewDynamicRESTMapper(kubeConfig, httpClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic REST mapper: %w", err)
-	}
 
 	opts := client.Options{
 		Scheme:     scheme,
@@ -69,8 +59,10 @@ func NewAddonManager(ctx context.Context, kubeConfig *rest.Config, scheme *runti
 		return nil, fmt.Errorf("failed to create new Kubernetes client: %w", err)
 	}
 
+	getter := utils.NewAddOnDeploymentConfigGetter(addonClient)
+
 	addonConfigValuesFn := addonfactory.GetAddOnDeploymentConfigValues(
-		addonfactory.NewAddOnDeploymentConfigGetter(addonClient),
+		getter,
 		addonfactory.ToAddOnCustomizedVariableValues,
 		addonfactory.ToAddOnResourceRequirementsValues,
 	)
@@ -100,17 +92,16 @@ func NewAddonManager(ctx context.Context, kubeConfig *rest.Config, scheme *runti
 
 	mcoaAgentAddon, err := addonfactory.NewAgentAddonFactory(addoncfg.Name, addon.FS, "manifests/charts/mcoa").
 		WithConfigGVRs(configGVRs...).
-		WithGetValuesFuncs(addonConfigValuesFn, addonhelm.GetValuesFunc(ctx, k8sClient, agentLogger)).
-		WithAgentHealthProber(addon.HealthProber(k8sClient, agentLogger)).
+		WithAgentHealthProber(addon.HealthProber(getter, agentLogger)).
+		WithGetValuesFuncs(addonConfigValuesFn, addonhelm.GetValuesFunc(ctx, k8sClient, getter, agentLogger)).
+		WithAgentHealthProber(addon.HealthProber(getter, agentLogger)).
 		WithAgentRegistrationOption(registrationOption).
 		WithAgentDeployTriggerClusterFilter(func(old, new *clusterv1.ManagedCluster) bool {
-			return !equality.Semantic.DeepEqual(old.Labels, new.Labels)
+			return !maps.Equal(old.Labels, new.Labels)
 		}).
 		WithAgentInstallNamespace(
 			// Set agent install namespace from addon deployment config if it exists
-			utils.AgentInstallNamespaceFromDeploymentConfigFunc(
-				utils.NewAddOnDeploymentConfigGetter(addonClient),
-			),
+			utils.AgentInstallNamespaceFromDeploymentConfigFunc(getter),
 		).WithScheme(scheme).
 		WithTrimCRDDescription().
 		BuildHelmAgentAddon()

--- a/internal/controllers/resourcecreator/controller.go
+++ b/internal/controllers/resourcecreator/controller.go
@@ -28,7 +28,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -72,49 +71,29 @@ var partOfMCOAPredicate = builder.WithPredicates(predicate.NewPredicateFuncs(fun
 	return partOfMCOALabelSelector.Matches(labels.Set(obj.GetLabels()))
 }))
 
-type ResourceCreatorManager struct {
-	mgr    *ctrl.Manager
-	logger logr.Logger
-}
-
-func NewResourceCreatorManager(logger logr.Logger, scheme *runtime.Scheme) (*ResourceCreatorManager, error) {
+// SetupWithManager sets up the controller with the Manager.
+func SetupWithManager(mgr ctrl.Manager, logger logr.Logger) error {
 	l := logger.WithName("resourcecreator")
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme: scheme,
-		Metrics: server.Options{
-			BindAddress: ":8084",
-		},
-		Logger: l.WithName("manager"),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("unable to start manager: %w", err)
-	}
-
-	if err = (&ResourceCreatorReconciler{
+	r := &ResourceCreatorReconciler{
 		Client: mgr.GetClient(),
 		Log:    l.WithName("controller"),
 		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		return nil, fmt.Errorf("unable to create mcoa-resourcecreator controller: %w", err)
 	}
 
-	wm := ResourceCreatorManager{
-		mgr:    &mgr,
-		logger: l,
-	}
-
-	return &wm, nil
-}
-
-func (wm *ResourceCreatorManager) Start(ctx context.Context) {
-	wm.logger.Info("Starting resourcecreator manager")
-	go func() {
-		err := (*wm.mgr).Start(ctx)
-		if err != nil {
-			wm.logger.Error(err, "there was an error while running the reconciliation resourcecreator")
-		}
-	}()
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&addonv1beta1.AddOnDeploymentConfig{}, mcoaAODCPredicate).
+		// Trigger reconciliations due to changes in Placements
+		Watches(&addonv1beta1.ClusterManagementAddOn{}, r.enqueueAODC(), cmaoPredicate).
+		// Trigger reconciliations if the pool of ManagedClusters changes
+		Watches(&clusterv1.ManagedCluster{}, r.enqueueAODC(), builder.OnlyMetadata).
+		// Trigger reconciliations if the metrics configuration resources change
+		Watches(&cooprometheusv1alpha1.PrometheusAgent{}, r.enqueueForMCOAOwnedResources()).
+		Watches(&cooprometheusv1alpha1.ScrapeConfig{}, r.enqueueForMCOControlledResources(), partOfMCOAPredicate).
+		Watches(&prometheusv1.PrometheusRule{}, r.enqueueForMCOControlledResources(), partOfMCOAPredicate).
+		// Trigger reconciliations if right-sizing ConfigMaps change
+		Watches(&corev1.ConfigMap{}, r.enqueueAODC(), rsConfigMapPredicate).
+		Complete(r)
 }
 
 // ResourceCreatorReconciler creates resources for default mode according to user configuration
@@ -192,33 +171,20 @@ func (r *ResourceCreatorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
-func (r *ResourceCreatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&addonv1beta1.AddOnDeploymentConfig{}, mcoaAODCPredicate).
-		// Trigger reconciliations due to changes in Placements
-		Watches(&addonv1beta1.ClusterManagementAddOn{}, r.enqueueAODC(), cmaoPredicate).
-		// Trigger reconciliations if the pool of ManagedClusters changes
-		Watches(&clusterv1.ManagedCluster{}, r.enqueueAODC(), builder.OnlyMetadata).
-		// Trigger reconciliations if the metrics configuration resources change
-		Watches(&cooprometheusv1alpha1.PrometheusAgent{}, r.enqueueForMCOAOwnedResources()).
-		Watches(&cooprometheusv1alpha1.ScrapeConfig{}, r.enqueueForMCOControlledResources(), partOfMCOAPredicate).
-		Watches(&prometheusv1.PrometheusRule{}, r.enqueueForMCOControlledResources(), partOfMCOAPredicate).
-		// Trigger reconciliations if right-sizing ConfigMaps change
-		Watches(&corev1.ConfigMap{}, r.enqueueAODC(), rsConfigMapPredicate).
-		Complete(r)
+func mcoaAODCRequest() []reconcile.Request {
+	return []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      addoncfg.Name,
+				Namespace: addoncfg.InstallNamespace,
+			},
+		},
+	}
 }
 
 func (r *ResourceCreatorReconciler) enqueueAODC() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-		return []reconcile.Request{
-			{
-				NamespacedName: types.NamespacedName{
-					Name:      addoncfg.Name,
-					Namespace: addoncfg.InstallNamespace,
-				},
-			},
-		}
+		return mcoaAODCRequest()
 	})
 }
 
@@ -234,14 +200,7 @@ func (r *ResourceCreatorReconciler) enqueueForMCOAOwnedResources() handler.Event
 			return []reconcile.Request{}
 		}
 
-		return []reconcile.Request{
-			{
-				NamespacedName: types.NamespacedName{
-					Name:      addoncfg.Name,
-					Namespace: addoncfg.InstallNamespace,
-				},
-			},
-		}
+		return mcoaAODCRequest()
 	})
 }
 
@@ -268,13 +227,6 @@ func (r *ResourceCreatorReconciler) enqueueForMCOControlledResources() handler.E
 			return []reconcile.Request{}
 		}
 
-		return []reconcile.Request{
-			{
-				NamespacedName: types.NamespacedName{
-					Name:      addoncfg.Name,
-					Namespace: addoncfg.InstallNamespace,
-				},
-			},
-		}
+		return mcoaAODCRequest()
 	})
 }

--- a/internal/controllers/resourcecreator/controller_test.go
+++ b/internal/controllers/resourcecreator/controller_test.go
@@ -1,0 +1,229 @@
+package resourcecreator
+
+import (
+	"context"
+	"testing"
+
+	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestValidateAODC(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		objName   string
+		expected  bool
+	}{
+		{
+			name:      "valid namespace and name",
+			namespace: addoncfg.InstallNamespace,
+			objName:   addoncfg.Name,
+			expected:  true,
+		},
+		{
+			name:      "invalid namespace",
+			namespace: "wrong-ns",
+			objName:   addoncfg.Name,
+			expected:  false,
+		},
+		{
+			name:      "invalid name",
+			namespace: addoncfg.InstallNamespace,
+			objName:   "wrong-name",
+			expected:  false,
+		},
+		{
+			name:      "invalid both",
+			namespace: "wrong-ns",
+			objName:   "wrong-name",
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateAODC(tt.namespace, tt.objName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCMAOPlacementsChanged(t *testing.T) {
+	tests := []struct {
+		name     string
+		oldObj   client.Object
+		newObj   client.Object
+		expected bool
+	}{
+		{
+			name: "placements unchanged",
+			oldObj: &addonv1beta1.ClusterManagementAddOn{
+				Spec: addonv1beta1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonv1beta1.InstallStrategy{
+						Placements: []addonv1beta1.PlacementStrategy{
+							{PlacementRef: addonv1beta1.PlacementRef{Name: "p1"}},
+						},
+					},
+				},
+			},
+			newObj: &addonv1beta1.ClusterManagementAddOn{
+				Spec: addonv1beta1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonv1beta1.InstallStrategy{
+						Placements: []addonv1beta1.PlacementStrategy{
+							{PlacementRef: addonv1beta1.PlacementRef{Name: "p1"}},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "placements changed",
+			oldObj: &addonv1beta1.ClusterManagementAddOn{
+				Spec: addonv1beta1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonv1beta1.InstallStrategy{
+						Placements: []addonv1beta1.PlacementStrategy{
+							{PlacementRef: addonv1beta1.PlacementRef{Name: "p1"}},
+						},
+					},
+				},
+			},
+			newObj: &addonv1beta1.ClusterManagementAddOn{
+				Spec: addonv1beta1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonv1beta1.InstallStrategy{
+						Placements: []addonv1beta1.PlacementStrategy{
+							{PlacementRef: addonv1beta1.PlacementRef{Name: "p2"}},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cmaoPlacementsChanged(tt.oldObj, tt.newObj)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMCOAAODCRequest(t *testing.T) {
+	expected := []reconcile.Request{
+		{
+			NamespacedName: types.NamespacedName{
+				Name:      addoncfg.Name,
+				Namespace: addoncfg.InstallNamespace,
+			},
+		},
+	}
+	assert.Equal(t, expected, mcoaAODCRequest())
+}
+
+func TestEnqueueFunctions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = addonv1beta1.Install(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := &ResourceCreatorReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	t.Run("enqueueAODC", func(t *testing.T) {
+		h := reconciler.enqueueAODC()
+		q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+		h.Create(context.Background(), event.CreateEvent{Object: &corev1.ConfigMap{}}, q)
+
+		var actual []reconcile.Request
+		for q.Len() > 0 {
+			item, _ := q.Get()
+			actual = append(actual, item)
+			q.Done(item)
+		}
+		assert.Equal(t, mcoaAODCRequest(), actual)
+	})
+
+	t.Run("enqueueForMCOAOwnedResources", func(t *testing.T) {
+		h := reconciler.enqueueForMCOAOwnedResources()
+
+		t.Run("owned resource", func(t *testing.T) {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "addon.open-cluster-management.io/v1alpha1",
+							Kind:       "ClusterManagementAddOn",
+							Name:       addoncfg.Name,
+						},
+					},
+				},
+			}
+			q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			h.Create(context.Background(), event.CreateEvent{Object: obj}, q)
+
+			var actual []reconcile.Request
+			for q.Len() > 0 {
+				item, _ := q.Get()
+				actual = append(actual, item)
+				q.Done(item)
+			}
+			assert.Equal(t, mcoaAODCRequest(), actual)
+		})
+
+		t.Run("unowned resource", func(t *testing.T) {
+			obj := &corev1.ConfigMap{}
+			q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			h.Create(context.Background(), event.CreateEvent{Object: obj}, q)
+			assert.Equal(t, 0, q.Len())
+		})
+	})
+
+	t.Run("enqueueForMCOControlledResources", func(t *testing.T) {
+		h := reconciler.enqueueForMCOControlledResources()
+
+		t.Run("controlled by MCO", func(t *testing.T) {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "observability.open-cluster-management.io/v1beta1",
+							Kind:       "MultiClusterObservability",
+							Controller: func() *bool { b := true; return &b }(),
+						},
+					},
+				},
+			}
+			q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			h.Create(context.Background(), event.CreateEvent{Object: obj}, q)
+
+			var actual []reconcile.Request
+			for q.Len() > 0 {
+				item, _ := q.Get()
+				actual = append(actual, item)
+				q.Done(item)
+			}
+			assert.Equal(t, mcoaAODCRequest(), actual)
+		})
+
+		t.Run("not controlled by MCO", func(t *testing.T) {
+			obj := &corev1.ConfigMap{}
+			q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			h.Create(context.Background(), event.CreateEvent{Object: obj}, q)
+			assert.Equal(t, 0, q.Len())
+		})
+	})
+}

--- a/internal/controllers/watcher/controller.go
+++ b/internal/controllers/watcher/controller.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -34,81 +33,42 @@ const (
 	localClusterNamespace = "local-cluster"
 )
 
-type WatcherManager struct {
-	mgr    *ctrl.Manager
-	logger logr.Logger
-}
-
-func NewWatcherManager(addonManager *addonmanager.AddonManager, scheme *runtime.Scheme, logger logr.Logger) (*WatcherManager, error) {
-	l := logger.WithName("watcher")
-
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{Scheme: scheme, Logger: l.WithName("manager")})
-	if err != nil {
-		return nil, fmt.Errorf("unable to start manager: %w", err)
-	}
-
-	if err = (&WatcherReconciler{
-		Client:        mgr.GetClient(),
-		Log:           l.WithName("controller"),
-		Scheme:        mgr.GetScheme(),
-		addonnManager: addonManager,
-		Cache:         NewReferenceCache(),
-	}).SetupWithManager(mgr); err != nil {
-		return nil, fmt.Errorf("unable to create mcoa-watcher controller: %w", err)
-	}
-
-	if err = mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
-		return nil, fmt.Errorf("unable to set up health check: %w", err)
-	}
-	if err = mgr.AddReadyzCheck("check", healthz.Ping); err != nil {
-		return nil, fmt.Errorf("unable to set up ready check: %w", err)
-	}
-
-	wm := WatcherManager{
-		mgr:    &mgr,
-		logger: l,
-	}
-
-	return &wm, nil
-}
-
-func (wm *WatcherManager) Start(ctx context.Context) {
-	wm.logger.Info("Starting watcher manager")
-	go func() {
-		err := (*wm.mgr).Start(ctx)
-		if err != nil {
-			wm.logger.Error(err, "there was an error while running the reconciliation watcher")
-		}
-	}()
-}
-
 // WatcherReconciler triggers reconciliation in the AddonManager when something changes in an upstream resource
 type WatcherReconciler struct {
 	client.Client
-	Log           logr.Logger
-	Scheme        *runtime.Scheme
-	addonnManager *addonmanager.AddonManager
-	Cache         *ReferenceCache
+	Log          logr.Logger
+	Scheme       *runtime.Scheme
+	addonManager addonmanager.AddonManager
+	Cache        *ReferenceCache
 }
 
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
 func (r *WatcherReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.V(2).Info("reconciliation triggered", "request", req.String())
-	(*r.addonnManager).Trigger(req.Namespace, req.Name)
+	r.addonManager.Trigger(req.Namespace, req.Name)
 
 	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *WatcherReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func SetupWithManager(mgr ctrl.Manager, addonManager addonmanager.AddonManager, logger logr.Logger) error {
+	l := logger.WithName("watcher")
+
+	r := &WatcherReconciler{
+		Client:       mgr.GetClient(),
+		Log:          l.WithName("controller"),
+		Scheme:       mgr.GetScheme(),
+		addonManager: addonManager,
+		Cache:        NewReferenceCache(),
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("watcher").
 		Watches(&workv1.ManifestWork{}, r.enqueueForManifestWork(), builder.WithPredicates(manifestWorkPredicate)).
 		Watches(&corev1.Secret{}, r.enqueueForConfigResource(), builder.OnlyMetadata).
 		Watches(&corev1.ConfigMap{}, r.enqueueForConfigResource(), builder.OnlyMetadata).
-		Watches(&corev1.ConfigMap{}, r.enqueueForAllManagedClusters(), builder.WithPredicates(imagesConfigMapPredicate), builder.OnlyMetadata).
-		Watches(&corev1.ConfigMap{}, r.enqueueForAllManagedClusters(), builder.WithPredicates(rshandlers.RSConfigMapPredicate()), builder.OnlyMetadata).
+		Watches(&corev1.ConfigMap{}, r.enqueueForAllManagedClusters(), builder.WithPredicates(predicate.Or(imagesConfigMapPredicate, rshandlers.RSConfigMapPredicate())), builder.OnlyMetadata).
 		Watches(&hyperv1.HostedCluster{}, r.enqueueForLocalCluster(), hostedClusterPredicate).
 		Watches(&prometheusv1.ServiceMonitor{}, r.enqueueForLocalCluster(), hypershiftServiceMonitorsPredicate(r.Log), builder.OnlyMetadata).
 		Complete(r)
@@ -133,7 +93,9 @@ func (r *WatcherReconciler) getConfigResourceKey(obj client.Object) string {
 func (r *WatcherReconciler) enqueueForManifestWork() handler.EventHandler {
 	return handler.Funcs{
 		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			r.updateCache(e.Object.(*workv1.ManifestWork))
+			if mw, ok := e.Object.(*workv1.ManifestWork); ok {
+				r.updateCache(mw)
+			}
 		},
 		UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 			oldMw, okOld := e.ObjectOld.(*workv1.ManifestWork)
@@ -142,7 +104,7 @@ func (r *WatcherReconciler) enqueueForManifestWork() handler.EventHandler {
 				return
 			}
 			if oldMw.Generation != newMw.Generation {
-				r.updateCache(e.ObjectNew.(*workv1.ManifestWork))
+				r.updateCache(newMw)
 			}
 		},
 		DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -238,12 +200,12 @@ func (r *WatcherReconciler) enqueueForAllManagedClusters() handler.EventHandler 
 
 func (r *WatcherReconciler) enqueueForConfigResource() handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-		rqs := []reconcile.Request{}
 		namespaces := r.Cache.GetNamespaces(r.getConfigResourceKey(obj))
 		if len(namespaces) == 0 {
-			return []reconcile.Request{}
+			return nil
 		}
 
+		rqs := make([]reconcile.Request, 0, len(namespaces))
 		r.Log.V(2).Info("Enqueue for config resource event", "gvk", obj.GetObjectKind().GroupVersionKind().String(), "name", obj.GetName(), "namespace", obj.GetNamespace(), "clustersCount", len(namespaces))
 
 		for _, ns := range namespaces {
@@ -261,9 +223,22 @@ func (r *WatcherReconciler) enqueueForConfigResource() handler.EventHandler {
 	})
 }
 
-var manifestWorkPredicate = predicate.NewPredicateFuncs(func(obj client.Object) bool {
-	return obj.GetLabels()[addoncfg.LabelOCMAddonName] == addoncfg.Name
-})
+var manifestWorkPredicate = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return e.Object.GetLabels()[addoncfg.LabelOCMAddonName] == addoncfg.Name
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldMw, okOld := e.ObjectOld.(*workv1.ManifestWork)
+		newMw, okNew := e.ObjectNew.(*workv1.ManifestWork)
+		if !okOld || !okNew {
+			return false
+		}
+		return oldMw.Generation != newMw.Generation && newMw.Labels[addoncfg.LabelOCMAddonName] == addoncfg.Name
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return e.Object.GetLabels()[addoncfg.LabelOCMAddonName] == addoncfg.Name
+	},
+}
 
 var hostedClusterPredicate = builder.WithPredicates(predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
@@ -310,7 +285,7 @@ func isHypershiftServiceMonitor(logger logr.Logger, obj client.Object) bool {
 		for _, owner := range obj.GetOwnerReferences() {
 			gv, err := schema.ParseGroupVersion(owner.APIVersion)
 			if err != nil {
-				logger.V(1).Info("failed to parse groupVersion", "error", err.Error())
+				logger.V(1).Info("failed to parse groupVersion", "apiVersion", owner.APIVersion, "error", err)
 				continue
 			}
 

--- a/internal/metrics/handlers/hypershift_test.go
+++ b/internal/metrics/handlers/hypershift_test.go
@@ -41,7 +41,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -68,7 +68,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -275,7 +275,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -287,7 +287,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -337,7 +337,7 @@ func TestHypershift_ExtractDependentMetrics(t *testing.T) {
 					Params: map[string][]string{
 						"match[]": {
 							`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-							`{__name__=~"acm_"}`, // ignore regex
+							`{__name__=~"acm_"}`,                               // ignore regex
 							`{__name__="acm_managed_cluster_labels"}`,
 							`{__name__="active_streams_lease:grpc_server_handled_total:sum"}`,
 						},

--- a/internal/metrics/handlers/hypershift_test.go
+++ b/internal/metrics/handlers/hypershift_test.go
@@ -41,7 +41,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -68,7 +68,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -275,7 +275,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -287,7 +287,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -337,7 +337,7 @@ func TestHypershift_ExtractDependentMetrics(t *testing.T) {
 					Params: map[string][]string{
 						"match[]": {
 							`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-							`{__name__=~"acm_"}`,                               // ignore regex
+							`{__name__=~"acm_"}`, // ignore regex
 							`{__name__="acm_managed_cluster_labels"}`,
 							`{__name__="active_streams_lease:grpc_server_handled_total:sum"}`,
 						},

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	addonctrl "github.com/stolostron/multicluster-observability-addon/internal/controllers/addon"
 	"github.com/stolostron/multicluster-observability-addon/internal/controllers/resourcecreator"
 	"github.com/stolostron/multicluster-observability-addon/internal/controllers/watcher"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -41,6 +42,10 @@ import (
 	clusterv1beta1 "open-cluster-management.io/api/cluster/v1beta1"
 	workv1 "open-cluster-management.io/api/work/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 var scheme = runtime.NewScheme()
@@ -149,7 +154,9 @@ func runControllers(ctx context.Context, kubeConfig *rest.Config) error {
 		go func() {
 			<-ctx.Done()
 			logger.Info("shutting down pprof server")
-			_ = srv.Shutdown(context.Background())
+			if err := srv.Shutdown(context.Background()); err != nil {
+				logger.Error(err, "failed to shutdown pprof server")
+			}
 		}()
 	} else {
 		logger.V(1).Info("pprof server disabled")
@@ -159,30 +166,64 @@ func runControllers(ctx context.Context, kubeConfig *rest.Config) error {
 	kubeConfig.QPS = 50.0
 	kubeConfig.Burst = 100
 
-	mgr, err := addonctrl.NewAddonManager(ctx, kubeConfig, scheme, logger)
+	httpClient, err := rest.HTTPClientFor(kubeConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP client for kubeConfig: %w", err)
+	}
+
+	mapper, err := apiutil.NewDynamicRESTMapper(kubeConfig, httpClient)
+	if err != nil {
+		return fmt.Errorf("failed to create dynamic REST mapper: %w", err)
+	}
+
+	addonMgr, err := addonctrl.NewAddonManager(ctx, kubeConfig, scheme, logger, httpClient, mapper)
 	if err != nil {
 		return fmt.Errorf("failed to create addon manager: %w", err)
 	}
 
+	// Create a single shared controller-runtime Manager for our custom controllers
+	sharedMgr, err := ctrl.NewManager(kubeConfig, ctrl.Options{
+		Scheme: scheme,
+		Logger: logger.WithName("manager"),
+		MapperProvider: func(c *rest.Config, hc *http.Client) (meta.RESTMapper, error) {
+			return mapper, nil
+		},
+		Client: client.Options{
+			HTTPClient: httpClient,
+		},
+		Metrics: server.Options{
+			BindAddress: ":8084",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start shared manager: %w", err)
+	}
+	if err = sharedMgr.AddHealthzCheck("health", healthz.Ping); err != nil {
+		return fmt.Errorf("failed to set up health check: %w", err)
+	}
+	if err = sharedMgr.AddReadyzCheck("check", healthz.Ping); err != nil {
+		return fmt.Errorf("failed to set up ready check: %w", err)
+	}
+
 	disableReconciliation := os.Getenv("DISABLE_WATCHER_CONTROLLER")
 	if disableReconciliation == "" {
-		var wm *watcher.WatcherManager
-		wm, err = watcher.NewWatcherManager(&mgr, scheme, logger)
-		if err != nil {
-			return fmt.Errorf("unable to create watcher manager: %w", err)
+		if err = watcher.SetupWithManager(sharedMgr, addonMgr, logger); err != nil {
+			return fmt.Errorf("unable to create watcher controller: %w", err)
 		}
-
-		wm.Start(ctx)
 	}
 
-	var rcm *resourcecreator.ResourceCreatorManager
-	rcm, err = resourcecreator.NewResourceCreatorManager(logger, scheme)
-	if err != nil {
-		return fmt.Errorf("unable to create resource creator manager: %w", err)
+	if err = resourcecreator.SetupWithManager(sharedMgr, logger); err != nil {
+		return fmt.Errorf("unable to create resource creator controller: %w", err)
 	}
-	rcm.Start(ctx)
 
-	err = mgr.Start(ctx)
+	go func() {
+		logger.Info("Starting shared controller-runtime manager")
+		if startErr := sharedMgr.Start(ctx); startErr != nil {
+			logger.Error(startErr, "shared manager exited with error")
+		}
+	}()
+
+	err = addonMgr.Start(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to start addon manager: %w", err)
 	}


### PR DESCRIPTION
Main improvements are:

- Shared Manager: Replaced separate WatcherManager and ResourceCreatorManager (each with its own internal cache and manager) with a single shared controller-runtime manager in main.go. This reduces the memory footprint and overhead by sharing caches and background goroutines.
- Efficient Config Access: Migrated to the AddOnDeploymentConfigGetter interface for optimized retrieval of addon configurations from the hub.
- Improved Predicates: Refactored watcher predicates and event filtering to reduce unnecessary reconciliation triggers, improving overall system responsiveness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health/values resolution for add-ons by consistently using the resolved add-on deployment configuration.
  * Added clearer, more contextual error messages when the required add-on deployment configuration reference is missing or ambiguous.
  * Refined watcher request generation to avoid incorrect enqueues when namespaces can’t be determined.

* **Refactor**
  * Streamlined controller startup by sharing HTTP/REST mapping and wiring controllers through a unified manager setup.
  * Simplified watcher and resource-creator controller initialization and reduced duplicated reconcile request construction.

* **Tests**
  * Added/updated unit tests for add-on validation, enqueue behavior, and health probing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->