### PR TITLE
feat(main): add pprof server

### DIFF
--- a/internal/metrics/handlers/hypershift_test.go
+++ b/internal/metrics/handlers/hypershift_test.go
@@ -41,7 +41,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -68,7 +68,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -263,7 +263,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -275,7 +275,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -325,7 +325,7 @@ func TestHypershift_ExtractDependentMetrics(t *testing.T) {
 					Params: map[string][]string{
 						"match[]": {
 							`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-							`{__name__=~"acm_"}`, // ignore regex
+							`{__name__=~"acm_"}`,                               // ignore regex
 							`{__name__="acm_managed_cluster_labels"}`,
 							`{__name__="active_streams_lease:grpc_server_handled_total:sum"}`,
 						},

--- a/internal/metrics/handlers/hypershift_test.go
+++ b/internal/metrics/handlers/hypershift_test.go
@@ -41,7 +41,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -275,7 +275,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},

--- a/internal/metrics/handlers/hypershift_test.go
+++ b/internal/metrics/handlers/hypershift_test.go
@@ -68,7 +68,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -263,7 +263,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -325,7 +325,7 @@ func TestHypershift_ExtractDependentMetrics(t *testing.T) {
 					Params: map[string][]string{
 						"match[]": {
 							`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-							`{__name__=~"acm_"}`,                               // ignore regex
+							`{__name__=~"acm_"}`, // ignore regex
 							`{__name__="acm_managed_cluster_labels"}`,
 							`{__name__="active_streams_lease:grpc_server_handled_total:sum"}`,
 						},

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	goflag "flag"
 	"fmt"
 	"net/http"
@@ -66,9 +67,11 @@ func init() {
 	// +kubebuilder:scaffold:scheme
 }
 
-var logVerbosity int
-var enablePprof bool
-var pprofAddr string
+var (
+	logVerbosity int
+	enablePprof  bool
+	pprofAddr    string
+)
 
 func main() {
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
@@ -138,7 +141,7 @@ func runControllers(ctx context.Context, kubeConfig *rest.Config) error {
 
 		go func() {
 			logger.Info("starting pprof server", "addr", pprofAddr)
-			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				logger.Error(err, "pprof server failed")
 			}
 		}()

--- a/main.go
+++ b/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	goflag "flag"
 	"fmt"
+	"net/http"
+	"net/http/pprof"
 	"os"
 
 	"github.com/ViaQ/logerr/v2/log"
@@ -65,6 +67,8 @@ func init() {
 }
 
 var logVerbosity int
+var enablePprof bool
+var pprofAddr string
 
 func main() {
 	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
@@ -109,6 +113,8 @@ func newControllerCommand() *cobra.Command {
 	cmd.Use = "controller"
 	cmd.Short = "Start the addon controller"
 	cmd.Flags().IntVar(&logVerbosity, "log-verbosity", 0, "Log verbosity level. The higher the level, the noisier the logs.")
+	cmd.Flags().BoolVar(&enablePprof, "enable-pprof", false, "Enable pprof profiling.")
+	cmd.Flags().StringVar(&pprofAddr, "pprof-addr", "127.0.0.1:6060", "The address the pprof server will bind to.")
 
 	return cmd
 }
@@ -116,6 +122,35 @@ func newControllerCommand() *cobra.Command {
 func runControllers(ctx context.Context, kubeConfig *rest.Config) error {
 	logger := log.NewLogger("mcoa", log.WithVerbosity(logVerbosity))
 	ctrl.SetLogger(logger)
+
+	if enablePprof {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+		srv := &http.Server{
+			Addr:    pprofAddr,
+			Handler: mux,
+		}
+
+		go func() {
+			logger.Info("starting pprof server", "addr", pprofAddr)
+			if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				logger.Error(err, "pprof server failed")
+			}
+		}()
+
+		go func() {
+			<-ctx.Done()
+			logger.Info("shutting down pprof server")
+			_ = srv.Shutdown(context.Background())
+		}()
+	} else {
+		logger.V(1).Info("pprof server disabled")
+	}
 
 	// Increase client-side throttling limits to support large number of managed clusters
 	kubeConfig.QPS = 50.0


### PR DESCRIPTION
Introduces --enable-pprof and --pprof-addr flags to the controller. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance profiling support to the controller command via `--enable-pprof` and `--pprof-addr` flags, enabling operators to analyze controller performance and behavior through standard profiling endpoints with graceful shutdown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->