### PR TITLE
[release-2.17] feat: add Perses virtualization dashboards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters:
         - shadow
     misspell:
       locale: US
+      ignore-rules:
+        - utilisation
     revive:
       rules:
         - name: package-comments

--- a/internal/perses/dashboards/virtualization/helpers.go
+++ b/internal/perses/dashboards/virtualization/helpers.go
@@ -1,0 +1,154 @@
+package virtualization
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	v1 "github.com/perses/perses/pkg/model/api/v1"
+	v1Common "github.com/perses/perses/pkg/model/api/v1/common"
+	dashboardModel "github.com/perses/perses/pkg/model/api/v1/dashboard"
+	"github.com/perses/perses/pkg/model/api/v1/variable"
+)
+
+type GridItem struct {
+	X, Y, W, H int
+}
+
+// AddTextVariable adds a text variable (free-form user input) to the dashboard.
+func AddTextVariable(name string, value string, displayName string, description string) dashboard.Option {
+	return func(builder *dashboard.Builder) error {
+		display := &variable.Display{
+			Name:        displayName,
+			Description: description,
+		}
+		builder.Dashboard.Spec.Variables = append(builder.Dashboard.Spec.Variables, dashboardModel.Variable{
+			Kind: variable.KindText,
+			Spec: &dashboardModel.TextVariableSpec{
+				TextSpec: variable.TextSpec{
+					Value:   value,
+					Display: display,
+				},
+				Name: name,
+			},
+		})
+		return nil
+	}
+}
+
+// StaticListValue represents a value in a static list variable.
+type StaticListValue struct {
+	Label string
+	Value string
+}
+
+// AddStaticListVariable adds a list variable backed by static values.
+// description is optional (pass "" to omit).
+func AddStaticListVariable(name string, displayName string, description string, values []StaticListValue, defaultValue string, allowAll bool, allowMultiple bool, customAllValue string) dashboard.Option {
+	return func(builder *dashboard.Builder) error {
+		staticValues := make([]map[string]any, 0, len(values))
+		for _, v := range values {
+			if v.Label == "" {
+				staticValues = append(staticValues, map[string]any{"value": v.Value})
+			} else {
+				staticValues = append(staticValues, map[string]any{"label": v.Label, "value": v.Value})
+			}
+		}
+
+		display := &variable.Display{
+			Name:        displayName,
+			Description: description,
+		}
+
+		spec := dashboardModel.ListVariableSpec{
+			ListSpec: variable.ListSpec{
+				Display:        display,
+				AllowAllValue:  allowAll,
+				AllowMultiple:  allowMultiple,
+				CustomAllValue: customAllValue,
+				Plugin: v1Common.Plugin{
+					Kind: "StaticListVariable",
+					Spec: map[string]any{
+						"values": staticValues,
+					},
+				},
+			},
+			Name: name,
+		}
+
+		if allowMultiple && defaultValue != "" {
+			spec.DefaultValue = &variable.DefaultValue{
+				SliceValues: []string{defaultValue},
+			}
+		} else if defaultValue != "" {
+			spec.DefaultValue = &variable.DefaultValue{
+				SingleValue: defaultValue,
+			}
+		}
+
+		builder.Dashboard.Spec.Variables = append(builder.Dashboard.Spec.Variables, dashboardModel.Variable{
+			Kind: variable.KindList,
+			Spec: &spec,
+		})
+		return nil
+	}
+}
+
+var errPositionsMismatch = errors.New("grid positions count does not match panel count")
+
+// addCustomPanelGroupImpl is the shared implementation for building a panel group
+// with explicit grid positions and configurable collapse state.
+func addCustomPanelGroupImpl(title string, collapseOpen bool, positions []GridItem, panelOpts ...panelgroup.Option) dashboard.Option {
+	return func(builder *dashboard.Builder) error {
+		pg, err := panelgroup.New(title, panelOpts...)
+		if err != nil {
+			return err
+		}
+
+		if len(positions) < len(pg.Panels) {
+			return fmt.Errorf("%w: panel group %q has %d panels but only %d grid positions", errPositionsMismatch, title, len(pg.Panels), len(positions))
+		}
+
+		if builder.Dashboard.Spec.Panels == nil {
+			builder.Dashboard.Spec.Panels = make(map[string]*v1.Panel)
+		}
+
+		layoutIdx := len(builder.Dashboard.Spec.Layouts)
+		gridItems := make([]dashboardModel.GridItem, 0, len(pg.Panels))
+
+		for i := range pg.Panels {
+			panelRef := fmt.Sprintf("%d_%d", layoutIdx, i)
+			builder.Dashboard.Spec.Panels[panelRef] = &pg.Panels[i]
+
+			gi := positions[i]
+			gridItems = append(gridItems, dashboardModel.GridItem{
+				X:      gi.X,
+				Y:      gi.Y,
+				Width:  gi.W,
+				Height: gi.H,
+				Content: &v1Common.JSONRef{
+					Ref: fmt.Sprintf("#/spec/panels/%s", panelRef),
+				},
+			})
+		}
+
+		builder.Dashboard.Spec.Layouts = append(builder.Dashboard.Spec.Layouts, dashboardModel.Layout{
+			Kind: "Grid",
+			Spec: dashboardModel.GridLayoutSpec{
+				Display: &dashboardModel.GridLayoutDisplay{
+					Title:    title,
+					Collapse: &dashboardModel.GridLayoutCollapse{Open: collapseOpen},
+				},
+				Items: gridItems,
+			},
+		})
+
+		return nil
+	}
+}
+
+// AddCustomPanelGroup adds a panel group with explicit grid positions for each panel.
+func AddCustomPanelGroup(title string, positions []GridItem, panelOpts ...panelgroup.Option) dashboard.Option {
+	return addCustomPanelGroupImpl(title, true, positions, panelOpts...)
+}

--- a/internal/perses/dashboards/virtualization/node-memory-overview.go
+++ b/internal/perses/dashboards/virtualization/node-memory-overview.go
@@ -1,0 +1,180 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/community-mixins/pkg/promql"
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+	promqlVar "github.com/perses/plugins/prometheus/sdk/go/variable/promql"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/virtualization"
+)
+
+// addCustomPanelGroupWithCollapse is like AddCustomPanelGroup but allows controlling
+// whether the grid section starts expanded (Open) or collapsed.
+func addCustomPanelGroupWithCollapse(title string, collapseOpen bool, positions []GridItem, panelOpts ...panelgroup.Option) dashboard.Option {
+	return addCustomPanelGroupImpl(title, collapseOpen, positions, panelOpts...)
+}
+
+func nodeMemoryClusterVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("cluster",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("cluster",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers("node_memory_MemTotal_bytes"),
+			),
+			listVar.DisplayName("Cluster"),
+			listVar.AllowAllValue(true),
+			listVar.AllowMultiple(true),
+			listVar.CustomAllValue(".*"),
+			listVar.DefaultValues("$__all"),
+		),
+	)
+}
+
+func nodeMemoryNodeVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("node",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("node",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers(
+					promql.SetLabelMatchers(
+						"kube_node_role",
+						[]promql.LabelMatcher{{Name: "cluster", Type: "=~", Value: "$cluster"}},
+					),
+				),
+			),
+			listVar.DisplayName("Node"),
+			listVar.AllowAllValue(true),
+			listVar.AllowMultiple(false),
+			listVar.CustomAllValue(".*"),
+			listVar.DefaultValue("$__all"),
+		),
+	)
+}
+
+func nodeMemoryRoleVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("role",
+		listVar.List(
+			promqlVar.PrometheusPromQL(
+				`kube_node_role{cluster=~"$cluster"}`,
+				promqlVar.LabelName("role"),
+				promqlVar.Datasource(datasource),
+			),
+			listVar.DisplayName("role"),
+			listVar.AllowAllValue(false),
+			listVar.AllowMultiple(false),
+			listVar.DefaultValue("worker"),
+		),
+	)
+}
+
+func withNodeMemorySummary(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Summary", true,
+		[]GridItem{
+			{X: 0, Y: 0, W: 10, H: 7},
+			{X: 10, Y: 0, W: 6, H: 7},
+			{X: 16, Y: 0, W: 6, H: 7},
+			{X: 0, Y: 7, W: 22, H: 7},
+			{X: 0, Y: 14, W: 5, H: 7},
+			{X: 5, Y: 14, W: 5, H: 7},
+			{X: 10, Y: 14, W: 5, H: 7},
+			{X: 15, Y: 14, W: 7, H: 7},
+		},
+		panels.NodeMemoryClusterUtilizationNow(datasource),
+		panels.NodeMemoryClusterVirtualCommittedNow(datasource),
+		panels.NodeMemoryVmVirtualCommittedNow(datasource),
+		panels.NodeMemoryClusterUtilizationHistorySummary(datasource),
+		panels.NodeMemoryNodeUtilizationMinNow(datasource),
+		panels.NodeMemoryNodeUtilizationMaxNow(datasource),
+		panels.NodeMemoryNodePressureMaxNow(datasource),
+		panels.NodeMemoryNodeSystemExceedsReservationAlertNow(datasource),
+	)
+}
+
+func withNodeMemoryCluster(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Cluster", false,
+		[]GridItem{
+			{X: 0, Y: 0, W: 15, H: 7},
+			{X: 15, Y: 0, W: 7, H: 7},
+			{X: 0, Y: 7, W: 15, H: 7},
+			{X: 15, Y: 7, W: 7, H: 7},
+			{X: 0, Y: 14, W: 15, H: 5},
+			{X: 0, Y: 19, W: 15, H: 6},
+		},
+		panels.NodeMemoryClusterUtilizationHistory(datasource),
+		panels.NodeMemoryClusterUtilizationNow(datasource),
+		panels.NodeMemoryClusterVirtualCommittedHistory(datasource),
+		panels.NodeMemoryClusterVirtualCommittedNow(datasource),
+		panels.NodeMemoryClusterPressure(datasource),
+		panels.NodeMemorySwap(datasource),
+	)
+}
+
+func withNodeMemoryNodes(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Nodes", false,
+		[]GridItem{
+			{X: 0, Y: 0, W: 15, H: 8},
+			{X: 15, Y: 0, W: 7, H: 8},
+			{X: 0, Y: 8, W: 15, H: 8},
+			{X: 15, Y: 8, W: 7, H: 8},
+			{X: 0, Y: 16, W: 15, H: 8},
+			{X: 15, Y: 16, W: 7, H: 8},
+			{X: 0, Y: 24, W: 22, H: 6},
+		},
+		panels.NodeMemoryNodeUtilizationHistory(datasource),
+		panels.NodeMemoryNodeUtilizationMinNow(datasource),
+		panels.NodeMemoryNodeRequestsHistory(datasource),
+		panels.NodeMemoryNodeRequestsMinmaxNow(datasource),
+		panels.NodeMemoryUtilizationDistribution(datasource),
+		panels.NodeMemoryPlanMinmax(datasource),
+		panels.NodeMemoryNodePressureHistory(datasource),
+	)
+}
+
+func withNodeMemorySystemReserved(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("System Reserved", false,
+		[]GridItem{
+			{X: 0, Y: 0, W: 9, H: 8},
+			{X: 9, Y: 0, W: 9, H: 8},
+			{X: 18, Y: 0, W: 6, H: 8},
+		},
+		panels.NodeMemoryNodeSystemReservedUtilizationHistory(datasource),
+		panels.NodeMemoryNodeSystemReservedMinmaxHistory(datasource),
+		panels.NodeMemoryNodeSystemExceedsReservationAlertNow(datasource),
+	)
+}
+
+func withNodeMemoryWorkloads(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Workloads", false,
+		[]GridItem{
+			{X: 0, Y: 0, W: 14, H: 6},
+			{X: 14, Y: 0, W: 7, H: 6},
+			{X: 0, Y: 6, W: 14, H: 6},
+			{X: 14, Y: 6, W: 7, H: 6},
+		},
+		panels.NodeMemoryVMs(datasource),
+		panels.NodeMemoryVmVirtualCommittedNow(datasource),
+		panels.NodeMemoryVMVirtualMemoryUtilization(datasource),
+		panels.NodeMemoryNumberOfRunningVMs(datasource),
+	)
+}
+
+// BuildNodeMemoryOverview builds the acm-node-memory-overview Perses dashboard.
+func BuildNodeMemoryOverview(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-node-memory-overview",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Nodes Memory"),
+
+		nodeMemoryClusterVariable(datasource),
+		nodeMemoryNodeVariable(datasource),
+		nodeMemoryRoleVariable(datasource),
+
+		withNodeMemorySummary(datasource),
+		withNodeMemoryCluster(datasource),
+		withNodeMemoryNodes(datasource),
+		withNodeMemorySystemReserved(datasource),
+		withNodeMemoryWorkloads(datasource),
+	)
+}

--- a/internal/perses/dashboards/virtualization/single-cluster-view.go
+++ b/internal/perses/dashboards/virtualization/single-cluster-view.go
@@ -1,0 +1,222 @@
+package virtualization
+
+import (
+	"time"
+
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/dashboard"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	variable "github.com/perses/perses/pkg/model/api/v1/variable"
+	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/virtualization"
+)
+
+func singleClusterClusterVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("cluster",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("cluster",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers("kubevirt_hyperconverged_operator_health_status"),
+			),
+			listVar.DisplayName("Cluster"),
+			listVar.AllowAllValue(false),
+			listVar.AllowMultiple(false),
+			listVar.SortingBy(variable.SortAlphabeticalAsc),
+		),
+	)
+}
+
+func singleClusterHealthImpactVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("health_impact",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("operator_health_impact",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers(`ALERTS{kubernetes_operator_part_of="kubevirt"}`),
+			),
+			listVar.DisplayName("Alerts - Impact on Operator Health"),
+			listVar.Description("Filter the alerts by their impact on the operator health"),
+			listVar.AllowAllValue(true),
+			listVar.AllowMultiple(true),
+			listVar.DefaultValues("$__all"),
+			listVar.SortingBy(variable.SortNone),
+		),
+	)
+}
+
+func singleClusterSeverityVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("severity",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("severity",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers(`ALERTS{kubernetes_operator_part_of="kubevirt"}`),
+			),
+			listVar.DisplayName("Alerts - Severity"),
+			listVar.Description("Filter the alerts by their severity level"),
+			listVar.AllowAllValue(true),
+			listVar.AllowMultiple(true),
+			listVar.DefaultValues("$__all"),
+			listVar.SortingBy(variable.SortNone),
+		),
+	)
+}
+
+func withSingleClusterGeneralInformation(datasource, project string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("General Information", true,
+		[]GridItem{
+			// Row 1: eight equal stat panels (W:3 each = 24)
+			{X: 0, Y: 0, W: 3, H: 3},  // Cluster Name
+			{X: 3, Y: 0, W: 3, H: 3},  // OpenShift Virt Version
+			{X: 6, Y: 0, W: 3, H: 3},  // Provider
+			{X: 9, Y: 0, W: 3, H: 3},  // OpenShift Version
+			{X: 12, Y: 0, W: 3, H: 3}, // Operator Status
+			{X: 15, Y: 0, W: 3, H: 3}, // Operator Conditions
+			{X: 18, Y: 0, W: 3, H: 3}, // Total Nodes
+			{X: 21, Y: 0, W: 3, H: 3}, // Total VMs
+			// Row 2: VM status + operational stats, W:3 each (matching top row)
+			{X: 0, Y: 3, W: 3, H: 3},  // Running VMs
+			{X: 3, Y: 3, W: 3, H: 3},  // VMs in Error
+			{X: 6, Y: 3, W: 3, H: 3},  // Stopped VMs
+			{X: 9, Y: 3, W: 3, H: 3},  // Starting VMs
+			{X: 12, Y: 3, W: 3, H: 3}, // Migrating VMs
+			{X: 15, Y: 3, W: 3, H: 3}, // VMs Running (%)
+			{X: 18, Y: 3, W: 3, H: 3}, // VMs Live Migration Disabled
+			{X: 21, Y: 3, W: 3, H: 3}, // VMs Created (24h)
+			// Row 3: tables
+			{X: 0, Y: 6, W: 12, H: 7},  // Running VMs by OS
+			{X: 12, Y: 6, W: 12, H: 7}, // Recent VMs Started
+		},
+		panels.SingleClusterClusterName(datasource),
+		panels.SingleClusterOpenshiftVirtVersion(datasource),
+		panels.SingleClusterProvider(datasource),
+		panels.SingleClusterOpenshiftVersion(datasource),
+		panels.SingleClusterOperatorStatus(datasource),
+		panels.SingleClusterOperatorConditions(datasource),
+		panels.SingleClusterTotalNodes(datasource),
+		panels.SingleClusterTotalVMs(datasource, project),
+		panels.SingleClusterVMsRunning(datasource, project),
+		panels.SingleClusterVMsInError(datasource, project),
+		panels.SingleClusterVMsStopped(datasource, project),
+		panels.SingleClusterVMsStarting(datasource, project),
+		panels.SingleClusterVMsMigrating(datasource, project),
+		panels.SingleClusterVMsRunningPercent(datasource, project),
+		panels.SingleClusterVMsNotEvictable(datasource, project),
+		panels.SingleClusterVMsCreatedLast24h(datasource),
+		panels.SingleClusterRunningVMsByOS(datasource),
+		panels.SingleClusterRecentVMsStarted(datasource, project),
+	)
+}
+
+func withSingleClusterAdditionalVMDetails(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Additional Virtual Machines Details", false,
+		[]GridItem{
+			{X: 0, Y: 15, W: 12, H: 8},
+			{X: 12, Y: 15, W: 12, H: 8},
+		},
+		panels.SingleClusterVMsRunningByNode(datasource),
+		panels.SingleClusterVMsByStatus(datasource),
+	)
+}
+
+func withSingleClusterCPUTop20(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("CPU Utilization - Top 20", false,
+		[]GridItem{
+			{X: 0, Y: 16, W: 12, H: 7},
+			{X: 12, Y: 16, W: 12, H: 7},
+			{X: 0, Y: 23, W: 12, H: 7},
+			{X: 12, Y: 23, W: 12, H: 7},
+			{X: 0, Y: 30, W: 12, H: 7},
+			{X: 12, Y: 30, W: 12, H: 7},
+		},
+		panels.SingleClusterNodesCPUUtilization(datasource),
+		panels.SingleClusterVMsTotalCPUUsage(datasource),
+		panels.SingleClusterNodesCPUUsagePercent(datasource),
+		panels.SingleClusterVMsCPUUsagePercent(datasource),
+		panels.SingleClusterNodesCPUStealPercent(datasource),
+		panels.SingleClusterVMsCPUReadyPercent(datasource),
+	)
+}
+
+func withSingleClusterMemoryTop20(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Memory Utilization - Top 20", false,
+		[]GridItem{
+			{X: 0, Y: 17, W: 12, H: 7},
+			{X: 12, Y: 17, W: 12, H: 7},
+			{X: 0, Y: 24, W: 12, H: 7},
+			{X: 12, Y: 24, W: 12, H: 7},
+		},
+		panels.SingleClusterNodesMemoryUsage(datasource),
+		panels.SingleClusterVMsMemoryUsage(datasource),
+		panels.SingleClusterNodesMemoryUsagePercent(datasource),
+		panels.SingleClusterVMsMemoryUsagePercent(datasource),
+	)
+}
+
+func withSingleClusterNetworkTop20(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Network Utilization - Top 20", false,
+		[]GridItem{
+			{X: 0, Y: 18, W: 12, H: 6},
+			{X: 12, Y: 18, W: 12, H: 6},
+			{X: 0, Y: 24, W: 12, H: 6},
+			{X: 12, Y: 24, W: 12, H: 6},
+		},
+		panels.SingleClusterNodesNetworkReceived(datasource),
+		panels.SingleClusterVMsNetworkReceived(datasource),
+		panels.SingleClusterNodesNetworkTransmitted(datasource),
+		panels.SingleClusterVMsNetworkTransmitted(datasource),
+	)
+}
+
+func withSingleClusterStorageTop20(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Storage Utilization - Top 20", false,
+		[]GridItem{
+			{X: 0, Y: 19, W: 12, H: 7},
+			{X: 12, Y: 19, W: 12, H: 7},
+			{X: 0, Y: 26, W: 12, H: 7},
+			{X: 12, Y: 26, W: 12, H: 7},
+		},
+		panels.SingleClusterNodesVMStorageIOPS(datasource),
+		panels.SingleClusterVMsStorageIOPS(datasource),
+		panels.SingleClusterNodesVMStorageTraffic(datasource),
+		panels.SingleClusterVMsStorageTraffic(datasource),
+	)
+}
+
+func withSingleClusterAlerts(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Alerts", false,
+		[]GridItem{
+			{X: 0, Y: 20, W: 8, H: 3},
+			{X: 8, Y: 20, W: 8, H: 3},
+			{X: 16, Y: 20, W: 8, H: 3},
+			{X: 0, Y: 23, W: 16, H: 5},
+			{X: 16, Y: 23, W: 8, H: 5},
+			{X: 0, Y: 28, W: 24, H: 11},
+		},
+		panels.SingleClusterCriticalSeverityAlerts(datasource),
+		panels.SingleClusterWarningSeverityAlerts(datasource),
+		panels.SingleClusterInfoSeverityAlerts(datasource),
+		panels.SingleClusterOperatorHealthImpactAlertsTable(datasource),
+		panels.SingleClusterOperatorCSVIssuesTable(datasource),
+		panels.SingleClusterAllAlertsTable(datasource),
+	)
+}
+
+// BuildSingleClusterView builds the acm-openshift-virtualization-single-cluster-view Perses dashboard.
+func BuildSingleClusterView(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-openshift-virtualization-single-cluster-view",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Cluster Details"),
+		dashboard.Duration(time.Hour),
+
+		singleClusterClusterVariable(datasource),
+		singleClusterHealthImpactVariable(datasource),
+		singleClusterSeverityVariable(datasource),
+
+		withSingleClusterGeneralInformation(datasource, project),
+		withSingleClusterAdditionalVMDetails(datasource),
+		withSingleClusterCPUTop20(datasource),
+		withSingleClusterMemoryTop20(datasource),
+		withSingleClusterNetworkTop20(datasource),
+		withSingleClusterStorageTop20(datasource),
+		withSingleClusterAlerts(datasource),
+	)
+}

--- a/internal/perses/dashboards/virtualization/single-vm-view.go
+++ b/internal/perses/dashboards/virtualization/single-vm-view.go
@@ -1,0 +1,191 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/dashboard"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	v1variable "github.com/perses/perses/pkg/model/api/v1/variable"
+	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/virtualization"
+)
+
+func singleVMViewClusterVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("cluster",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("cluster",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers("kubevirt_vm_info"),
+			),
+			listVar.DisplayName("Cluster"),
+			listVar.Description("Filter the virtual machine by its cluster"),
+			listVar.AllowAllValue(false),
+			listVar.AllowMultiple(false),
+			listVar.SortingBy(v1variable.SortAlphabeticalAsc),
+		),
+	)
+}
+
+func singleVMViewNamespaceVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("namespace",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("namespace",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers(`kubevirt_vm_info{cluster="$cluster"}`),
+			),
+			listVar.DisplayName("Namespace"),
+			listVar.Description("Filter the Virtual Machine by its Namespace"),
+			listVar.AllowAllValue(false),
+			listVar.AllowMultiple(false),
+			listVar.SortingBy(v1variable.SortAlphabeticalAsc),
+		),
+	)
+}
+
+func singleVMViewNameVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("name",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("name",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers(`kubevirt_vm_info{cluster="$cluster", namespace="$namespace"}`),
+			),
+			listVar.DisplayName("VM Name"),
+			listVar.Description("Filter the Virtual Machine by its name"),
+			listVar.AllowAllValue(false),
+			listVar.AllowMultiple(false),
+			listVar.SortingBy(v1variable.SortAlphabeticalAsc),
+		),
+	)
+}
+
+func withSingleVMGeneralInformation(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("General Information", true,
+		[]GridItem{
+			{X: 0, Y: 1, W: 4, H: 4},
+			{X: 4, Y: 1, W: 4, H: 4},
+			{X: 8, Y: 1, W: 4, H: 4},
+			{X: 12, Y: 1, W: 4, H: 4},
+			{X: 16, Y: 1, W: 4, H: 5},
+			{X: 20, Y: 1, W: 4, H: 5},
+			{X: 0, Y: 5, W: 8, H: 13},
+			{X: 8, Y: 5, W: 8, H: 13},
+			{X: 16, Y: 6, W: 4, H: 5},
+			{X: 20, Y: 6, W: 4, H: 5},
+			{X: 16, Y: 11, W: 8, H: 7},
+		},
+		panels.SingleVMStatus(datasource),
+		panels.SingleVMCriticalSeverityAlerts(datasource),
+		panels.SingleVMWarningSeverityAlerts(datasource),
+		panels.SingleVMInfoSeverityAlerts(datasource),
+		panels.SingleVMMemoryUsagePercentGauge(datasource),
+		panels.SingleVMCPUUsagePercentGauge(datasource),
+		panels.SingleVMVMInformationTable(datasource),
+		panels.SingleVMGeneralInformationTable(datasource),
+		panels.SingleVMFilesystemUsagePercentGauge(datasource),
+		panels.SingleVMCPUDelayPercentGauge(datasource),
+		panels.SingleVMAllocatedResourcesTable(datasource),
+	)
+}
+
+func withSingleVMAdditionalDetails(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Additional Virtual Machines Details", false,
+		[]GridItem{
+			{X: 0, Y: 14, W: 12, H: 5},
+			{X: 12, Y: 14, W: 12, H: 5},
+		},
+		panels.SingleVMNetworkTable(datasource),
+		panels.SingleVMSnapshotsTable(datasource),
+	)
+}
+
+func withSingleVMCPUUtilization(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("CPU Utilization", false,
+		[]GridItem{
+			{X: 0, Y: 17, W: 12, H: 6},
+			{X: 12, Y: 17, W: 12, H: 6},
+			{X: 0, Y: 23, W: 12, H: 6},
+			{X: 12, Y: 23, W: 12, H: 6},
+		},
+		panels.SingleVMTotalCPUUsage(datasource),
+		panels.SingleVMCPUUsagePercentTimeSeries(datasource),
+		panels.SingleVMCPUReadyTime(datasource),
+		panels.SingleVMCPUDelayPercentTimeSeries(datasource),
+	)
+}
+
+func withSingleVMMemoryUtilization(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Memory Utilization", false,
+		[]GridItem{
+			{X: 0, Y: 18, W: 12, H: 6},
+			{X: 12, Y: 18, W: 12, H: 6},
+		},
+		panels.SingleVMMemoryUsage(datasource),
+		panels.SingleVMMemoryUsagePercentTimeSeries(datasource),
+	)
+}
+
+func withSingleVMNetworkUtilization(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Network Utilization", false,
+		[]GridItem{
+			{X: 0, Y: 17, W: 12, H: 6},
+			{X: 12, Y: 17, W: 12, H: 6},
+			{X: 0, Y: 23, W: 12, H: 6},
+			{X: 12, Y: 23, W: 12, H: 6},
+		},
+		panels.SingleVMNetworkTransmit(datasource),
+		panels.SingleVMNetworkReceive(datasource),
+		panels.SingleVMNetworkTransmitPacketsDropped(datasource),
+		panels.SingleVMNetworkReceivePacketsDropped(datasource),
+	)
+}
+
+func withSingleVMStorageUtilization(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Storage Utilization", false,
+		[]GridItem{
+			{X: 0, Y: 20, W: 12, H: 6},
+			{X: 12, Y: 20, W: 12, H: 6},
+		},
+		panels.SingleVMStorageTraffic(datasource),
+		panels.SingleVMStorageIOPs(datasource),
+	)
+}
+
+func withSingleVMFilesystemUtilization(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("File System Utilization", false,
+		[]GridItem{
+			{X: 0, Y: 21, W: 12, H: 6},
+			{X: 12, Y: 21, W: 12, H: 6},
+		},
+		panels.SingleVMFilesystemUsage(datasource),
+		panels.SingleVMFilesystemUsagePercentTimeSeries(datasource),
+	)
+}
+
+func withSingleVMAlerts(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Alerts", false,
+		[]GridItem{
+			{X: 0, Y: 19, W: 24, H: 6},
+		},
+		panels.SingleVMVMAlertsTable(datasource),
+	)
+}
+
+// BuildSingleVMView builds the acm-openshift-virtualization-single-vm-view Perses dashboard.
+func BuildSingleVMView(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-openshift-virtualization-single-vm-view",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Virtual Machine Details"),
+
+		singleVMViewClusterVariable(datasource),
+		singleVMViewNamespaceVariable(datasource),
+		singleVMViewNameVariable(datasource),
+
+		withSingleVMGeneralInformation(datasource),
+		withSingleVMAdditionalDetails(datasource),
+		withSingleVMCPUUtilization(datasource),
+		withSingleVMMemoryUtilization(datasource),
+		withSingleVMNetworkUtilization(datasource),
+		withSingleVMStorageUtilization(datasource),
+		withSingleVMFilesystemUtilization(datasource),
+		withSingleVMAlerts(datasource),
+	)
+}

--- a/internal/perses/dashboards/virtualization/top-consumers.go
+++ b/internal/perses/dashboards/virtualization/top-consumers.go
@@ -1,0 +1,128 @@
+package virtualization
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	promqlVar "github.com/perses/plugins/prometheus/sdk/go/variable/promql"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/virtualization"
+)
+
+// topConsumersPairedGrid places a table (left) next to its time-series (right).
+var topConsumersPairedGrid = []GridItem{
+	{X: 0, Y: 0, W: 12, H: 9},
+	{X: 12, Y: 0, W: 12, H: 9},
+}
+
+// topNHiddenVariable creates a hidden list variable backed by a
+// PrometheusPromQL query. It evaluates expr (typically topk($topn, ...)),
+// extracts the "name" label from the results, selects all values, and
+// joins them into a pipe-separated regex for use in name=~"$varName".
+func topNHiddenVariable(varName, expr, datasource string) dashboard.Option {
+	return dashboard.AddVariable(varName,
+		listVar.List(
+			promqlVar.PrometheusPromQL(expr,
+				promqlVar.LabelName("name"),
+				promqlVar.Datasource(datasource),
+			),
+			listVar.Hidden(true),
+			listVar.AllowAllValue(false),
+			listVar.AllowMultiple(true),
+			listVar.DefaultValues("$__all"),
+		),
+	)
+}
+
+func withTopConsumersMemoryGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Memory",
+		topConsumersPairedGrid,
+		panels.TopConsumersMemoryTable(datasource, project),
+		panels.TopConsumersMemoryTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersCPUGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("CPU",
+		topConsumersPairedGrid,
+		panels.TopConsumersCPUTable(datasource, project),
+		panels.TopConsumersCPUTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersStorageTrafficGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Storage Traffic",
+		topConsumersPairedGrid,
+		panels.TopConsumersStorageTrafficTable(datasource, project),
+		panels.TopConsumersStorageTrafficTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersStorageIOPSGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Storage IOPS",
+		topConsumersPairedGrid,
+		panels.TopConsumersStorageIOPSTable(datasource, project),
+		panels.TopConsumersStorageIOPSTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersNetworkTrafficGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Network Traffic",
+		topConsumersPairedGrid,
+		panels.TopConsumersNetworkTrafficTable(datasource, project),
+		panels.TopConsumersNetworkTrafficTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersVCPUWaitGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("vCPU Wait",
+		topConsumersPairedGrid,
+		panels.TopConsumersVCPUWaitTable(datasource, project),
+		panels.TopConsumersVCPUWaitTimeSeries(datasource),
+	)
+}
+
+func withTopConsumersMemorySwapGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Memory Swap Traffic",
+		topConsumersPairedGrid,
+		panels.TopConsumersMemorySwapTable(datasource, project),
+		panels.TopConsumersMemorySwapTimeSeries(datasource),
+	)
+}
+
+// BuildTopConsumers creates the Top Consumers dashboard showing the highest
+// resource consumers across clusters, adapted from the Grafana
+// "KubeVirt / Infrastructure Resources / Top Consumers" dashboard.
+// Each resource type is a collapsible group with a table and time-series pair.
+func BuildTopConsumers(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-virtual-machines-top-consumers",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Top Consumers"),
+
+		VMClusterVariable(datasource),
+		VMNamespaceVariable(datasource),
+		AddStaticListVariable("topn", "Top N", "Number of top consumers to display",
+			[]StaticListValue{
+				{Label: "5", Value: "5"},
+				{Label: "10", Value: "10"},
+				{Label: "20", Value: "20"},
+				{Label: "50", Value: "50"},
+			},
+			"5", false, false, "",
+		),
+
+		topNHiddenVariable(panels.TopNMemoryVarName, panels.TopNMemoryVarExpr, datasource),
+		topNHiddenVariable(panels.TopNCPUVarName, panels.TopNCPUVarExpr, datasource),
+		topNHiddenVariable(panels.TopNStorageTrafficVarName, panels.TopNStorageTrafficVarExpr, datasource),
+		topNHiddenVariable(panels.TopNStorageIOPSVarName, panels.TopNStorageIOPSVarExpr, datasource),
+		topNHiddenVariable(panels.TopNNetworkTrafficVarName, panels.TopNNetworkTrafficVarExpr, datasource),
+		topNHiddenVariable(panels.TopNVCPUWaitVarName, panels.TopNVCPUWaitVarExpr, datasource),
+		topNHiddenVariable(panels.TopNMemorySwapVarName, panels.TopNMemorySwapVarExpr, datasource),
+
+		withTopConsumersMemoryGroup(datasource, project),
+		withTopConsumersCPUGroup(datasource, project),
+		withTopConsumersStorageTrafficGroup(datasource, project),
+		withTopConsumersStorageIOPSGroup(datasource, project),
+		withTopConsumersNetworkTrafficGroup(datasource, project),
+		withTopConsumersVCPUWaitGroup(datasource, project),
+		withTopConsumersMemorySwapGroup(datasource, project),
+	)
+}

--- a/internal/perses/dashboards/virtualization/variables.go
+++ b/internal/perses/dashboards/virtualization/variables.go
@@ -1,0 +1,186 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/community-mixins/pkg/promql"
+	"github.com/perses/perses/go-sdk/dashboard"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+	promqlVar "github.com/perses/plugins/prometheus/sdk/go/variable/promql"
+)
+
+func VMClusterVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("cluster",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("cluster",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers("kubevirt_vm_info"),
+			),
+			listVar.DisplayName("Cluster"),
+			listVar.AllowAllValue(false),
+			listVar.AllowMultiple(false),
+		),
+	)
+}
+
+func VMClusterVariableMulti(datasource string) dashboard.Option {
+	return dashboard.AddVariable("cluster",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("cluster",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers("kubevirt_vm_info"),
+			),
+			listVar.DisplayName("Cluster"),
+			listVar.AllowAllValue(true),
+			listVar.AllowMultiple(true),
+			listVar.CustomAllValue(".*"),
+			listVar.DefaultValues("$__all"),
+		),
+	)
+}
+
+func VMNamespaceVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("namespace",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("namespace",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers(
+					promql.SetLabelMatchers(
+						"kubevirt_vm_info",
+						[]promql.LabelMatcher{{Name: "cluster", Type: "=~", Value: "$cluster"}},
+					),
+				),
+			),
+			listVar.DisplayName("Namespace"),
+			listVar.Description("Filter the virtual machine by the namespace."),
+			listVar.AllowAllValue(true),
+			listVar.AllowMultiple(true),
+			listVar.CustomAllValue(".*"),
+			listVar.DefaultValues("$__all"),
+		),
+	)
+}
+
+func VMNameVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("name",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("name",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers(
+					promql.SetLabelMatchers(
+						"kubevirt_vm_info",
+						[]promql.LabelMatcher{
+							{Name: "cluster", Type: "=~", Value: "$cluster"},
+							{Name: "namespace", Type: "=~", Value: "$namespace"},
+						},
+					),
+				),
+			),
+			listVar.DisplayName("VM Name"),
+			listVar.Description("Filter the virtual machine by the name."),
+			listVar.AllowAllValue(true),
+			listVar.AllowMultiple(true),
+			listVar.CustomAllValue(".*"),
+			listVar.DefaultValues("$__all"),
+		),
+	)
+}
+
+var vmStatusStaticValues = []StaticListValue{
+	{Label: "Running", Value: "running"},
+	{Label: "Stopped", Value: "non_running"},
+	{Label: "Starting", Value: "starting"},
+	{Label: "Migrating", Value: "migrating"},
+	{Label: "Error", Value: "error"},
+}
+
+// VMStatusVariableStatic is a multi-select status filter used by inventory and
+// utilization dashboards where $status is used as a regex label matcher.
+func VMStatusVariableStatic() dashboard.Option {
+	return AddStaticListVariable("status", "Status", "Filter virtual machines by status",
+		vmStatusStaticValues, "$__all", true, true, ".*",
+	)
+}
+
+// VMStatusVariableStaticSingleSelect is a single-select status filter used by
+// the time-in-status dashboard, where $status is matched against status_group
+// and multi-select would produce an invalid "a,b" regex.
+func VMStatusVariableStaticSingleSelect() dashboard.Option {
+	return AddStaticListVariable("status", "Status", "Filter virtual machines by status",
+		vmStatusStaticValues, "$__all", true, false, ".*",
+	)
+}
+
+// VMStatusVariableJoinExpr is used by service-level and time-in-status dashboards
+// where status is a PromQL join expression rather than a label filter.
+// The cluster filter is intentionally omitted from these join expressions:
+// Perses substitutes ${status:raw} as a raw string without a second pass for
+// nested variables, so $cluster inside a variable value would be sent literally
+// to Prometheus and match nothing. The outer query already filters by cluster.
+//
+// See: https://perses.dev/perses/docs/api/variable/
+// Upstream limitation: https://github.com/perses/perses/issues/2016
+func VMStatusVariableJoinExpr() dashboard.Option {
+	return AddStaticListVariable("status", "Status", "Filter virtual machines by status",
+		[]StaticListValue{
+			{Label: "All", Value: `on(cluster,name,namespace) group_left()(0*(sum by(cluster,namespace,name)(kubevirt_vm_info{})))`},
+			{Label: "Stopped", Value: `on(cluster,name,namespace) group_left()(0*(sum by(cluster,namespace,name)(kubevirt_vm_info{status_group="non_running"}>0)))`},
+			{Label: "Starting", Value: `on(cluster,name,namespace) group_left()(0*(sum by(cluster,namespace,name)(kubevirt_vm_info{status_group="starting"}>0)))`},
+			{Label: "Migrating", Value: `on(cluster,name,namespace) group_left()(0*(sum by(cluster,namespace,name)(kubevirt_vm_info{status_group="migrating"}>0)))`},
+			{Label: "Error", Value: `on(cluster,name,namespace) group_left()(0*(sum by(cluster,namespace,name)(kubevirt_vm_info{status_group="error"}>0)))`},
+			{Label: "Running", Value: `on(cluster,name,namespace) group_left()(0*(sum by(cluster,namespace,name)(kubevirt_vm_info{status_group="running"}>0)))`},
+		},
+		`on(cluster,name,namespace) group_left()(0*(sum by(cluster,namespace,name)(kubevirt_vm_info{})))`,
+		false, false, "",
+	)
+}
+
+// vmiLabelListVariable builds a multi-select variable that lists distinct values
+// of a VMI label from kubevirt_vmi_info. expr overrides the default
+// per-label query when the variable needs a custom metric union (e.g. guest OS
+// fields that also appear in kubevirt_vm_info).
+func vmiLabelListVariable(name, displayName, datasource, expr string) dashboard.Option {
+	if expr == "" {
+		expr = `sum by (` + name + `)(kubevirt_vmi_info{cluster=~"$cluster", namespace=~"$namespace",` + name + `!="<none>"})`
+	}
+	return dashboard.AddVariable(name,
+		listVar.List(
+			promqlVar.PrometheusPromQL(
+				expr,
+				promqlVar.LabelName(name),
+				promqlVar.Datasource(datasource),
+			),
+			listVar.DisplayName(displayName),
+			listVar.AllowAllValue(true),
+			listVar.AllowMultiple(true),
+			listVar.CustomAllValue(".*"),
+			listVar.DefaultValues("$__all"),
+		),
+	)
+}
+
+func VMFlavorVariable(datasource string) dashboard.Option {
+	return vmiLabelListVariable("flavor", "Flavor", datasource, "")
+}
+
+func VMWorkloadVariable(datasource string) dashboard.Option {
+	return vmiLabelListVariable("workload", "Workload", datasource, "")
+}
+
+func VMInstanceTypeVariable(datasource string) dashboard.Option {
+	return vmiLabelListVariable("instance_type", "Instance Type", datasource, "")
+}
+
+func VMPreferenceVariable(datasource string) dashboard.Option {
+	return vmiLabelListVariable("preference", "Preference", datasource, "")
+}
+
+func VMGuestOSNameVariable(datasource string) dashboard.Option {
+	return vmiLabelListVariable("guest_os_name", "OS Name", datasource,
+		`sum by (guest_os_name)(kubevirt_vm_info{cluster=~"$cluster", namespace=~"$namespace",guest_os_name!="<none>"} or kubevirt_vmi_info{cluster=~"$cluster", namespace=~"$namespace",guest_os_name!="<none>"})`)
+}
+
+func VMGuestOSVersionVariable(datasource string) dashboard.Option {
+	return vmiLabelListVariable("guest_os_version_id", "OS Version", datasource,
+		`sum by (guest_os_version_id)(kubevirt_vm_info{cluster=~"$cluster", namespace=~"$namespace",guest_os_version_id!="<none>"} or kubevirt_vmi_info{cluster=~"$cluster", namespace=~"$namespace",guest_os_version_id!="<none>"})`)
+}

--- a/internal/perses/dashboards/virtualization/virt-overview.go
+++ b/internal/perses/dashboards/virtualization/virt-overview.go
@@ -1,0 +1,176 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	"github.com/perses/perses/go-sdk/dashboard"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	"github.com/perses/perses/pkg/model/api/v1/variable"
+	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/virtualization"
+)
+
+func virtOverviewClusterVariable(datasource string) dashboard.Option {
+	return dashboard.AddVariable("cluster",
+		listVar.List(
+			labelValuesVar.PrometheusLabelValues("cluster",
+				dashboards.AddVariableDatasource(datasource),
+				labelValuesVar.Matchers("kubevirt_hyperconverged_operator_health_status"),
+			),
+			listVar.DisplayName("Cluster"),
+			listVar.Hidden(false),
+			listVar.AllowAllValue(true),
+			listVar.AllowMultiple(true),
+			listVar.CustomAllValue(".*"),
+			listVar.DefaultValues("$__all"),
+			listVar.SortingBy(variable.SortAlphabeticalAsc),
+		),
+	)
+}
+
+// NOTE: The "operator_health" variable values are literal PromQL comparison
+// operator strings (e.g. "==0", "==1", "==2", "<3"). Consuming queries
+// concatenate these directly into metric selectors, e.g.:
+//
+//	kubevirt_hyperconverged_operator_health_status{...}$operator_health
+//
+// Normalizing, trimming, or altering these values will silently break all
+// panels that depend on this variable.
+func virtOverviewOperatorHealthVariable() dashboard.Option {
+	return AddStaticListVariable(
+		"operator_health",
+		"Operator Health",
+		"Filter the clusters by the health of the OpenShift Virtualization operator",
+		[]StaticListValue{
+			{Label: "Healthy", Value: "==0"},
+			{Label: "Warning", Value: "==1"},
+			{Label: "Critical", Value: "==2"},
+		},
+		"$__all",
+		true,  // allowAll — "<3" matches all health states
+		false, // allowMultiple — single selection maps to one PromQL operator
+		"<3",
+	)
+}
+
+func withVirtOverviewGeneralInformation(datasource, project string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("General Information", true,
+		[]GridItem{
+			// Row 1: five stat panels, W:4 each
+			{X: 0, Y: 1, W: 4, H: 3},
+			{X: 4, Y: 1, W: 4, H: 3},
+			{X: 8, Y: 1, W: 4, H: 3},
+			{X: 12, Y: 1, W: 4, H: 3},
+			{X: 16, Y: 1, W: 4, H: 3},
+			// Row 2: one panel per VM status, W:4 each
+			{X: 0, Y: 4, W: 4, H: 3},
+			{X: 4, Y: 4, W: 4, H: 3},
+			{X: 8, Y: 4, W: 4, H: 3},
+			{X: 12, Y: 4, W: 4, H: 3},
+			{X: 16, Y: 4, W: 4, H: 3},
+			// Row 3: tables
+			{X: 0, Y: 7, W: 6, H: 7},
+			{X: 6, Y: 7, W: 9, H: 7},
+			{X: 15, Y: 7, W: 9, H: 7},
+		},
+		panels.OverviewTotalClusters(datasource),
+		panels.OverviewClustersCriticalHealth(datasource),
+		panels.OverviewClustersWarningHealth(datasource),
+		panels.OverviewTotalAllocatableNodes(datasource),
+		panels.OverviewTotalVMsStat(datasource, project),
+		panels.OverviewVMsRunning(datasource, project),
+		panels.OverviewVMsInErrorStat(datasource, project),
+		panels.OverviewVMsStopped(datasource, project),
+		panels.OverviewVMsStarting(datasource, project),
+		panels.OverviewVMsMigrating(datasource, project),
+		panels.OverviewVMsStartedLast7Days(datasource, project),
+		panels.OverviewClustersByOperatorVersion(datasource),
+		panels.OverviewClustersByOpenShiftVersion(datasource),
+	)
+}
+
+func withVirtOverviewOperatorHealth(datasource, project string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Operator Health", false,
+		[]GridItem{
+			{X: 0, Y: 15, W: 24, H: 8},
+		},
+		panels.OverviewOperatorHealthByCluster(datasource, project),
+	)
+}
+
+func withVirtOverviewAdditionalVMDetails(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Additional Virtual Machines Details", false,
+		[]GridItem{
+			{X: 0, Y: 16, W: 12, H: 7},
+			{X: 12, Y: 16, W: 12, H: 7},
+			{X: 0, Y: 23, W: 12, H: 7},
+			{X: 12, Y: 23, W: 12, H: 7},
+		},
+		panels.OverviewRunningVMsByOS(datasource),
+		panels.OverviewRunningVMsByClusterTop20(datasource),
+		panels.OverviewVMsByStatusTimeSeries(datasource),
+		panels.OverviewRunningVMsByNodeTop20(datasource),
+	)
+}
+
+func withVirtOverviewCPUUtilization(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("CPU Utilization - Top 20", false,
+		[]GridItem{
+			{X: 0, Y: 17, W: 12, H: 7},
+			{X: 12, Y: 17, W: 12, H: 7},
+		},
+		panels.OverviewCPUUsageByCluster(datasource),
+		panels.OverviewCPUUsagePercentByCluster(datasource),
+	)
+}
+
+func withVirtOverviewMemoryUtilization(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Memory Utilization - Top 20", false,
+		[]GridItem{
+			{X: 0, Y: 18, W: 12, H: 7},
+			{X: 12, Y: 18, W: 12, H: 7},
+		},
+		panels.OverviewMemoryUsageByCluster(datasource),
+		panels.OverviewMemoryUsagePercentByCluster(datasource),
+	)
+}
+
+func withVirtOverviewNetworkUtilization(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Network Utilization - Top 20", false,
+		[]GridItem{
+			{X: 0, Y: 19, W: 12, H: 7},
+			{X: 12, Y: 19, W: 12, H: 7},
+		},
+		panels.OverviewNetworkReceivedByCluster(datasource),
+		panels.OverviewNetworkTransmittedByCluster(datasource),
+	)
+}
+
+func withVirtOverviewStorageUtilization(datasource string) dashboard.Option {
+	return addCustomPanelGroupWithCollapse("Storage Utilization - Top 20", false,
+		[]GridItem{
+			{X: 0, Y: 20, W: 12, H: 7},
+			{X: 12, Y: 20, W: 12, H: 7},
+		},
+		panels.OverviewStorageTrafficByCluster(datasource),
+		panels.OverviewStorageIOPsByCluster(datasource),
+	)
+}
+
+// BuildVirtOverview builds the acm-openshift-virtualization-overview Perses dashboard.
+func BuildVirtOverview(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-openshift-virtualization-overview",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Clusters Overview"),
+
+		virtOverviewClusterVariable(datasource),
+		virtOverviewOperatorHealthVariable(),
+
+		withVirtOverviewGeneralInformation(datasource, project),
+		withVirtOverviewOperatorHealth(datasource, project),
+		withVirtOverviewAdditionalVMDetails(datasource),
+		withVirtOverviewCPUUtilization(datasource),
+		withVirtOverviewMemoryUtilization(datasource),
+		withVirtOverviewNetworkUtilization(datasource),
+		withVirtOverviewStorageUtilization(datasource),
+	)
+}

--- a/internal/perses/dashboards/virtualization/vm-by-time-in-status.go
+++ b/internal/perses/dashboards/virtualization/vm-by-time-in-status.go
@@ -1,0 +1,39 @@
+package virtualization
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/virtualization"
+)
+
+func withTimeInStatusStatsAndTable(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Time In Status",
+		[]GridItem{
+			{X: 0, Y: 0, W: 8, H: 3},
+			{X: 8, Y: 0, W: 8, H: 3},
+			{X: 16, Y: 0, W: 8, H: 3},
+			{X: 0, Y: 3, W: 24, H: 16},
+		},
+		panels.TotalAllocatedCPU(datasource),
+		panels.TotalAllocatedMemory(datasource),
+		panels.TotalAllocatedDisk(datasource),
+		panels.TimeInStatusTable(datasource, project),
+	)
+}
+
+func BuildVMByTimeInStatus(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-virtual-machines-by-time-in-status",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Virtual Machines Time in Status"),
+
+		VMClusterVariableMulti(datasource),
+		VMNamespaceVariable(datasource),
+		VMNameVariable(datasource),
+		VMStatusVariableStaticSingleSelect(),
+		AddTextVariable("days_in_status_gt", "0", "Days in Status >",
+			"Filter the Virtual Machines that are in the specific status for more than the selected number of days"),
+		AddTextVariable("days_in_status_lt", "1000", "Days in Status <",
+			"Filter the Virtual Machines that are in the specific status for less than the selected number of days"),
+
+		withTimeInStatusStatsAndTable(datasource, project),
+	)
+}

--- a/internal/perses/dashboards/virtualization/vm-inventory.go
+++ b/internal/perses/dashboards/virtualization/vm-inventory.go
@@ -1,0 +1,35 @@
+package virtualization
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/virtualization"
+)
+
+func withInventoryGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Virtual Machines Inventory",
+		[]GridItem{
+			{X: 0, Y: 0, W: 24, H: 24},
+		},
+		panels.VMInventoryTable(datasource, project),
+	)
+}
+
+func BuildVMInventory(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-virtual-machines-inventory",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Virtual Machines Inventory"),
+
+		VMClusterVariable(datasource),
+		VMNamespaceVariable(datasource),
+		VMNameVariable(datasource),
+		VMStatusVariableStatic(),
+		VMFlavorVariable(datasource),
+		VMWorkloadVariable(datasource),
+		VMInstanceTypeVariable(datasource),
+		VMPreferenceVariable(datasource),
+		VMGuestOSNameVariable(datasource),
+		VMGuestOSVersionVariable(datasource),
+
+		withInventoryGroup(datasource, project),
+	)
+}

--- a/internal/perses/dashboards/virtualization/vm-service-level.go
+++ b/internal/perses/dashboards/virtualization/vm-service-level.go
@@ -1,0 +1,41 @@
+package virtualization
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/virtualization"
+)
+
+func withServiceLevelStatsAndTable(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Service Level",
+		[]GridItem{
+			{X: 0, Y: 0, W: 8, H: 3},
+			{X: 8, Y: 0, W: 8, H: 3},
+			{X: 16, Y: 0, W: 8, H: 3},
+			{X: 0, Y: 3, W: 8, H: 3},
+			{X: 8, Y: 3, W: 8, H: 3},
+			{X: 16, Y: 3, W: 8, H: 3},
+			{X: 0, Y: 6, W: 24, H: 16},
+		},
+		panels.TotalUptimePercent(datasource),
+		panels.TotalPlannedDowntimePercent(datasource),
+		panels.TotalUnplannedDowntimePercent(datasource),
+		panels.TotalUptimeHours(datasource),
+		panels.TotalPlannedDowntimeHours(datasource),
+		panels.TotalUnplannedDowntimeHours(datasource),
+		panels.ServiceLevelTable(datasource, project),
+	)
+}
+
+func BuildVMServiceLevel(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-virtual-machines-service-level",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Virtual Machines Service Level"),
+
+		VMClusterVariableMulti(datasource),
+		VMNamespaceVariable(datasource),
+		VMNameVariable(datasource),
+		VMStatusVariableStaticSingleSelect(),
+
+		withServiceLevelStatsAndTable(datasource, project),
+	)
+}

--- a/internal/perses/dashboards/virtualization/vm-utilization.go
+++ b/internal/perses/dashboards/virtualization/vm-utilization.go
@@ -1,0 +1,29 @@
+package virtualization
+
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	panels "github.com/stolostron/multicluster-observability-addon/internal/perses/panels/virtualization"
+)
+
+func withUtilizationGroup(datasource, project string) dashboard.Option {
+	return AddCustomPanelGroup("Virtual Machines Utilization",
+		[]GridItem{
+			{X: 0, Y: 0, W: 24, H: 24},
+		},
+		panels.VMUtilizationTable(datasource, project),
+	)
+}
+
+func BuildVMUtilization(project string, datasource string) (dashboard.Builder, error) {
+	return dashboard.New("acm-virtual-machines-utilization",
+		dashboard.ProjectName(project),
+		dashboard.Name("Virtualization / Virtual Machines Utilization"),
+
+		VMClusterVariable(datasource),
+		VMNamespaceVariable(datasource),
+		VMNameVariable(datasource),
+		VMStatusVariableStatic(),
+
+		withUtilizationGroup(datasource, project),
+	)
+}

--- a/internal/perses/dashboards/virtualization/vm_dashboards_test.go
+++ b/internal/perses/dashboards/virtualization/vm_dashboards_test.go
@@ -1,0 +1,117 @@
+package virtualization
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/perses/perses/pkg/model/api/v1/variable"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildVMInventory(t *testing.T) {
+	_, err := BuildVMInventory("test-project", "test-datasource")
+	require.NoError(t, err)
+}
+
+func TestBuildVMUtilization(t *testing.T) {
+	_, err := BuildVMUtilization("test-project", "test-datasource")
+	require.NoError(t, err)
+}
+
+func TestBuildVMServiceLevel(t *testing.T) {
+	_, err := BuildVMServiceLevel("test-project", "test-datasource")
+	require.NoError(t, err)
+}
+
+func TestBuildVMByTimeInStatus(t *testing.T) {
+	_, err := BuildVMByTimeInStatus("test-project", "test-datasource")
+	require.NoError(t, err)
+}
+
+func TestBuildNodeMemoryOverview(t *testing.T) {
+	_, err := BuildNodeMemoryOverview("test-project", "test-datasource")
+	require.NoError(t, err)
+}
+
+func TestBuildVirtOverview(t *testing.T) {
+	_, err := BuildVirtOverview("test-project", "test-datasource")
+	require.NoError(t, err)
+}
+
+func TestBuildSingleClusterView(t *testing.T) {
+	_, err := BuildSingleClusterView("test-project", "test-datasource")
+	require.NoError(t, err)
+}
+
+func TestBuildSingleVMView(t *testing.T) {
+	_, err := BuildSingleVMView("test-project", "test-datasource")
+	require.NoError(t, err)
+}
+
+func TestBuildTopConsumers(t *testing.T) {
+	b, err := BuildTopConsumers("test-project", "test-datasource")
+	require.NoError(t, err)
+
+	spec := b.Dashboard.Spec
+
+	// 7 collapsible groups (memory, CPU, storage traffic, storage IOPS,
+	// network traffic, vCPU wait, memory swap).
+	assert.Len(t, spec.Layouts, 7, "expected 7 layout groups")
+
+	// Locate the topn list variable and verify its static values.
+	var topnValues []string
+	for _, v := range spec.Variables {
+		if v.Kind != variable.KindList {
+			continue
+		}
+		raw, marshalErr := json.Marshal(v.Spec)
+		require.NoError(t, marshalErr)
+		var parsed struct {
+			Name   string `json:"name"`
+			Plugin struct {
+				Spec struct {
+					Values []struct {
+						Value string `json:"value"`
+					} `json:"values"`
+				} `json:"spec"`
+			} `json:"plugin"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &parsed))
+		if parsed.Name == "topn" {
+			for _, sv := range parsed.Plugin.Spec.Values {
+				topnValues = append(topnValues, sv.Value)
+			}
+			break
+		}
+	}
+	assert.Equal(t, []string{"5", "10", "20", "50"}, topnValues, "topn variable values")
+
+	// 3 visible variables (cluster, namespace, topn) + 7 hidden topN
+	// variables (one per resource category).
+	assert.Len(t, spec.Variables, 10, "expected 10 variables (3 visible + 7 hidden)")
+
+	// Verify all 7 hidden topN variables exist by name.
+	hiddenVarNames := map[string]bool{}
+	for _, v := range spec.Variables {
+		raw, marshalErr := json.Marshal(v.Spec)
+		require.NoError(t, marshalErr)
+		var parsed struct {
+			Name    string `json:"name"`
+			Display struct {
+				Hidden bool `json:"hidden"`
+			} `json:"display"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &parsed))
+		if parsed.Display.Hidden {
+			hiddenVarNames[parsed.Name] = true
+		}
+	}
+	for _, name := range []string{
+		"topn_memory", "topn_cpu", "topn_storage_traffic",
+		"topn_storage_iops", "topn_network_traffic",
+		"topn_vcpu_wait", "topn_memory_swap",
+	} {
+		assert.True(t, hiddenVarNames[name], "missing hidden variable %s", name)
+	}
+}

--- a/internal/perses/panels/virtualization/common-query-exprs.go
+++ b/internal/perses/panels/virtualization/common-query-exprs.go
@@ -1,0 +1,50 @@
+package virtualization
+
+// Shared PromQL sub-expressions used across multiple dashboards.
+
+// vmInfoStatusExpr converts status_group to a human-readable status label.
+// Each label_replace step capitalizes and renames to match the Status filter options.
+// Used by: inventory, utilization dashboards.
+const vmInfoStatusExpr = `sum by (cluster, namespace, name, status) (
+  label_replace(label_replace(label_replace(label_replace(label_replace(
+    kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"$status"} > 0,
+    "status", "Running",   "status_group", "running"),
+    "status", "Stopped",   "status_group", "non_running"),
+    "status", "Starting",  "status_group", "starting"),
+    "status", "Migrating", "status_group", "migrating"),
+    "status", "Error",     "status_group", "error")
+)`
+
+// totalVMsExpr counts the total number of distinct VMs.
+// Used by: overview, single-cluster dashboards.
+const totalVMsExpr = `sum(count(kubevirt_vm_info{cluster=~"$cluster"}) by (name, namespace))`
+
+// Allocated CPU/memory expressions with guest_effective fallback.
+// Each expression prefers source="guest_effective" (available on newer
+// KubeVirt versions) and falls back to the legacy cores*sockets*threads
+// calculation with source=~"default|domain".
+
+// Multi-VM expressions: filter by cluster/namespace/name regex variables,
+// aggregate by (cluster, namespace, name).
+// Used by: inventory, utilization, time-in-status dashboards.
+const allocatedCPUMultiVMExpr = `(
+sum by (cluster, namespace, name)(kubevirt_vm_resource_requests{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", resource="cpu", unit="cores", source="guest_effective"})
+or
+sum by (cluster, namespace, name)(
+(kubevirt_vm_resource_requests{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", resource="cpu", unit="cores", source=~"default|domain"})
+* ignoring (unit)(kubevirt_vm_resource_requests{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", resource="cpu", unit="sockets", source=~"default|domain"})
+* ignoring (unit)(kubevirt_vm_resource_requests{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", resource="cpu", unit="threads", source=~"default|domain"})
+) or
+sum by (cluster, namespace, name)(
+(kubevirt_vm_resource_requests{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", resource="cpu", unit="cores", source=~"default|domain"})
+* ignoring (unit)(kubevirt_vm_resource_requests{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", resource="cpu", unit="sockets", source=~"default|domain"})
+) or
+sum by (cluster, namespace, name)(
+kubevirt_vm_resource_requests{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", resource="cpu", unit="cores", source=~"default|domain"})
+)`
+
+const allocatedMemoryMultiVMExpr = `(
+sum by (cluster, namespace, name)(kubevirt_vm_resource_requests{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", resource="memory", source="guest_effective"})
+or
+max by (cluster, namespace, name)(kubevirt_vm_resource_requests{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", resource="memory", source=~"default|domain"})
+)`

--- a/internal/perses/panels/virtualization/dashboard_links.go
+++ b/internal/perses/panels/virtualization/dashboard_links.go
@@ -1,0 +1,80 @@
+package virtualization
+
+import (
+	"fmt"
+	"strings"
+)
+
+const dashboardLinkBasePath = "/monitoring/v2/dashboards/view"
+
+func dashboardLinkURL(dashboard, project string, vars ...string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s?dashboard=%s&project=%s", dashboardLinkBasePath, dashboard, project)
+	for i := 0; i+1 < len(vars); i += 2 {
+		fmt.Fprintf(&b, "&var-%s=%s", vars[i], vars[i+1])
+	}
+	return b.String()
+}
+
+func clusterDetailsDashboardLinkURL(project string) string {
+	return dashboardLinkURL(
+		"acm-openshift-virtualization-single-cluster-view", project,
+		"cluster", `${__data.fields["cluster"]}`,
+	)
+}
+
+func vmDetailsDashboardLinkByValueURL(project string) string {
+	return dashboardLinkURL(
+		"acm-openshift-virtualization-single-vm-view", project,
+		"cluster", `${__data.fields["cluster"]}`,
+		"namespace", `${__data.fields["namespace"]}`,
+		"name", `${__data.fields["name"]}`,
+	)
+}
+
+func vmDetailsDashboardLinkByFieldURL(project string) string {
+	return dashboardLinkURL(
+		"acm-openshift-virtualization-single-vm-view", project,
+		"cluster", "$cluster",
+		"namespace", `${__data.fields["namespace"]}`,
+		"name", `${__data.fields["name"]}`,
+	)
+}
+
+// tableDataLink builds the dataLink map used in table column settings.
+func tableDataLink(title, url string) map[string]any {
+	return map[string]any{
+		"openNewTab": true,
+		"title":      title,
+		"url":        url,
+	}
+}
+
+// vmsByTimeInStatusLinkURL returns the URL for the "VMs by Time in Status"
+// dashboard, pre-filtered to the given status value and the current cluster.
+// Pass an empty status to link without a status filter.
+func vmsByTimeInStatusLinkURL(project, status string) string {
+	vars := []string{"cluster", "$cluster"}
+	if status != "" {
+		vars = append(vars, "status", status)
+	}
+	return dashboardLinkURL("acm-virtual-machines-by-time-in-status", project, vars...)
+}
+
+// vmInventoryLinkURL returns the URL for the VM Inventory dashboard
+// pre-scoped to the current cluster.
+func vmInventoryLinkURL(project string) string {
+	return dashboardLinkURL(
+		"acm-virtual-machines-inventory", project,
+		"cluster", "$cluster",
+	)
+}
+
+// vmServiceLevelLinkURL returns the URL for the "VM Service Level" dashboard
+// pre-scoped to the current cluster.
+func vmServiceLevelLinkURL(project string) string {
+	return dashboardLinkURL(
+		"acm-virtual-machines-service-level", project,
+		"cluster", "$cluster",
+	)
+}

--- a/internal/perses/panels/virtualization/node-memory-panel.go
+++ b/internal/perses/panels/virtualization/node-memory-panel.go
@@ -1,0 +1,686 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/link"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	gaugePanel "github.com/perses/plugins/gaugechart/sdk/go"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	timeSeriesPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+func memoryTSBottomLegend() timeSeriesPanel.Legend {
+	return timeSeriesPanel.Legend{
+		Position: timeSeriesPanel.BottomPosition,
+		Mode:     timeSeriesPanel.ListMode,
+	}
+}
+
+// NodeMemoryClusterUtilizationNow is a gauge for aggregated physical memory utilization.
+func NodeMemoryClusterUtilizationNow(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Cluster Utilization",
+		panel.Description("This panel is providing the aggregated memory utilization of all nodes of the cluster. This value is more helpful, the more balanced the memory utilization of all nodes is.\nKeep it green."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{Unit: &dashboards.PercentDecimalUnit}),
+			gaugePanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.7},
+					{Value: 0.8, Color: "#FFB249"},
+					{Value: 0.9, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationNowPhysicalRatio,
+			query.SeriesNameFormat("Physical Memory utilization"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryClusterVirtualCommittedNow is a gauge for virtual memory commitment vs allocatable.
+func NodeMemoryClusterVirtualCommittedNow(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Cluster Virtual Committed",
+		panel.Description("This panel shows the amount of committed virtual memory as a percentage of the allocatable physical memory. Overcommit occurs whenever the values goes beyond 100%."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{Unit: &dashboards.PercentDecimalUnit}),
+			gaugePanel.Max(2),
+			gaugePanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 1.2},
+					{Value: 1.5, Color: "#EA4747"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterVirtualCommittedNowRatio,
+			query.SeriesNameFormat("Virtual Memory commitment"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryVmVirtualCommittedNow is a gauge for average VM overcommit ratio.
+func NodeMemoryVmVirtualCommittedNow(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VM Virtual Committed",
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{Unit: &dashboards.PercentDecimalUnit}),
+			gaugePanel.Max(2),
+			gaugePanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 1.5},
+					{Value: 1.75, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryVMVirtualCommittedNowAvgOvercommit,
+			query.SeriesNameFormat("Average VM overcommit ratio"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodeUtilizationMinNow is a gauge for the lowest node memory utilization.
+func NodeMemoryNodeUtilizationMinNow(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Node Utilization - min",
+		panel.Description("This panel is showing the node memory utilization of the node with the lowest memory utilization in the cluster."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{Unit: &dashboards.PercentDecimalUnit}),
+			gaugePanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.7},
+					{Value: 0.8},
+					{Value: 0.9, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeUtilizationMinNow,
+			query.SeriesNameFormat("Min"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodeUtilizationMaxNow is a gauge for the highest node memory utilization.
+func NodeMemoryNodeUtilizationMaxNow(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Node Utilization - max",
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{Unit: &dashboards.PercentDecimalUnit}),
+			gaugePanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.7},
+					{Value: 0.8},
+					{Value: 0.9, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeUtilizationMaxNow,
+			query.SeriesNameFormat("Max"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodePressureMaxNow is a gauge for peak memory PSI (pressure stall information).
+func NodeMemoryNodePressureMaxNow(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Node PSI - max",
+		panel.Description("Memory PSI (Pressure Stall Information)"),
+		panel.AddLink("https://access.redhat.com/solutions/6987181",
+			link.Name("Red Hat Customer Portal Article"),
+			link.TargetBlank(true),
+		),
+		panel.AddLink("https://www.kernel.org/doc/html/latest/accounting/psi.html",
+			link.Name("Upstream Linux Kernel PSI Documentation"),
+		),
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{
+				Unit:          &dashboards.DecimalUnit,
+				DecimalPlaces: 3,
+			}),
+			gaugePanel.Max(1),
+			gaugePanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.1},
+					{Value: 0.25},
+					{Value: 0.5, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodePressureMaxNow,
+			query.SeriesNameFormat("{{instance}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodeRequestsMinmaxNow shows min/max pod memory requests as a fraction of allocatable.
+func NodeMemoryNodeRequestsMinmaxNow(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Node Requests - min/max",
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{Unit: &dashboards.PercentDecimalUnit}),
+			statPanel.WithSparkline(statPanel.Sparkline{}),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.8, Color: "#FF9F1C"},
+					{Value: 0.9, Color: "#EA4747"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeRequestsMinNow,
+			query.SeriesNameFormat("Min"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeRequestsMaxNow,
+			query.SeriesNameFormat("Max"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryPlanMinmax shows min/max virtual commit level across nodes.
+func NodeMemoryPlanMinmax(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Node Virtual - min/max",
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{Unit: &dashboards.PercentDecimalUnit}),
+			statPanel.WithSparkline(statPanel.Sparkline{}),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 1.2},
+					{Value: 1.5, Color: "#FF9F1C"},
+					{Value: 2, Color: "#EA4747"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryPlanMinVirtualCommitLevel,
+			query.SeriesNameFormat("min {{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryPlanMaxVirtualCommitLevel,
+			query.SeriesNameFormat("max {{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodeSystemExceedsReservationAlertNow shows the share of nodes firing SystemMemoryExceedsReservation.
+func NodeMemoryNodeSystemExceedsReservationAlertNow(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("System Exceeding Reservation",
+		panel.Description("This panel provides the percentage of nodes where core system (hypervisor) components are utilizing more than reserved memory. This should not happen, and is specifically critical for clusters under load. Keep it green."),
+		panel.AddLink("https://access.redhat.com/solutions/5788171",
+			link.Name("Red Hat Customer Portal Article"),
+			link.TargetBlank(true),
+		),
+		panel.AddLink("https://github.com/openshift/runbooks/blob/master/alerts/machine-config-operator/SystemMemoryExceedsReservation.md",
+			link.Name("Upstream OpenShift Alert Runbook"),
+			link.Tooltip("Runbook"),
+		),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{Unit: &dashboards.PercentDecimalUnit}),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 1, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeSystemExceedsReservationAlertNow,
+			query.SeriesNameFormat("{{alertname}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryClusterPressure plots cluster memory pressure (waiting vs stalled).
+func NodeMemoryClusterPressure(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Cluster - Memory Pressure",
+		panel.Description("The pressure is indicating if workloads are waiting for memory."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit:        &dashboards.DecimalUnit,
+					ShortValues: true,
+				},
+				Max: 1,
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.1},
+					{Value: 0.25, Color: "#FF9F1C"},
+					{Value: 0.5, Color: "#EA4747"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterPressureWaiting,
+			query.SeriesNameFormat("Waiting"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterPressureStalled,
+			query.SeriesNameFormat("Stalled"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryClusterUtilizationHistory shows capacity, utilization, and planned requests over time.
+func NodeMemoryClusterUtilizationHistory(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Physical Memory Utilization & Requests",
+		panel.Description("This is showing the total system utilization (split between virt and non virt workloads). In addition the current plan (requests) are shown in order to to show how much available memory the scheduler is seeing."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+				Min: 0,
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.WithQuerySettings([]timeSeriesPanel.QuerySettingsItem{
+				{QueryIndex: 0, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#8f8fff"},
+				{QueryIndex: 1, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#EE6C6C"},
+				{QueryIndex: 2, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#643535"},
+				{QueryIndex: 3, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#FFCC00"},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationHistoryCapacity,
+			query.SeriesNameFormat("Node memory capacity"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationHistoryUtilWithVirt,
+			query.SeriesNameFormat("Utilization - Node memory utilization (with virt)"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationHistoryUtilWithoutVirt,
+			query.SeriesNameFormat("Utilization - Node memory utilization (without virt)"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationHistoryPlanRequests,
+			query.SeriesNameFormat("Plan - Memory requests"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryClusterUtilizationHistorySummary summarizes allocatable, VM plan, and utilization (worst-case view).
+func NodeMemoryClusterUtilizationHistorySummary(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Cluster Utilization",
+		panel.Description("The virtual memory assignment is showing the worst-case scenario if all virtual memory was used right now. The assigned virtual memory is shown on top of the non virtualization related memory utilization. The current utilization plus worst-case virtual memory utilization is indicating the worst case memory overcommitment."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+				Min: 0,
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.WithQuerySettings([]timeSeriesPanel.QuerySettingsItem{
+				{QueryIndex: 1, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#59CC8D"},
+				{QueryIndex: 2, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#FFCC00"},
+				{QueryIndex: 3, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#EE6C6C"},
+				{QueryIndex: 0, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#196b3e"},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0,
+				LineWidth:    1.25,
+				PointRadius:  2.75,
+				ConnectNulls: false,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationHistorySummaryAllocatablePlusSwap,
+			query.SeriesNameFormat("Cluster allocatable memory + swap capacity"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationHistorySummaryAllocatable,
+			dashboards.AddQueryDataSource(datasourceName),
+			query.SeriesNameFormat("Cluster allocatable memory capacity"),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationHistorySummaryPlanVMAssigned,
+			query.SeriesNameFormat("Plan - VM assigned virtual memory"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationHistorySummaryUtilizationCluster,
+			query.SeriesNameFormat("Utilization - Cluster memory utilization"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterUtilizationHistorySummaryPlanMaxVMAssigned,
+			query.SeriesNameFormat("Plan - Maximum VM assigned virtual memory"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryClusterVirtualCommittedHistory shows virtual memory assignment vs capacity over time.
+func NodeMemoryClusterVirtualCommittedHistory(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Virtual Memory Assignment",
+		panel.Description("The virtual memory assignment is showing the worst-case scenario if all virtual memory was used right now. The assigned virtual memory is shown on top of the non virtualization related memory utilization. The current utilization plus worst-case virtual memory utilization is indicating the worst case memory overcommitment."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+				Min: 0,
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.WithQuerySettings([]timeSeriesPanel.QuerySettingsItem{
+				{QueryIndex: 0, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#8f8fff"},
+				{QueryIndex: 1, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#FFCC00"},
+				{QueryIndex: 2, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#7c6400"},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0,
+				LineWidth:    1.25,
+				PointRadius:  2.75,
+				ConnectNulls: false,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterVirtualCommittedHistoryNodeCapacity,
+			query.SeriesNameFormat("Node capacity"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterVirtualCommittedHistoryPlanVMAssigned,
+			query.SeriesNameFormat("Plan - VM assigned virtual memory"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryClusterVirtualCommittedHistoryUtilWithoutVirt,
+			query.SeriesNameFormat("Utilization - Node memory utilization (without virt)"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodePressureHistory plots memory PSI waiting rate per instance.
+func NodeMemoryNodePressureHistory(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Node - Pressure",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit:        &dashboards.DecimalUnit,
+					ShortValues: true,
+				},
+				Min: 0,
+				Max: 2,
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodePressureHistory,
+			query.SeriesNameFormat("{{instance}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodeRequestsHistory shows pod memory requests as a fraction of node allocatable.
+func NodeMemoryNodeRequestsHistory(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Plan - Pod Requests per Node",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.8, Color: "#FFB249"},
+					{Value: 0.9, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeRequestsHistory,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodeUtilizationHistory shows actual memory overcommit level per node.
+func NodeMemoryNodeUtilizationHistory(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Utilization - Actual Overcommit Level",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.8, Color: "#FFB249"},
+					{Value: 0.9, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeUtilizationHistory,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryUtilizationDistribution plots per-node virtual memory commit level.
+func NodeMemoryUtilizationDistribution(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Plan - Virtual Memory Commit Level",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 1.2},
+					{Value: 1.5, Color: "#FF9F1C"},
+					{Value: 2, Color: "#EA4747"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryUtilizationDistribution,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemorySwap shows aggregated cluster swap available vs used.
+func NodeMemorySwap(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Cluster - Aggregated Swap",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.WithQuerySettings([]timeSeriesPanel.QuerySettingsItem{
+				{QueryIndex: 0, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#59CC8D"},
+				{QueryIndex: 1, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#FFB249"},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemorySwapAvailableBytes,
+			query.SeriesNameFormat("Available"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemorySwapUsedBytes,
+			query.SeriesNameFormat("Used"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodeSystemReservedUtilizationHistory shows top nodes by system reserved memory utilization.
+func NodeMemoryNodeSystemReservedUtilizationHistory(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Utilization - Reserved System Memory",
+		panel.Description("This graph is showing the utilization of the hypervisor system reserved memory. The utilization must stay below 100%, otherwise the hypervisor is using more memory for system processes than what was reserved. This is putting system processes at risk."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.9},
+					{Value: 1, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeSystemReservedUtilizationHistory,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNodeSystemReservedMinmaxHistory shows min and max system reserved utilization across nodes.
+func NodeMemoryNodeSystemReservedMinmaxHistory(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Utilization - min/max",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0.9, Color: "#EE6C6C"},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeSystemReservedMinHistory,
+			query.SeriesNameFormat("min {{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNodeSystemReservedMaxHistory,
+			query.SeriesNameFormat("max {{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryVMs plots per-VM memory overcommit ratio (domain + overhead vs request).
+func NodeMemoryVMs(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VM Overcommit Ratio",
+		panel.Description("Any value larger than 1 shows that the VM is using more memory than it requested"),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 1},
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryVMsOvercommitRatio,
+			query.SeriesNameFormat("{{namespace}}/{{label_vm_kubevirt_io_name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryVMVirtualMemoryUtilization compares VM guest memory used to launcher usage (top 10).
+func NodeMemoryVMVirtualMemoryUtilization(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VM Virtual Memory Utilization vs Host VM Utilization",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+				Min: 0,
+			}),
+			timeSeriesPanel.WithLegend(memoryTSBottomLegend()),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 1},
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0,
+				LineWidth:    1.25,
+				PointRadius:  2.75,
+				ConnectNulls: false,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryVMVirtualMemoryUtilizationHostVMRatio,
+			query.SeriesNameFormat("{{namespace}}/{{label_vm_kubevirt_io_name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// NodeMemoryNumberOfRunningVMs counts running VMs via kubevirt_vmi_memory_domain_bytes.
+func NodeMemoryNumberOfRunningVMs(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Number of Running VMs",
+		timeSeriesPanel.Chart(),
+		panel.AddQuery(query.PromQL(
+			nodeMemoryNumberOfRunningVMs,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}

--- a/internal/perses/panels/virtualization/node-memory-queries.go
+++ b/internal/perses/panels/virtualization/node-memory-queries.go
@@ -1,0 +1,381 @@
+package virtualization
+
+// ClusterPressure
+const (
+	nodeMemoryClusterPressureWaiting = `sum(rate(node_pressure_memory_waiting_seconds_total{cluster=~"$cluster", instance=~"$node"}[10m]))`
+	nodeMemoryClusterPressureStalled = `sum(rate(node_pressure_memory_stalled_seconds_total{cluster=~"$cluster", instance=~"$node"}[10m]))`
+)
+
+// ClusterUtilizationHistory
+const (
+	nodeMemoryClusterUtilizationHistoryCapacity = `sum((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))`
+
+	nodeMemoryClusterUtilizationHistoryUtilWithVirt = `sum((label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})
+)`
+
+	nodeMemoryClusterUtilizationHistoryUtilWithoutVirt = `sum((label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})
+) - sum(kubevirt_vmi_memory_used_bytes{cluster=~"$cluster", node=~"$node"})`
+
+	nodeMemoryClusterUtilizationHistoryPlanRequests = `(sum((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})) - sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})))
++
+sum(kube_pod_resource_request{cluster=~"$cluster", resource="memory", node=~"$node"})`
+)
+
+// ClusterUtilizationHistorySummary
+const (
+	nodeMemoryClusterUtilizationHistorySummaryAllocatablePlusSwap = `sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})) + sum(label_replace(node_memory_SwapTotal_bytes{cluster=~"$cluster", instance=~"$node"}, "node", "$1", "instance", "(.+)"))`
+
+	nodeMemoryClusterUtilizationHistorySummaryAllocatable = `sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))`
+
+	nodeMemoryClusterUtilizationHistorySummaryPlanVMAssigned = `# all used - system reserved + plan vm
+sum((label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})
+)
+-
+(sum((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})) - sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})))
+
+-
+sum(kubevirt_vmi_memory_used_bytes{cluster=~"$cluster", node=~"$node"})
+
++
+sum(kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster", node=~"$node"})`
+
+	nodeMemoryClusterUtilizationHistorySummaryUtilizationCluster = `sum((label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+(sum((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})) - sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})))`
+
+	nodeMemoryClusterUtilizationHistorySummaryPlanMaxVMAssigned = `scalar(kubevirt_hco_memory_overcommit_percentage{cluster=~"$cluster"} / 100)
+
+*
+
+sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))`
+)
+
+// ClusterUtilizationNow (physical memory utilization ratio)
+const nodeMemoryClusterUtilizationNowPhysicalRatio = `(
+sum((label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+(sum((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})) - sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})))
+)
+
+/
+
+(
+sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)`
+
+// ClusterVirtualCommittedHistory
+const (
+	nodeMemoryClusterVirtualCommittedHistoryNodeCapacity = `sum((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))`
+
+	nodeMemoryClusterVirtualCommittedHistoryPlanVMAssigned = `sum((label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+(sum((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})) - sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})))
++
+sum(kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster", node=~"$node"})`
+
+	nodeMemoryClusterVirtualCommittedHistoryUtilWithoutVirt = `sum((label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum(kubevirt_vmi_memory_used_bytes{cluster=~"$cluster", node=~"$node"})`
+)
+
+// ClusterVirtualCommittedNow (virtual memory commitment ratio)
+const nodeMemoryClusterVirtualCommittedNowRatio = `(
+sum((label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) group_left() kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+(sum((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) group_left() kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})) - sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) group_left() kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})))
++
+sum(kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster", node=~"$node"})
+)
+
+/
+
+(
+sum((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) group_left() kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)`
+
+// NodePressureHistory
+const nodeMemoryNodePressureHistory = `sum by (instance) (rate(node_pressure_memory_waiting_seconds_total{cluster=~"$cluster", instance=~"$node"}[10m]))`
+
+// NodePressureMaxNow
+const nodeMemoryNodePressureMaxNow = `topk(1, (sum by (instance) (rate(node_pressure_memory_waiting_seconds_total{cluster=~"$cluster", instance=~"$node"}[10m]@end()))))`
+
+// NodeRequestsHistory
+const nodeMemoryNodeRequestsHistory = `sum by (node) (kube_pod_resource_request{cluster=~"$cluster", resource="memory", node=~"$node"})
+
+/ on (node)
+
+(
+(kube_node_status_allocatable{cluster=~"$cluster", resource="memory"} * on (node) kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})
+)`
+
+// NodeRequestsMinmaxNow
+const (
+	nodeMemoryNodeRequestsMinNow = `min(
+sum by (node) (kube_pod_resource_request{cluster=~"$cluster", resource="memory", node=~"$node"})
+
+/ on (node)
+
+(
+(kube_node_status_allocatable{cluster=~"$cluster", resource="memory"} * on (node) kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})
+)
+)`
+
+	nodeMemoryNodeRequestsMaxNow = `max(
+sum by (node) (kube_pod_resource_request{cluster=~"$cluster", resource="memory", node=~"$node"})
+
+/ on (node)
+
+(
+(kube_node_status_allocatable{cluster=~"$cluster", resource="memory"} * on (node) kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})
+)
+)`
+)
+
+// NodeSystemExceedsReservationAlertNow
+const nodeMemoryNodeSystemExceedsReservationAlertNow = `(count(ALERTS{cluster=~"$cluster", alertname="SystemMemoryExceedsReservation"}) or vector(0))
+/
+count(ALERTS{cluster=~"$cluster", alertname="Watchdog"})`
+
+// NodeSystemReservedMinmaxHistory
+const (
+	nodeMemoryNodeSystemReservedMinHistory = `min(
+sum by (node) (container_memory_rss{cluster=~"$cluster", cgroup_id="/system.slice"})
+
+/ on (node)
+
+(
+sum by (node) ((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum by (node) ((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)
+)`
+
+	nodeMemoryNodeSystemReservedMaxHistory = `max(
+sum by (node) (container_memory_rss{cluster=~"$cluster", cgroup_id="/system.slice"})
+
+/ on (node)
+
+(
+sum by (node) ((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum by (node) ((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)
+
+)`
+)
+
+// NodeSystemReservedUtilizationHistory
+const nodeMemoryNodeSystemReservedUtilizationHistory = `topk(5, (
+sum by (node) (container_memory_rss{cluster=~"$cluster", cgroup_id="/system.slice"})
+
+/ on (node)
+
+(
+sum by (node) ((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum by (node) ((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)
+))`
+
+// NodeUtilizationHistory
+const nodeMemoryNodeUtilizationHistory = `(
+label_replace((
+(label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})
+), "node", "$1", "instance", "(.+)")
+- on (node)
+(
+sum by (node) ((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum by (node) ((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)
+)
+
+/ on (node)
+
+(
+(kube_node_status_allocatable{cluster=~"$cluster", resource="memory"} * on (node) kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})
+)`
+
+// NodeUtilizationMaxNow
+const nodeMemoryNodeUtilizationMaxNow = `(max by () ((
+label_replace((
+(label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})
+), "node", "$1", "instance", "(.+)")
+- on (node)
+(
+sum by (node) ((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum by (node) ((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)
+)
+
+/ on (node)
+
+(
+(kube_node_status_allocatable{cluster=~"$cluster", resource="memory"} * on (node) kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})
+))
+)`
+
+// NodeUtilizationMinNow
+const nodeMemoryNodeUtilizationMinNow = `(min by () ((
+label_replace((
+(label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})
+), "node", "$1", "instance", "(.+)")
+- on (node)
+(
+sum by (node) ((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum by (node) ((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)
+)
+
+/ on (node)
+
+(
+(kube_node_status_allocatable{cluster=~"$cluster", resource="memory"} * on (node) kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})
+))
+)`
+
+// NumberofrunningVMs
+const nodeMemoryNumberOfRunningVMs = `count(max by (cluster, namespace, name, node)(kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster"}) * on(node) group_left() kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})`
+
+// PlanMinmax (virtual commit level per node)
+const (
+	nodeMemoryPlanMinVirtualCommitLevel = `(min by () ((
+
+(
+(
+label_replace((
+(label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})
+), "node", "$1", "instance", "(.+)")
+- on (node)
+(
+sum by (node) ((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum by (node) ((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)
+)
++
+sum by (node) (kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster"})
+)
+
+
+/
+
+(kube_node_status_allocatable{cluster=~"$cluster", resource="memory"} * on (node) kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})
+
+)))`
+
+	nodeMemoryPlanMaxVirtualCommitLevel = `(max by () ((
+
+(
+(
+label_replace((
+(label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})
+), "node", "$1", "instance", "(.+)")
+- on (node)
+(
+sum by (node) ((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum by (node) ((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)
+)
++
+sum by (node) (kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster"})
+)
+
+
+/
+
+(kube_node_status_allocatable{cluster=~"$cluster", resource="memory"} * on (node) kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})
+
+)))`
+)
+
+// Swap (total capacity and used bytes per dashboard)
+const (
+	nodeMemorySwapAvailableBytes = `sum((
+label_replace(
+  (node_memory_SwapTotal_bytes{cluster=~"$cluster", instance=~"$node"}),
+  "node", "$1",
+  "instance", "(.+)"
+) * on (node) kube_node_role{cluster=~"$cluster", role="$role", node=~"$node"}
+)
+)`
+
+	nodeMemorySwapUsedBytes = `sum((
+label_replace(
+  (node_memory_SwapTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_SwapFree_bytes{cluster=~"$cluster", instance=~"$node"}),
+  "node", "$1",
+  "instance", "(.+)"
+) * on (node) kube_node_role{cluster=~"$cluster", role="$role", node=~"$node"}
+)
+)`
+)
+
+// UtilizationDistribution (virtual memory commit level per node)
+const nodeMemoryUtilizationDistribution = `(
+(
+label_replace((
+(label_replace((node_memory_MemTotal_bytes{cluster=~"$cluster", instance=~"$node"} - node_memory_MemAvailable_bytes{cluster=~"$cluster", instance=~"$node"}), "node", "$1", "instance", "(.+)") * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"})
+), "node", "$1", "instance", "(.+)")
+- on (node)
+(
+sum by (node) ((kube_node_status_capacity{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+-
+sum by (node) ((kube_node_status_allocatable{resource="memory", cluster=~"$cluster", node=~"$node"} * on (node) kube_node_role{role="$role", cluster=~"$cluster", node=~"$node"}))
+)
+)
++
+sum by (node) (kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster"})
+)
+
+
+/
+
+(kube_node_status_allocatable{cluster=~"$cluster", resource="memory"} * on (node) kube_node_role{cluster=~"$cluster", node=~"$node", role=~"$role"})`
+
+// VMs (VM overcommit ratio)
+const nodeMemoryVMsOvercommitRatio = `(label_replace(max by (cluster, namespace, name)(kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster"}), "label_vm_kubevirt_io_name", "$1", "name", "(.+)"))
+
+/ on (namespace, label_vm_kubevirt_io_name) group_left()
+
+max by (namespace, label_vm_kubevirt_io_name) (
+  group by(namespace, pod, label_vm_kubevirt_io_name) (
+    kube_pod_labels{cluster=~"$cluster", label_vm_kubevirt_io_name!=""}
+  )
+  * on(namespace, pod) group_left()
+  max by (namespace, pod) (kube_pod_resource_request{cluster=~"$cluster", resource="memory"})
+)`
+
+// VMvirtualmemoryutiliztaionhostvmurilization (top 10 VM memory used ratio)
+const nodeMemoryVMVirtualMemoryUtilizationHostVMRatio = `topk(10, (label_replace(max by (cluster, namespace, name)(kubevirt_vmi_memory_used_bytes{cluster=~"$cluster"}@end()), "label_vm_kubevirt_io_name", "$1", "name", "(.+)"))
+
+/ on (namespace, label_vm_kubevirt_io_name) group_left()
+
+sum by (namespace, label_vm_kubevirt_io_name) (
+  group by(namespace, pod, label_vm_kubevirt_io_name) (
+    kube_pod_labels{cluster=~"$cluster", label_vm_kubevirt_io_name!=""}
+  )
+  * on(namespace, pod) group_left()
+  max by (namespace, pod) (container_memory_usage_bytes{cluster=~"$cluster"})
+)
+)`
+
+// VmVirtualCommittedNow (average VM overcommit ratio)
+const nodeMemoryVMVirtualCommittedNowAvgOvercommit = `avg(
+(
+(label_replace(max by (cluster, namespace, name)(kubevirt_vmi_memory_domain_bytes{cluster=~"$cluster"}), "label_vm_kubevirt_io_name", "$1", "name", "(.+)"))
++ on(cluster, name, namespace) group_left() max by (cluster, name, namespace)(kubevirt_vmi_launcher_memory_overhead_bytes{cluster=~"$cluster"})
+)
+
+/ on (namespace, label_vm_kubevirt_io_name) group_left()
+
+max by (namespace, label_vm_kubevirt_io_name) (
+  group by(namespace, pod, label_vm_kubevirt_io_name) (
+    kube_pod_labels{cluster=~"$cluster", label_vm_kubevirt_io_name!=""}
+  )
+  * on(namespace, pod) group_left()
+  max by (namespace, pod) (kube_pod_resource_request{cluster=~"$cluster", resource="memory"})
+)
+)`

--- a/internal/perses/panels/virtualization/overview-panel.go
+++ b/internal/perses/panels/virtualization/overview-panel.go
@@ -1,0 +1,792 @@
+package virtualization
+
+import (
+	"encoding/json"
+	"maps"
+
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/link"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	timeSeriesPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+// mergePluginSpecFields JSON-roundtrips the current plugin spec into a map and
+// merges extra fields into it. It must be applied AFTER any typed panel builders
+// (e.g. timeSeriesPanel.Chart) — typed builders overwrite Spec with a fresh
+// struct, so any fields merged before them will be silently dropped.
+// Keep mergePluginSpecFields last in a panel's option list.
+func mergePluginSpecFields(extra map[string]any) panel.Option {
+	return func(b *panel.Builder) error {
+		raw, err := json.Marshal(b.Spec.Plugin.Spec)
+		if err != nil {
+			return err
+		}
+		base := map[string]any{}
+		if len(raw) > 0 && string(raw) != "null" {
+			if err := json.Unmarshal(raw, &base); err != nil {
+				return err
+			}
+		}
+		maps.Copy(base, extra)
+		b.Spec.Plugin.Spec = base
+		return nil
+	}
+}
+
+// OverviewTotalClusters (0_0)
+func OverviewTotalClusters(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Clusters",
+		panel.Description("Total clusters with OpenShift Virtualization."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			overviewTotalClusters,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewClustersCriticalHealth (0_1)
+func OverviewClustersCriticalHealth(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Clusters in Critical Health",
+		panel.Description("Total number of clusters with critical issues that impact the operator health, which are based on alerts and the operator conditions. This means there is a risk of core functionality loss for your clusters."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0, Color: "#f2495c"},
+				},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "value"}),
+		panel.AddQuery(query.PromQL(
+			overviewClustersCriticalHealth,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewTotalAllocatableNodes (0_2)
+func OverviewTotalAllocatableNodes(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Allocatable Nodes",
+		panel.Description("Total number of nodes that are available to host virtual machines."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+			statPanel.Format(commonSdk.Format{Unit: &dashboards.DecimalUnit}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none", "metricLabel": ""}),
+		panel.AddQuery(query.PromQL(
+			overviewTotalAllocatableNodes,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewTotalVMsStat (0_3)
+func OverviewTotalVMsStat(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Total VMs",
+		panel.Description("Total number of virtual machines."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode":   "none",
+			"metricLabel": "",
+		}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, ""),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewTotalVMs,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewVMsRunning (0_4a)
+func OverviewVMsRunning(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Running VMs",
+		panel.Description("Number of virtual machines currently running."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "running"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusStatRunning,
+			query.SeriesNameFormat("Running"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewVMsInErrorStat (0_4b) — red when ≥1.
+func OverviewVMsInErrorStat(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs in Error",
+		panel.Description("Number of virtual machines currently in an error state. Any value above zero requires attention."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				DefaultColor: "#808080",
+				Steps: []commonSdk.StepOption{
+					{Value: 1, Color: "#f2495c"},
+				},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "value"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "error"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusStatError,
+			query.SeriesNameFormat("Error"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewVMsStopped (0_4c)
+func OverviewVMsStopped(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Stopped VMs",
+		panel.Description("Number of virtual machines currently stopped."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "non_running"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusStatStopped,
+			query.SeriesNameFormat("Stopped"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewVMsStarting (0_4d)
+func OverviewVMsStarting(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Starting VMs",
+		panel.Description("Number of virtual machines currently starting up."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "starting"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusStatStarting,
+			query.SeriesNameFormat("Starting"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewVMsMigrating (0_4e)
+func OverviewVMsMigrating(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Migrating VMs",
+		panel.Description("Number of virtual machines currently being migrated."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "migrating"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusStatMigrating,
+			query.SeriesNameFormat("Migrating"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewClustersWarningHealth (0_5)
+func OverviewClustersWarningHealth(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Clusters in Warning Health",
+		panel.Description("Total number of clusters with warning level issues that impact the operator health, which are based on alerts and the operator conditions. This means there is a risk of core functionality loss for your clusters."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0, Color: "#ff9830"},
+				},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "value"}),
+		panel.AddQuery(query.PromQL(
+			overviewClustersWarningHealth,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewVMsStartedLast7Days (0_6)
+func OverviewVMsStartedLast7Days(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Number of VMs Started in the Last 7 Days",
+		tablePanel.Table(),
+		mergePluginSpecFields(map[string]any{
+			"columnSettings": []any{
+				map[string]any{
+					"name":          "cluster",
+					"enableSorting": true,
+					"dataLink": map[string]any{
+						"openNewTab": true,
+						"title":      "Cluster Details",
+						"url":        clusterDetailsDashboardLinkURL(project),
+					},
+				},
+				map[string]any{"name": "timestamp", "hide": true},
+				map[string]any{"name": "value", "header": "Total VMs Started", "enableSorting": true},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			overviewVMsStartedLast7Days,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+var overviewTableMergeJoinByCluster = []commonSdk.Transform{
+	{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+	{Kind: commonSdk.JoinByColumValueKind, Spec: commonSdk.JoinByColumnValueSpec{Columns: []string{"cluster"}}},
+}
+
+// OverviewClustersByOperatorVersion (0_7)
+func OverviewClustersByOperatorVersion(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Clusters by Operator Version",
+		tablePanel.Table(
+			tablePanel.Transform([]commonSdk.Transform{
+				{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+				{Kind: commonSdk.JoinByColumValueKind, Spec: commonSdk.JoinByColumnValueSpec{Columns: []string{"version"}}},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{
+			"columnSettings": []any{
+				map[string]any{"name": "timestamp", "hide": true},
+				map[string]any{"name": "version", "header": "OpenShift Virtualization Operator Version", "enableSorting": true},
+				map[string]any{"name": "phase", "hide": true},
+				map[string]any{"name": "reason", "hide": true},
+				map[string]any{"name": "value", "hide": true},
+				map[string]any{"name": "value #1", "header": "# of Clusters", "enableSorting": true, "width": 104},
+				map[string]any{"name": "value #2", "header": "% of Total Clusters", "enableSorting": true, "format": map[string]any{"unit": "percent-decimal"}, "width": 136},
+				map[string]any{"name": "openshiftVersion", "hide": true},
+				map[string]any{"name": "Time 1", "hide": true},
+				map[string]any{"name": "Time 2", "hide": true},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			overviewClustersByOperatorVersionCounts,
+			query.SeriesNameFormat("{{version}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewClustersByOperatorVersionPercent,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewClustersByOpenShiftVersion (0_8)
+func OverviewClustersByOpenShiftVersion(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Clusters by OpenShift Version",
+		tablePanel.Table(
+			tablePanel.Transform([]commonSdk.Transform{
+				{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+				{Kind: commonSdk.JoinByColumValueKind, Spec: commonSdk.JoinByColumnValueSpec{Columns: []string{"openshiftVersion"}}},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{
+			"columnSettings": []any{
+				map[string]any{"name": "timestamp", "hide": true},
+				map[string]any{"name": "openshiftVersion", "header": "OpenShift Version", "enableSorting": true},
+				map[string]any{"name": "value", "hide": true},
+				map[string]any{"name": "value #1", "header": "# of Clusters", "enableSorting": true, "width": 104},
+				map[string]any{"name": "value #2", "header": "% of Total Clusters", "enableSorting": true, "format": map[string]any{"unit": "percent-decimal"}, "width": 136},
+				map[string]any{"name": "Time 1", "hide": true},
+				map[string]any{"name": "Time 2", "hide": true},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			overviewClustersByOpenShiftVersionCounts,
+			query.SeriesNameFormat("{{openshiftVersion}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewClustersByOpenShiftVersionPercent,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewOperatorHealthByCluster (1_0)
+func OverviewOperatorHealthByCluster(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Operator Health by Cluster",
+		tablePanel.Table(
+			tablePanel.Transform(overviewTableMergeJoinByCluster),
+		),
+		mergePluginSpecFields(map[string]any{
+			"columnSettings": []any{
+				map[string]any{
+					"name": "value #1", "header": "Operator Health", "enableSorting": true,
+					"cellSettings": []any{
+						map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "0"}}, "text": "Healthy", "backgroundColor": "#73BF69"},
+						map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "1"}}, "text": "Warning", "backgroundColor": "#ff9830"},
+						map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "2"}}, "text": "Critical", "backgroundColor": "#f2495c"},
+					},
+				},
+				map[string]any{
+					"name": "cluster", "header": "Cluster", "enableSorting": true,
+					"dataLink": map[string]any{
+						"openNewTab": true,
+						"title":      "Cluster Details",
+						"url":        clusterDetailsDashboardLinkURL(project),
+					},
+				},
+				map[string]any{"name": "openshiftVersion", "hide": true},
+				map[string]any{
+					"name": "value #5", "header": "Operator Conditions Health", "enableSorting": true,
+					"cellSettings": []any{
+						map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "0"}}, "text": "Healthy", "textColor": "#73BF69"},
+						map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "1"}}, "text": "Warning", "textColor": "#ff9830"},
+						map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "2"}}, "text": "Error", "textColor": "#f2495c"},
+					},
+				},
+				map[string]any{"name": "value #2", "header": "Alerts with Critical Impact", "enableSorting": true},
+				map[string]any{"name": "value #3", "header": "Alerts with Warning Impact", "enableSorting": true},
+				map[string]any{"name": "value #4", "header": "Number of Running VMs", "enableSorting": true},
+				map[string]any{"name": "Time 1", "header": "", "hide": true},
+				map[string]any{"name": "Time 2", "header": "", "hide": true},
+				map[string]any{"name": "Time 3", "hide": true},
+				map[string]any{"name": "Time 4", "hide": true},
+				map[string]any{"name": "Time 5", "hide": true},
+				map[string]any{"name": "Time 6", "hide": true},
+				map[string]any{"name": "timestamp", "hide": true},
+				map[string]any{"name": "__name__", "hide": true},
+				map[string]any{"name": "clusterID", "hide": true},
+				map[string]any{"name": "clusterType", "hide": true},
+				map[string]any{"name": "endpoint", "hide": true},
+				map[string]any{"name": "instance", "hide": true},
+				map[string]any{"name": "job", "hide": true},
+				map[string]any{"name": "namespace", "hide": true},
+				map[string]any{"name": "pod", "hide": true},
+				map[string]any{"name": "receive", "hide": true},
+				map[string]any{"name": "service", "hide": true},
+				map[string]any{"name": "tenant_id", "hide": true},
+				map[string]any{"name": "value", "hide": true},
+				map[string]any{"name": "version", "hide": true},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			overviewOperatorHealthByClusterStatus,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewOperatorHealthByClusterCriticalAlerts,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewOperatorHealthByClusterWarningAlerts,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewOperatorHealthByClusterRunningVMs,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewOperatorHealthByClusterHCO,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func overviewPieChartPlugin() panel.Option {
+	return func(b *panel.Builder) error {
+		b.Spec.Plugin.Kind = "PieChart"
+		b.Spec.Plugin.Spec = map[string]any{
+			"calculation": "last-number",
+			"format":      map[string]any{"unit": "decimal"},
+			"legend":      map[string]any{"mode": "table", "position": "right", "values": []string{"abs", "relative"}},
+			"radius":      50,
+		}
+		return nil
+	}
+}
+
+// OverviewRunningVMsByOS (2_0)
+func OverviewRunningVMsByOS(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Running VMs by OS",
+		overviewPieChartPlugin(),
+		panel.AddQuery(query.PromQL(
+			overviewRunningVMsByOSKnown,
+			query.SeriesNameFormat("{{os}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewRunningVMsByOSUnknown,
+			query.SeriesNameFormat("{{os}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func overviewTSChartLegendLast() timeSeriesPanel.Legend {
+	return timeSeriesPanel.Legend{
+		Position: timeSeriesPanel.RightPosition,
+		Mode:     timeSeriesPanel.TableMode,
+		Values:   []commonSdk.Calculation{commonSdk.LastNumberCalculation},
+	}
+}
+
+func overviewTSChartLegendLastMax() timeSeriesPanel.Legend {
+	return timeSeriesPanel.Legend{
+		Position: timeSeriesPanel.RightPosition,
+		Mode:     timeSeriesPanel.TableMode,
+		Values:   []commonSdk.Calculation{commonSdk.LastNumberCalculation, commonSdk.MaxCalculation},
+	}
+}
+
+// OverviewRunningVMsByClusterTop20 (2_1)
+func OverviewRunningVMsByClusterTop20(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Running VMs by Cluster - Top 20",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLast()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &dashboards.DecimalUnit},
+				Min:    0,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    2,
+				AreaOpacity:  0.11,
+				ConnectNulls: true,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{
+			"visual": map[string]any{
+				"display": "line", "lineWidth": 2, "areaOpacity": 0.11, "connectNulls": true, "lineStyle": "solid",
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			overviewRunningVMsByClusterTop20,
+			query.SeriesNameFormat("{{cluster}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewVMsByStatusTimeSeries (2_2)
+func OverviewVMsByStatusTimeSeries(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Virtual Machines by Status",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLast()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &dashboards.DecimalUnit},
+				Min:    0,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0,
+				ConnectNulls: false,
+			}),
+			timeSeriesPanel.WithQuerySettings([]timeSeriesPanel.QuerySettingsItem{
+				{QueryIndex: 3, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#f2495c"},
+				{QueryIndex: 4, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#1f60c4"},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusTSRunning,
+			query.SeriesNameFormat("running"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusTSStarting,
+			query.SeriesNameFormat("starting"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusTSMigrating,
+			query.SeriesNameFormat("migrating"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusTSError,
+			query.SeriesNameFormat("error"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			overviewVMsByStatusTSStopped,
+			query.SeriesNameFormat("stopped"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewRunningVMsByNodeTop20 (2_3)
+func OverviewRunningVMsByNodeTop20(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Running VMs by Node - Top 20",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLast()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit:          &dashboards.DecimalUnit,
+					DecimalPlaces: 0,
+				},
+				Min: 0,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+				Stack:        timeSeriesPanel.AllStack,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewRunningVMsByNodeTop20,
+			query.SeriesNameFormat("{{cluster}} | {{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewCPUUsageByCluster (3_0)
+func OverviewCPUUsageByCluster(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage by Cluster",
+		panel.Description("This panel displays the top 20 clusters based on their VMs CPU usage over the past 10 minutes. CPU usage is calculated as the total CPU time consumed by VMs. This provides insight into clusters with the highest CPU demand and helps identify potential resource bottlenecks."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLastMax()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &dashboards.SecondsUnit},
+				Min:    0,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewCPUUsageByClusterTop20,
+			query.SeriesNameFormat("{{cluster}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewCPUUsagePercentByCluster (3_1)
+func OverviewCPUUsagePercentByCluster(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Clusters by CPU Usage (%)",
+		panel.Description("This panel displays the top 20 clusters based on their CPU usage percentage for clusters running virtual machines (VMs) over the past 10 minutes. CPU usage is calculated as the total CPU time consumed by VMs divided by the total CPU capacity of all nodes in the cluster. This provides insight into how much of the cluster's overall CPU capacity is consumed by VM workloads."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLastMax()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &dashboards.PercentDecimalUnit},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewCPUUsagePercentByClusterTop20,
+			query.SeriesNameFormat("{{cluster}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewMemoryUsageByCluster (4_0)
+func OverviewMemoryUsageByCluster(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage by Cluster",
+		panel.Description("Top 20 Clusters based on the VMs memory usage in the clusters"),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLastMax()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &dashboards.BytesUnit},
+				Min:    0,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0.3,
+				ConnectNulls: false,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewMemoryUsageByClusterTop20,
+			query.SeriesNameFormat("{{cluster}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewMemoryUsagePercentByCluster (4_1)
+func OverviewMemoryUsagePercentByCluster(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage by Cluster (%)",
+		panel.Description("Top 20 clusters based on VM memory usage as a percentage of total physical memory across all nodes in the cluster."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLastMax()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &dashboards.PercentDecimalUnit},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0.3,
+				ConnectNulls: false,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewMemoryUsagePercentByClusterTop20,
+			query.SeriesNameFormat("{{cluster}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewNetworkReceivedByCluster (5_0)
+func OverviewNetworkReceivedByCluster(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Clusters by Network Received Bytes",
+		panel.Description("This panel displays the top 20 clusters by network received bytes per second over the past 10 minutes. The query measures the rate of incoming network traffic, helping identify clusters with the highest network activity. Use this information to monitor and optimize resource usage for workloads with significant data reception."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLastMax()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &decBytesPerSecUnit},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0.1,
+				ConnectNulls: true,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewNetworkReceivedBytesByClusterTop20,
+			query.SeriesNameFormat("{{cluster}} - Receive"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewNetworkTransmittedByCluster (5_1)
+func OverviewNetworkTransmittedByCluster(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Clusters by Network Transmitted Bytes",
+		panel.Description("This panel displays the top 20 clusters by network transmitted bytes per second over the past 10 minutes. The query measures the rate of outgoing network traffic, helping identify clusters with the highest network activity. Use this information to monitor and optimize resource usage for workloads with significant data transmission."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLastMax()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &decBytesPerSecUnit},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0.1,
+				ConnectNulls: true,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			overviewNetworkTransmittedBytesByClusterTop20,
+			query.SeriesNameFormat("{{cluster}} - Transmit"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewStorageTrafficByCluster (6_0)
+func OverviewStorageTrafficByCluster(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Storage Traffic by Cluster",
+		panel.Description("This panel displays the top 20 clusters based on their combined storage traffic (read + write) over the past 10 minutes."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLastMax()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &decBytesPerSecUnit},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{
+			"visual": map[string]any{
+				"display": "line", "lineStyle": "solid", "lineWidth": 1, "areaOpacity": 0.1, "connectNulls": false,
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			overviewStorageTrafficByClusterTop20,
+			query.SeriesNameFormat("{{cluster}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// OverviewStorageIOPsByCluster (6_1)
+func OverviewStorageIOPsByCluster(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Storage IOPS by Cluster",
+		panel.Description("This panel displays the top 20 clusters based on their combined storage IOPS (read + write) over the past 10 minutes."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(overviewTSChartLegendLastMax()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &opsPerSecUnit, ShortValues: true},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				LineWidth:    1,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{
+			"visual": map[string]any{
+				"display": "line", "lineStyle": "solid", "lineWidth": 1, "areaOpacity": 0.1, "connectNulls": false,
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			overviewStorageIOPsByClusterTop20,
+			query.SeriesNameFormat("{{cluster}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}

--- a/internal/perses/panels/virtualization/overview-queries.go
+++ b/internal/perses/panels/virtualization/overview-queries.go
@@ -1,0 +1,163 @@
+package virtualization
+
+// overviewHealthJoin filters series to only clusters matching the $operator_health variable.
+// Appended as +on(cluster) group_left()(...) to per-cluster queries whose result
+// already has a cluster label. The left side must end with a closing ) from an
+// aggregation or explicit grouping — never after a bare comparison operator.
+const overviewHealthJoin = `+on(cluster) group_left()(0*sum by (cluster)(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}$operator_health))`
+
+// overviewHealthAnd filters series via set intersection (and on(cluster)).
+// Use instead of overviewHealthJoin when the left side ends with a comparison
+// operator (==, !=, <, >, <=, >=) to avoid PromQL precedence issues, or when
+// the original query counts raw series rather than per-cluster aggregates.
+// "and" has lower precedence than all comparison and arithmetic operators, so
+// it is always safe to append without extra parentheses.
+const overviewHealthAnd = ` and on(cluster) sum by (cluster)(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}$operator_health)`
+
+// overviewHealthFilteredClusters is the set of clusters passing the health filter,
+// used inside aggregate queries that need to restrict clusters before aggregation.
+const overviewHealthFilteredClusters = `on(cluster) group_left()(0*sum by (cluster)(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}$operator_health))`
+
+// TotalClusters (0_0)
+const overviewTotalClusters = `count (
+label_replace(sum by (name, openshiftVersion) (acm_managed_cluster_labels{name=~"$cluster"}), "cluster", "$1", "name", "(.*)") + 
+` + overviewHealthFilteredClusters + `
+)`
+
+// ClustersCriticalHealth (0_1)
+const overviewClustersCriticalHealth = `count(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"} == 2` + overviewHealthAnd + `) or vector(0)`
+
+// TotalAllocatableNodes (0_2)
+const overviewTotalAllocatableNodes = `sum(count by (cluster) (count(kube_node_status_allocatable{resource=~".*kubevirt.*", cluster=~"$cluster"}) by (cluster,node))` + overviewHealthJoin + `)`
+
+// TotalVMs (0_3)
+const overviewTotalVMs = `sum(count by (name, namespace, cluster)(kubevirt_vm_info{cluster=~"$cluster"})` + overviewHealthJoin + `)`
+
+// VMsByStatusStat — Running (0_4, query 1)
+const overviewVMsByStatusStatRunning = `sum(sum by (cluster, status_group)(kubevirt_vm_info{cluster=~"$cluster", status_group="running"}>0)` + overviewHealthJoin + `) or vector(0)`
+
+// VMsByStatusStat — Stopped (0_4, query 2)
+const overviewVMsByStatusStatStopped = `sum(sum by (cluster, status_group)(kubevirt_vm_info{cluster=~"$cluster", status_group="non_running"}>0)` + overviewHealthJoin + `) or vector(0)`
+
+// VMsByStatusStat — Error (0_4, query 3)
+const overviewVMsByStatusStatError = `sum(sum by (cluster, status_group)(kubevirt_vm_info{cluster=~"$cluster", status_group="error"}>0)` + overviewHealthJoin + `) or vector(0)`
+
+// VMsByStatusStat — Starting (0_4, query 4)
+const overviewVMsByStatusStatStarting = `sum(sum by (cluster, status_group)(kubevirt_vm_info{cluster=~"$cluster", status_group="starting"}>0)` + overviewHealthJoin + `) or vector(0)`
+
+// VMsByStatusStat — Migrating (0_4, query 5)
+const overviewVMsByStatusStatMigrating = `sum(sum by (cluster, status_group)(kubevirt_vm_info{cluster=~"$cluster", status_group="migrating"}>0)` + overviewHealthJoin + `) or vector(0)`
+
+// ClustersWarningHealth (0_5)
+const overviewClustersWarningHealth = `count(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"} == 1` + overviewHealthAnd + `) or vector(0)`
+
+// VMsStartedLast7Days (0_6)
+const overviewVMsStartedLast7Days = `count by (cluster)(time() - (label_replace(max by (cluster, name, namespace)(kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=~"$cluster"})>0 ,"status","starting","","")) < 604800)` + overviewHealthAnd
+
+// ClustersByOperatorVersion — counts (0_7, query 1)
+const overviewClustersByOperatorVersionCounts = `count by (version)((count by (cluster, version) (csv_succeeded{name=~".*hyperconverged.*",cluster=~"$cluster"}>0))` + overviewHealthJoin + `) or (count by (version,phase, reason)((count by (cluster, version,phase, reason) (csv_abnormal{name=~".*hyperconverged.*",cluster=~"$cluster"}>0))` + overviewHealthJoin + `))`
+
+// ClustersByOperatorVersion — percent (0_7, query 2)
+const overviewClustersByOperatorVersionPercent = `count by (version)(
+    (count by (cluster, version) (csv_succeeded{name=~".*hyperconverged.*",cluster=~"$cluster"}))` + overviewHealthJoin + `
+) / scalar(count(count by (cluster)(csv_succeeded{name=~".*hyperconverged.*",cluster=~"$cluster"}) ` + overviewHealthAnd + `))`
+
+// ClustersByOpenShiftVersion — counts (0_8, query 1)
+const overviewClustersByOpenShiftVersionCounts = `count by (openshiftVersion)(
+label_replace(sum by (name, openshiftVersion) (acm_managed_cluster_labels{name=~"$cluster"}), "cluster", "$1", "name", "(.*)") + 
+` + overviewHealthFilteredClusters + `
+)`
+
+// ClustersByOpenShiftVersion — percent (0_8, query 2)
+const overviewClustersByOpenShiftVersionPercent = `count by (openshiftVersion)(
+label_replace(sum by (name, openshiftVersion) (acm_managed_cluster_labels{name=~"$cluster"}), "cluster", "$1", "name", "(.*)") + 
+` + overviewHealthFilteredClusters + `
+) / scalar(count(
+label_replace(sum by (name, openshiftVersion) (acm_managed_cluster_labels{name=~"$cluster"}), "cluster", "$1", "name", "(.*)") + 
+` + overviewHealthFilteredClusters + `
+))`
+
+// OperatorHealthByCluster — health status (1_0, query 1); $operator_health is substituted by Perses.
+const overviewOperatorHealthByClusterStatus = `(sum(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}$operator_health) by (cluster))`
+
+// OperatorHealthByCluster — critical alerts (1_0, query 2)
+const overviewOperatorHealthByClusterCriticalAlerts = `(sum(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}$operator_health) by (cluster))*0 + on (cluster) group_left() (sum by (cluster)(ALERTS{kubernetes_operator_part_of="kubevirt", alertstate="firing",cluster=~"$cluster",operator_health_impact="critical"}) or 
+ (sum by (cluster)(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}*0)))`
+
+// OperatorHealthByCluster — warning alerts (1_0, query 3)
+const overviewOperatorHealthByClusterWarningAlerts = `(sum(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}$operator_health) by (cluster))*0 + on (cluster) group_left() (sum by (cluster)(ALERTS{kubernetes_operator_part_of="kubevirt", alertstate="firing",cluster=~"$cluster",operator_health_impact="warning"}) or (sum by (cluster)(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}*0)))`
+
+// OperatorHealthByCluster — running VMs (1_0, query 4)
+const overviewOperatorHealthByClusterRunningVMs = `(sum(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}$operator_health) by (cluster))*0 + on (cluster) group_left() (sum by (cluster)(cnv:vmi_status_running:count{cluster=~"$cluster"})) or ((sum(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"}$operator_health) by (cluster))*0)`
+
+// OperatorHealthByCluster — HCO system health (1_0, query 5)
+const overviewOperatorHealthByClusterHCO = `sum by (cluster)(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"} $operator_health) * 0 
++ on(cluster) (sum by (cluster)(kubevirt_hco_system_health_status{cluster=~"$cluster"}))`
+
+// RunningVMsByOS — known guest OS (2_0, query 1)
+const overviewRunningVMsByOSKnown = `sum by (os)(sum by (cluster, os)(label_replace(kubevirt_vmi_info{cluster=~"$cluster", guest_os_name!="", phase="running"}, "os", "$1", "guest_os_name", "(.*)")
++ on (cluster, namespace, name) group_left()(0*(kubevirt_vm_info{cluster=~"$cluster", status_group="running"}>0)))` + overviewHealthJoin + `)`
+
+// RunningVMsByOS — unknown guest OS (2_0, query 2)
+const overviewRunningVMsByOSUnknown = `sum by (os)(sum by (cluster, os)(label_replace(kubevirt_vmi_info{cluster=~"$cluster", guest_os_name="", phase="running"}, "os", "unknown", "guest_os_name", "")
++ on (cluster, namespace, name) group_left()(0*(kubevirt_vm_info{cluster=~"$cluster", status_group="running"}>0)))` + overviewHealthJoin + `)`
+
+// RunningVMsByClusterTop20 (2_1)
+const overviewRunningVMsByClusterTop20 = `topk(20, sum by (cluster) (kubevirt_vm_info{cluster=~"$cluster", status_group="running"} > 0))` + overviewHealthJoin
+
+// VMsByStatusTS — running (2_2, query 1)
+const overviewVMsByStatusTSRunning = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="running"}>0) by (name, namespace, cluster)` + overviewHealthJoin + `) or vector(0)`
+
+// VMsByStatusTS — starting (2_2, query 2)
+const overviewVMsByStatusTSStarting = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="starting"}>0) by (name, namespace, cluster)` + overviewHealthJoin + `) or vector(0)`
+
+// VMsByStatusTS — migrating (2_2, query 3)
+const overviewVMsByStatusTSMigrating = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="migrating"}>0) by (name, namespace, cluster)` + overviewHealthJoin + `) or vector(0)`
+
+// VMsByStatusTS — error (2_2, query 4)
+const overviewVMsByStatusTSError = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="error"}>0) by (name, namespace, cluster)` + overviewHealthJoin + `) or vector(0)`
+
+// VMsByStatusTS — stopped (2_2, query 5)
+const overviewVMsByStatusTSStopped = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="non_running"}>0) by (name, namespace, cluster)` + overviewHealthJoin + `) or vector(0)`
+
+// RunningVMsByNodeTop20 (2_3)
+const overviewRunningVMsByNodeTop20 = `topk(20, sum(kubevirt_vmi_phase_count{cluster=~"$cluster",namespace=~".*", phase="running"}) by (cluster,phase,node))` + overviewHealthJoin
+
+// CPUUsageByClusterTop20 (3_0)
+const overviewCPUUsageByClusterTop20 = `topk(20, sum(rate(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster",namespace=~".*"}[10m])) by (cluster))` + overviewHealthJoin
+
+// CPUUsagePercentByClusterTop20 (3_1)
+const overviewCPUUsagePercentByClusterTop20 = `topk(20,sum by(cluster)(rate(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster"}[10m]))/
+(sum by(cluster)(rate(node_cpu_seconds_total{cluster=~"$cluster"}[10m]))))` + overviewHealthJoin
+
+// MemoryUsageByClusterTop20 (4_0)
+const overviewMemoryUsageByClusterTop20 = `topk(20, sum by (cluster)(
+  kubevirt_vmi_memory_available_bytes{cluster=~"$cluster"} -
+  kubevirt_vmi_memory_unused_bytes{cluster=~"$cluster"} -
+  kubevirt_vmi_memory_cached_bytes{cluster=~"$cluster"}
+  )
+)` + overviewHealthJoin
+
+// MemoryUsagePercentByClusterTop20 (4_1)
+const overviewMemoryUsagePercentByClusterTop20 = `topk(20,(
+  sum by (cluster) (
+    kubevirt_vmi_memory_available_bytes{cluster=~"$cluster"} -        
+    kubevirt_vmi_memory_unused_bytes{cluster=~"$cluster"} - 
+    kubevirt_vmi_memory_cached_bytes{cluster=~"$cluster"}
+  )
+  /
+  (sum by (cluster)(label_replace(node_memory_MemTotal_bytes{cluster=~"$cluster"}, "node", "$1", "instance", "(.*)")))
+ )
+)` + overviewHealthJoin
+
+// NetworkReceivedBytesByClusterTop20 (5_0)
+const overviewNetworkReceivedBytesByClusterTop20 = `topk(20,sum(rate(kubevirt_vmi_network_receive_bytes_total{cluster=~"$cluster"}[10m])) by (cluster))` + overviewHealthJoin
+
+// NetworkTransmittedBytesByClusterTop20 (5_1)
+const overviewNetworkTransmittedBytesByClusterTop20 = `topk(20,sum(rate(kubevirt_vmi_network_transmit_bytes_total{cluster=~"$cluster"}[10m])) by (cluster))` + overviewHealthJoin
+
+// StorageTrafficByClusterTop20 (6_0)
+const overviewStorageTrafficByClusterTop20 = `topk(20, sum by (cluster)(rate(kubevirt_vmi_storage_read_traffic_bytes_total{cluster=~"$cluster"}[10m]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{cluster=~"$cluster"}[10m])))` + overviewHealthJoin
+
+// StorageIOPsByClusterTop20 (6_1)
+const overviewStorageIOPsByClusterTop20 = `topk(20, sum by (cluster) (rate(kubevirt_vmi_storage_iops_read_total{cluster=~"$cluster"}[10m]) + rate(kubevirt_vmi_storage_iops_write_total{cluster=~"$cluster"}[10m])))` + overviewHealthJoin

--- a/internal/perses/panels/virtualization/single-cluster-panel.go
+++ b/internal/perses/panels/virtualization/single-cluster-panel.go
@@ -1,0 +1,1135 @@
+package virtualization
+
+import (
+	"encoding/json"
+	"maps"
+
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/link"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	apicommon "github.com/perses/perses/pkg/model/api/v1/common"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	timeSeriesPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+var singleClusterOperatorHealthMappings = []any{
+	map[string]any{
+		"kind": "Value",
+		"spec": map[string]any{
+			"value": "0",
+			"result": map[string]any{
+				"color": "#73bf69",
+				"value": "OK",
+			},
+		},
+	},
+	map[string]any{
+		"kind": "Value",
+		"spec": map[string]any{
+			"value": "1",
+			"result": map[string]any{
+				"color": "#fade2a",
+				"value": "Warning",
+			},
+		},
+	},
+	map[string]any{
+		"kind": "Value",
+		"spec": map[string]any{
+			"value": "2",
+			"result": map[string]any{
+				"color": "#f2495c",
+				"value": "Critical",
+			},
+		},
+	},
+}
+
+func singleClusterRecentVMsColumnSettings(project string) []any {
+	return []any{
+		map[string]any{
+			"name":          "name",
+			"header":        "VM Name",
+			"enableSorting": true,
+			"dataLink": map[string]any{
+				"openNewTab": true,
+				"title":      "Virtual Machine Details",
+				"url":        vmDetailsDashboardLinkByFieldURL(project),
+			},
+		},
+		map[string]any{"name": "timestamp", "hide": true},
+		map[string]any{"name": "namespace", "header": "Namespace", "enableSorting": true},
+		map[string]any{"name": "value", "header": "Uptime", "enableSorting": true, "format": map[string]any{"unit": "seconds"}},
+	}
+}
+
+// mergeTimeSeriesVisual performs an untyped JSON patch on b.Spec.Plugin.Spec,
+// merging patch keys into the "visual" sub-object. It MUST be applied after
+// timeSeriesPanel.Chart (which overwrites Spec with a typed struct) and before
+// panel.AddQuery or any option that reads the finalized Spec.
+//
+// This workaround is required because the timeSeriesPanel.Visual struct does not
+// expose the lineStyle field. TODO: open an upstream PR against
+// github.com/perses/plugins/timeserieschart to add LineStyle to the Visual
+// struct so this untyped patch (and mergeTimeSeriesVisual) can be removed.
+func mergeTimeSeriesVisual(patch map[string]any) panel.Option {
+	return func(b *panel.Builder) error {
+		data, err := json.Marshal(b.Spec.Plugin.Spec)
+		if err != nil {
+			return err
+		}
+		var m map[string]any
+		if err := json.Unmarshal(data, &m); err != nil {
+			return err
+		}
+		existing, _ := m["visual"].(map[string]any)
+		if existing == nil {
+			existing = map[string]any{}
+		}
+		maps.Copy(existing, patch)
+		m["visual"] = existing
+		b.Spec.Plugin.Spec = m
+		return nil
+	}
+}
+
+func singleClusterTSLegend(values ...commonSdk.Calculation) timeSeriesPanel.Legend {
+	return timeSeriesPanel.Legend{
+		Position: timeSeriesPanel.RightPosition,
+		Mode:     timeSeriesPanel.TableMode,
+		Values:   values,
+	}
+}
+
+func singleClusterTSVisual(connectNulls bool) timeSeriesPanel.Visual {
+	return timeSeriesPanel.Visual{
+		Display:      timeSeriesPanel.LineDisplay,
+		LineWidth:    1,
+		AreaOpacity:  0.1,
+		ConnectNulls: connectNulls,
+	}
+}
+
+// SingleClusterClusterName shows the selected cluster label on the hyperconverged health metric.
+func SingleClusterClusterName(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Cluster Name",
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode":   "none",
+			"metricLabel": "cluster",
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterClusterName,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterOpenshiftVirtVersion shows the virt operator CSV version.
+func SingleClusterOpenshiftVirtVersion(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("OpenShift Virt Version",
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode":   "none",
+			"metricLabel": "version",
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterOpenshiftVirtVersion,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterTotalNodes shows allocatable nodes exposing kubevirt resources.
+func SingleClusterTotalNodes(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Allocatable Nodes",
+		panel.Description("Total node count in OpenShift Virtualization clusters"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+			statPanel.Format(commonSdk.Format{Unit: &dashboards.DecimalUnit}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterTotalNodes,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterTotalVMs counts the total number of distinct VMs in the selected cluster.
+func SingleClusterTotalVMs(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Total VMs",
+		panel.Description("Total number of virtual machines in the selected cluster."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+			statPanel.Format(commonSdk.Format{Unit: &dashboards.DecimalUnit}),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode":   "none",
+			"metricLabel": "",
+		}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, ""),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterTotalVMs,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsRunningPercent shows the percentage of VMs currently running.
+func SingleClusterVMsRunningPercent(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs Running (%)",
+		panel.Description("Percentage of virtual machines that are currently running out of all VMs in the cluster."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+			statPanel.Format(commonSdk.Format{Unit: &dashboards.PercentUnit}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddLink(vmServiceLevelLinkURL(project),
+			link.Name("VM Service Level"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsRunningPercent,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsNotEvictable shows VMIs with evictionStrategy=None that will
+// block node drain entirely. A non-zero value requires admin action before any
+// node drain or update can complete.
+func SingleClusterVMsNotEvictable(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs Not Evictable",
+		panel.Description("Number of running virtual machines with eviction strategy set to None. These VMs will block node drain and cluster updates entirely."),
+		panel.AddLink(vmInventoryLinkURL(project),
+			link.Name("VM Inventory"),
+			link.TargetBlank(true),
+		),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				DefaultColor: "#808080",
+				Steps: []commonSdk.StepOption{
+					{Value: 1, Color: "#f2495c"},
+				},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "value"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsNotEvictable,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsCreatedLast24h shows VMs created in the last 24 hours.
+func SingleClusterVMsCreatedLast24h(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs Created (24h)",
+		panel.Description("Number of virtual machines created in the last 24 hours."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsCreatedLast24h,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVirtualMachinesByStatus shows running / stopped / error / starting / migrating counts.
+func SingleClusterVMsRunning(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Running VMs",
+		panel.Description("Number of virtual machines currently running."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "running"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMStatusRunning,
+			query.SeriesNameFormat("Running"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func SingleClusterVMsInError(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs in Error",
+		panel.Description("Number of virtual machines currently in an error state. Any value above zero requires attention."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				DefaultColor: "#808080",
+				Steps: []commonSdk.StepOption{
+					{Value: 1, Color: "#f2495c"},
+				},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "value"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "error"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMStatusError,
+			query.SeriesNameFormat("Error"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func SingleClusterVMsStopped(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Stopped VMs",
+		panel.Description("Number of virtual machines currently stopped."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "non_running"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMStatusStopped,
+			query.SeriesNameFormat("Stopped"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func SingleClusterVMsStarting(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Starting VMs",
+		panel.Description("Number of virtual machines currently starting up."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "starting"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMStatusStarting,
+			query.SeriesNameFormat("Starting"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func SingleClusterVMsMigrating(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Migrating VMs",
+		panel.Description("Number of virtual machines currently being migrated."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddLink(vmsByTimeInStatusLinkURL(project, "migrating"),
+			link.Name("VMs by Time in Status"),
+			link.TargetBlank(true),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMStatusMigrating,
+			query.SeriesNameFormat("Migrating"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterProvider shows cloud provider from ACM managed cluster labels.
+func SingleClusterProvider(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Provider",
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode":   "none",
+			"metricLabel": "cloud",
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterProviderByCloud,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterOpenshiftVersion shows OpenShift version from CSV metrics.
+func SingleClusterOpenshiftVersion(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("OpenShift Version",
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode":   "none",
+			"metricLabel": "version",
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterOpenshiftVersion,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterOperatorStatus maps hyperconverged operator health codes to OK / Warning / Critical.
+func SingleClusterOperatorStatus(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Operator Status",
+		panel.Description("Inspect the Operator Conditions and the Alerts tab for additional details"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode": "value",
+			"mappings":  singleClusterOperatorHealthMappings,
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterOperatorHealthStatus,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterOperatorConditions maps HCO system health codes to OK / Warning / Critical.
+func SingleClusterOperatorConditions(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Operator Conditions",
+		panel.Description("Status of HCO conditions - Check the HCO Conditions in the cluster"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode": "value",
+			"mappings":  singleClusterOperatorHealthMappings,
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterHCOSystemHealthStatus,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterRunningVMsByOS is a pie chart of running guests grouped by OS name.
+func SingleClusterRunningVMsByOS(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Running VMs by OS",
+		panel.Plugin(apicommon.Plugin{
+			Kind: "PieChart",
+			Spec: map[string]any{
+				"calculation": "last-number",
+				"format":      map[string]any{"unit": "decimal"},
+				"legend":      map[string]any{"mode": "table", "position": "right", "values": []string{"abs", "relative"}},
+				"radius":      50,
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterRunningVMsByOS1,
+			query.SeriesNameFormat("{{os}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			singleClusterRunningVMsByOS2,
+			query.SeriesNameFormat("{{os}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterRecentVMsStarted lists VMs that started most recently with a drill-down link.
+func SingleClusterRecentVMsStarted(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Recent VMs Started",
+		tablePanel.Table(),
+		mergePluginSpecFields(map[string]any{
+			"columnSettings": singleClusterRecentVMsColumnSettings(project),
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterRecentVMsStarted,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsRunningByNode plots running VMI count per node (top series).
+func SingleClusterVMsRunningByNode(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs Running by Node",
+		panel.Description("Top 20 nodes"),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit:          &dashboards.DecimalUnit,
+					DecimalPlaces: 0,
+				},
+				Min: 0,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsRunningByNode,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsByStatus plots aggregate VM counts by lifecycle phase.
+func SingleClusterVMsByStatus(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs by Status",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation)),
+			timeSeriesPanel.WithQuerySettings([]timeSeriesPanel.QuerySettingsItem{
+				{QueryIndex: 0, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#5794f2"},
+				{QueryIndex: 1, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#56a64b"},
+				{QueryIndex: 2, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#e0b400"},
+				{QueryIndex: 3, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#f2495c"},
+				{QueryIndex: 4, ColorMode: timeSeriesPanel.FixedMode, ColorValue: "#1f60c4"},
+			}),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+				Min: 0,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsByStatusStarting,
+			query.SeriesNameFormat("starting"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsByStatusRunning,
+			query.SeriesNameFormat("running"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsByStatusMigrating,
+			query.SeriesNameFormat("migrating"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsByStatusError,
+			query.SeriesNameFormat("error"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsByStatusStopped,
+			query.SeriesNameFormat("stopped"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterNodesCPUUtilization shows node CPU utilization rate (recording rule).
+func SingleClusterNodesCPUUtilization(datasourceName string) panelgroup.Option {
+	u := string(commonSdk.SecondsUnit)
+	return panelgroup.AddPanel("Nodes by CPU Utilization",
+		panel.Description("This panel displays the CPU Utilization Percentage for the top 20 nodes in the cluster, that are running virtual machines, over the past 1 minute. Node CPU Utilization reflects the rate of CPU usage relative to the node's total capacity, providing insight into the most resource-intensive nodes."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &u,
+				},
+				Min: 0,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterNodesCPUUtilizationRate1m,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsTotalCPUUsage shows CPU seconds rate per VM.
+func SingleClusterVMsTotalCPUUsage(datasourceName string) panelgroup.Option {
+	u := string(commonSdk.SecondsUnit)
+	return panelgroup.AddPanel("VMs by Total CPU Usage",
+		panel.Description("This panel displays the total CPU Usage for the top 20 VMs over the past 10 minutes. CPU Usage represents the rate of CPU time consumed by each VM, providing insight into the most resource-intensive workloads in the cluster during the recent period."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &u,
+				},
+			}),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsTotalCPUUsage,
+			query.SeriesNameFormat("{{namespace}} | {{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterNodesCPUUsagePercent shows non-idle CPU share per node.
+func SingleClusterNodesCPUUsagePercent(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Nodes by CPU Usage (%)",
+		panel.Description("This panel shows the CPU Usage Percentage for the top 20 nodes in the cluster, that are running virtual machines, over the past 10 minutes. CPU Usage Percentage is calculated as the proportion of active CPU time (user, system, I/O wait) relative to the total available CPU time. It helps identify nodes with the highest workload demand and potential resource contention."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterNodesCPUUsagePercent,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsCPUUsagePercent shows guest CPU usage vs requested capacity.
+func SingleClusterVMsCPUUsagePercent(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs by CPU Usage (%)",
+		panel.Description("This panel displays the CPU Usage Percentage for the top 20 VMs over the past 10 minutes. CPU Usage Percentage measures how much of the allocated CPU resources (cores, sockets, and threads) each VM is actively utilizing. It helps identify VMs with high or low CPU utilization relative to their allocated capacity."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsCPUUsagePercent,
+			query.SeriesNameFormat("{{namespace}} | {{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterNodesCPUStealPercent shows steal time relative to total CPU.
+func SingleClusterNodesCPUStealPercent(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Nodes by CPU Steal Time (%)",
+		panel.Description("This panel shows the CPU steal time percentage over time for the top 20 nodes in the cluster, that are running virtual machines, over the past 10 minutes.\nIt can indicate resource contention on virtualized nodes. High values suggest VMs are competing for CPU resources, potentially impacting performance."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterNodesCPUStealPercent,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsCPUReadyPercent shows vCPU delay vs requested CPU topology.
+func SingleClusterVMsCPUReadyPercent(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs by CPU Ready (%)",
+		panel.Description("This panel shows the CPU Ready Percentage for the top 20 VMs over the past 10 minutes. CPU Ready indicates the proportion of time a VM's virtual CPUs were ready to execute but had to wait for physical CPU resources due to contention."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+				Min: 0,
+			}),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsCPUReadyPercent,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterNodesMemoryUsage shows estimated memory used in bytes per node.
+func SingleClusterNodesMemoryUsage(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Nodes by Memory Usage",
+		panel.Description("This panel shows the Memory Usage for the top 20 nodes in the cluster that are running virtual machines. Memory usage is calculated as the proportion of memory utilized relative to the total available memory on each node. This helps identify resource-intensive nodes hosting virtual machines, enabling proactive resource management."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit:          &dashboards.BytesUnit,
+					DecimalPlaces: 1,
+				},
+				Min: 0,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterNodesMemoryUsageBytes,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsMemoryUsage shows guest memory used (available - unused - cached).
+func SingleClusterVMsMemoryUsage(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs by Memory Usage",
+		panel.Description("This panel displays the memory usage for the top 20 virtual machines (VMs) in the cluster. Memory usage is calculated as the allocated memory minus unused and cached memory. This provides insight into the most memory-intensive VMs, helping identify resource-heavy workloads and potential optimizations. The data is based on the most recent metrics collected."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsMemoryUsageBytes,
+			query.SeriesNameFormat("{{namespace}} | {{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterNodesMemoryUsagePercent shows node memory utilization ratio.
+func SingleClusterNodesMemoryUsagePercent(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Nodes by Memory Usage (%)",
+		panel.Description("This panel shows the Memory Usage Percentage for the top 20 nodes in the cluster that are running virtual machines. Memory usage is calculated as the proportion of memory utilized relative to the total available memory on each node. This helps identify resource-intensive nodes hosting virtual machines, enabling proactive resource management."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+				Min: 0,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterNodesMemoryUsagePercent,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsMemoryUsagePercent shows guest memory used vs requested memory.
+func SingleClusterVMsMemoryUsagePercent(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs by Memory Usage (%)",
+		panel.Description("This panel displays the memory usage for the top 20 virtual machines (VMs) in the cluster. Memory usage is calculated as the allocated memory minus unused and cached memory. This provides insight into the most memory-intensive VMs, helping identify resource-heavy workloads and potential optimizations. The data is based on the most recent metrics collected."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsMemoryUsagePercent,
+			query.SeriesNameFormat("{{namespace}} | {{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterNodesNetworkReceived shows receive throughput per node.
+func SingleClusterNodesNetworkReceived(datasourceName string) panelgroup.Option {
+	u := string(commonSdk.BytesDecPerSecondsUnit)
+	return panelgroup.AddPanel("Nodes by Network Received Bytes",
+		panel.Description("This panel displays the top 20 nodes running virtual machines (VMs) based on their total network received bytes over the past hour. It includes only nodes hosting VMs and excludes traffic from the loopback interface. This provides insight into the nodes with the highest incoming network traffic, helping identify workloads with significant data reception requirements."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(true)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &u,
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterNodesNetworkReceivedRate,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsNetworkReceived shows receive throughput per VM.
+func SingleClusterVMsNetworkReceived(datasourceName string) panelgroup.Option {
+	u := string(commonSdk.BytesDecPerSecondsUnit)
+	return panelgroup.AddPanel("VMs by Network Received Bytes",
+		panel.Description("This panel displays the top 20 virtual machines (VMs) in the cluster by network received bytes per second over the past 10 minutes. The query measures the rate of incoming network traffic, helping identify VMs with the highest network activity. Use this information to monitor and optimize resource usage for workloads with significant data reception."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(true)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &u,
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsNetworkReceivedRate,
+			query.SeriesNameFormat("{{namespace}} | {{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterNodesNetworkTransmitted shows transmit throughput per node.
+func SingleClusterNodesNetworkTransmitted(datasourceName string) panelgroup.Option {
+	u := string(commonSdk.BytesDecPerSecondsUnit)
+	return panelgroup.AddPanel("Nodes by Network Transmitted Bytes",
+		panel.Description("This panel displays the top 20 nodes running virtual machines (VMs) based on their total network transmitted bytes over the past hour. It includes only nodes hosting VMs and excludes traffic from the loopback interface. This provides insight into the nodes with the highest outgoing network traffic, helping identify workloads with significant data transmission requirements."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(true)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &u,
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterNodesNetworkTransmitRate,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsNetworkTransmitted shows transmit throughput per VM.
+func SingleClusterVMsNetworkTransmitted(datasourceName string) panelgroup.Option {
+	u := string(commonSdk.BytesDecPerSecondsUnit)
+	return panelgroup.AddPanel("VMs by Network Transmitted Bytes",
+		panel.Description("This panel displays the top 20 virtual machines (VMs) in the cluster by network transmitted bytes per second over the past 10 minutes. The query measures the rate of outgoing network traffic, helping identify VMs with the highest network activity. Use this information to monitor and optimize resource usage for workloads with significant data transmission."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(true)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &u,
+				},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsNetworkTransmitRate,
+			query.SeriesNameFormat("{{namespace}} | {{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterNodesVMStorageIOPS aggregates read+write IOPS per node.
+func SingleClusterNodesVMStorageIOPS(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Nodes by VM Storage IOPS",
+		panel.Description("This panel displays the top 20 nodes running virtual machines (VMs) based on their combined storage IOPS (read + write) over the past 10 minutes. The metric aggregates the total input/output operations per second for all VMs on each node, helping identify nodes with the highest storage activity and potential bottlenecks."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &opsPerSecUnit, ShortValues: true},
+			}),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterNodesStorageIOPS,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsStorageIOPS aggregates read+write IOPS per VM.
+func SingleClusterVMsStorageIOPS(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VMs by Storage IOPS",
+		panel.Description("This panel displays the top 20 virtual machines (VMs) based on their combined storage IOPS (read + write) over the past 10 minutes. The metric aggregates the total input/output operations per second for each VM, helping identify workloads with the highest storage activity and potential hotspots for performance optimization."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &opsPerSecUnit, ShortValues: true},
+			}),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsStorageIOPS,
+			query.SeriesNameFormat("{{namespace}} | {{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterNodesVMStorageTraffic aggregates read+write bytes per second per node.
+func SingleClusterNodesVMStorageTraffic(datasourceName string) panelgroup.Option {
+	u := string(commonSdk.BytesDecPerSecondsUnit)
+	return panelgroup.AddPanel("Nodes by VM Storage Traffic",
+		panel.Description("This panel displays the top 20 nodes running virtual machines (VMs) based on their combined storage traffic (read + write) over the past 10 minutes. The metric aggregates the total input/output operations for all VMs on each node, helping identify nodes with the highest storage activity and potential bottlenecks."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &u,
+				},
+			}),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterNodesStorageTraffic,
+			query.SeriesNameFormat("{{node}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterVMsStorageTraffic aggregates read+write bytes per second per VM.
+func SingleClusterVMsStorageTraffic(datasourceName string) panelgroup.Option {
+	u := string(commonSdk.BytesDecPerSecondsUnit)
+	return panelgroup.AddPanel("VMs by Storage Traffic",
+		panel.Description("This panel displays the top 20 virtual machines (VMs) based on their combined storage traffic (read + write) over the past 10 minutes. The metric aggregates the total input/output operations for the last 10 minutes for each VM, helping identify workloads with the highest storage activity and potential hotspots for performance optimization."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleClusterTSLegend(commonSdk.LastNumberCalculation, commonSdk.MaxCalculation)),
+			timeSeriesPanel.WithVisual(singleClusterTSVisual(false)),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &u,
+				},
+			}),
+		),
+		mergeTimeSeriesVisual(map[string]any{"lineStyle": "solid"}),
+		panel.AddQuery(query.PromQL(
+			singleClusterVMsStorageTraffic,
+			query.SeriesNameFormat("{{namespace}} | {{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterCriticalSeverityAlerts counts firing critical kubevirt operator alerts.
+func SingleClusterCriticalSeverityAlerts(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Critical Severity Alerts",
+		panel.Description("Total number of alerts that are firing with the severity level: critical."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode": "value",
+			"thresholds": map[string]any{
+				"defaultColor": "#808080",
+				"steps": []map[string]any{
+					{"value": 1, "color": "#f2495c"},
+				},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterAlertsCritical,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterWarningSeverityAlerts counts firing warning alerts filtered by health impact.
+func SingleClusterWarningSeverityAlerts(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Warning Severity Alerts",
+		panel.Description("Total number of alerts that are firing with the severity level: warning."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode": "value",
+			"thresholds": map[string]any{
+				"defaultColor": "#808080",
+				"steps": []map[string]any{
+					{"value": 1, "color": "#ff9830"},
+				},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterAlertsWarning,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterInfoSeverityAlerts counts firing info-level kubevirt alerts.
+func SingleClusterInfoSeverityAlerts(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Info Severity Alerts",
+		panel.Description("Total number of alerts that are firing with the severity level: info."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+		),
+		mergePluginSpecFields(map[string]any{
+			"colorMode": "value",
+			"thresholds": map[string]any{
+				"defaultColor": "#808080",
+				"steps": []map[string]any{
+					{"value": 1, "color": "#6ed0e0"},
+				},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterAlertsInfo,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterOperatorHealthImpactAlertsTable lists firing alerts with operator health impact (excludes info).
+func SingleClusterOperatorHealthImpactAlertsTable(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Operator Health Impact Alerts",
+		panel.Plugin(apicommon.Plugin{
+			Kind: "Table",
+			Spec: map[string]any{
+				"columnSettings": []any{
+					map[string]any{
+						"name": "alertname", "header": "Name", "enableSorting": true,
+						"dataLink": map[string]any{
+							"openNewTab": true,
+							"title":      "Alert Runbook",
+							"url":        `https://kubevirt.io/monitoring/runbooks/${__data.fields["alertname"]}`,
+						},
+					},
+					map[string]any{"name": "operator_health_impact", "header": "Operator Health Impact", "enableSorting": true},
+					map[string]any{
+						"name": "severity", "header": "Severity", "enableSorting": true,
+						"cellSettings": []any{
+							map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "critical"}}, "textColor": "#f2495c"},
+							map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "warning"}}, "textColor": "#ff9830"},
+						},
+					},
+					map[string]any{"name": "alertstate", "hide": true},
+					map[string]any{"name": "timestamp", "hide": true},
+					map[string]any{"name": "value", "hide": true},
+					map[string]any{"name": "cluster", "hide": true},
+					map[string]any{"name": "name", "hide": true},
+					map[string]any{"name": "namespace", "hide": true},
+				},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterOperatorHealthImpactAlerts,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterOperatorCSVIssuesTable shows abnormal hyperconverged CSV rows by version/phase/reason.
+func SingleClusterOperatorCSVIssuesTable(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Operator CSV Issues",
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "timestamp", Hide: true},
+				{Name: "version", Header: "OpenShift Virtualization Operator Version", EnableSorting: true},
+				{Name: "phase", Header: "Phase", EnableSorting: true},
+				{Name: "reason", Header: "Reason", EnableSorting: true},
+				{Name: "value", Hide: true},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleClusterOperatorCSVAbnormal,
+			query.SeriesNameFormat("{{version}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleClusterAllAlertsTable lists all firing kubevirt alerts with severity and impact labels.
+func SingleClusterAllAlertsTable(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("All Alerts",
+		panel.Plugin(apicommon.Plugin{
+			Kind: "Table",
+			Spec: map[string]any{
+				"columnSettings": []any{
+					map[string]any{
+						"name": "alertname", "header": "Name", "enableSorting": true,
+						"dataLink": map[string]any{
+							"openNewTab": true,
+							"title":      "Alert Runbook",
+							"url":        `https://kubevirt.io/monitoring/runbooks/${__data.fields["alertname"]}`,
+						},
+					},
+					map[string]any{"name": "namespace", "header": "Namespace", "enableSorting": true},
+					map[string]any{"name": "operator_health_impact", "header": "Operator Health Impact", "enableSorting": true},
+					map[string]any{
+						"name": "severity", "header": "Severity", "enableSorting": true,
+						"cellSettings": []any{
+							map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "critical"}}, "textColor": "#f2495c"},
+							map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "warning"}}, "textColor": "#ff9830"},
+							map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "info"}}, "textColor": "#6ed0e0"},
+						},
+					},
+					map[string]any{"name": "name", "header": "VM Name", "enableSorting": true},
+					map[string]any{"name": "value", "header": "Total Alerts", "enableSorting": true},
+					map[string]any{"name": "timestamp", "hide": true},
+					map[string]any{"name": "alertstate", "hide": true},
+					map[string]any{"name": "cluster", "hide": true},
+				},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			singleClusterAllAlerts,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}

--- a/internal/perses/panels/virtualization/single-cluster-queries.go
+++ b/internal/perses/panels/virtualization/single-cluster-queries.go
@@ -1,0 +1,155 @@
+package virtualization
+
+// Cluster-scoped allocated resource expressions (used only by this dashboard).
+const allocatedCPUClusterExpr = `(
+sum by (cluster, namespace, name)(kubevirt_vm_resource_requests{cluster=~"$cluster", resource="cpu", unit="cores", source="guest_effective"})
+or
+sum by (cluster, namespace, name)(
+kubevirt_vm_resource_requests{cluster=~"$cluster", resource="cpu", unit="cores", source=~"default|domain"}
+* ignoring (unit)(kubevirt_vm_resource_requests{cluster=~"$cluster", resource="cpu", unit="sockets", source=~"default|domain"})
+* ignoring (unit)(kubevirt_vm_resource_requests{cluster=~"$cluster", resource="cpu", unit="threads", source=~"default|domain"})
+) or
+sum by (cluster, namespace, name)(
+kubevirt_vm_resource_requests{cluster=~"$cluster", resource="cpu", unit="cores", source=~"default|domain"}
+* ignoring (unit)(kubevirt_vm_resource_requests{cluster=~"$cluster", resource="cpu", unit="sockets", source=~"default|domain"})
+) or
+sum by (cluster, namespace, name)(
+kubevirt_vm_resource_requests{cluster=~"$cluster", resource="cpu", unit="cores", source=~"default|domain"})
+)`
+
+const allocatedMemoryClusterExpr = `(
+sum by (cluster, namespace, name)(kubevirt_vm_resource_requests{cluster=~"$cluster", resource="memory", source="guest_effective"})
+or
+max by (cluster, namespace, name)(kubevirt_vm_resource_requests{cluster=~"$cluster", resource="memory", source=~"default|domain"})
+)`
+
+// PromQL queries for acm-openshift-virtualization-single-cluster-view.
+
+// Cluster / inventory
+const (
+	singleClusterClusterName          = `kubevirt_hyperconverged_operator_health_status{name=~".*hyperconverged.*", cluster=~"$cluster"}`
+	singleClusterOpenshiftVirtVersion = `csv_succeeded{name=~".*hyperconverged.*", cluster=~"$cluster"}`
+	singleClusterTotalNodes           = `sum(count by (cluster) (count(kube_node_status_allocatable{resource=~".*kubevirt.*", cluster=~"$cluster"}) by (cluster,node)))`
+	singleClusterTotalVMs             = totalVMsExpr
+	singleClusterVMStatusRunning      = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="running"}>0) by (name, namespace) or vector(0))`
+	singleClusterVMStatusStopped      = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="non_running"}>0) by (name, namespace) or vector(0))`
+	singleClusterVMStatusError        = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="error"}>0) by (name, namespace) or vector(0))`
+	singleClusterVMStatusStarting     = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="starting"}>0) by (name, namespace) or vector(0))`
+	singleClusterVMStatusMigrating    = `sum(sum(kubevirt_vm_info{cluster=~"$cluster", status_group="migrating"}>0) by (name, namespace) or vector(0))`
+	singleClusterProviderByCloud      = `count(acm_managed_cluster_labels{name=~"$cluster"}) by (cloud)`
+	singleClusterOpenshiftVersion     = `count by (version)(count by (cluster, version) (csv_succeeded{name=~".*hyperconverged.*",cluster=~"$cluster"}>0))
+or(count by (version)(count by (cluster, version) (csv_abnormal{name=~".*hyperconverged.*",cluster=~"$cluster"}>0)))`
+	singleClusterOperatorHealthStatus  = `sum by (cluster)(kubevirt_hyperconverged_operator_health_status{cluster=~"$cluster"})`
+	singleClusterHCOSystemHealthStatus = `sum by (cluster) (kubevirt_hco_system_health_status{cluster=~"$cluster"})`
+	singleClusterRunningVMsByOS1       = `sum by (os)(sum by (cluster, os)(label_replace(kubevirt_vmi_info{cluster=~"$cluster", guest_os_name!="", phase="running"}, "os", "$1", "guest_os_name", "(.*)")
++ on (cluster, namespace, name) group_left()(0*(max by (cluster, namespace, name)(kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=~"$cluster"})>0))))`
+	singleClusterRunningVMsByOS2 = `sum by (os)(sum by (cluster, os)(label_replace(kubevirt_vmi_info{cluster=~"$cluster", guest_os_name="", phase="running"}, "os", "unknown", "guest_os_name", "")
++ on (cluster, namespace, name) group_left()(0*(max by (cluster, namespace, name)(kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=~"$cluster"})>0))))`
+	singleClusterRecentVMsStarted = `bottomk(5, sum by (name, namespace) (sort(time() - (max by (cluster, name, namespace)(kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=~"$cluster"})>0)) / 1 ))`
+
+	// VMs not evictable: evictable="false" on kubevirt_vmi_info means
+	// evictionStrategy=None — these VMIs will block node drain entirely.
+	singleClusterVMsNotEvictable = `sum(kubevirt_vmi_info{cluster=~"$cluster", evictable="false"}) or vector(0)`
+
+	// VMs created in the last 24 hours: count VMs whose creation timestamp
+	// is within the last 86400 seconds relative to now.
+	singleClusterVMsCreatedLast24h = `count(time() - kubevirt_vm_create_date_timestamp_seconds{cluster=~"$cluster"} < 86400) or vector(0)`
+)
+
+// singleClusterVMsRunningPercent is a var because it references other consts.
+var singleClusterVMsRunningPercent = `100 * (` + singleClusterVMStatusRunning + `) / (` + totalVMsExpr + ` > 0)`
+
+// VM details
+const (
+	singleClusterVMsRunningByNode     = `topk(20, sum(kubevirt_vmi_phase_count{cluster=~"$cluster",namespace=~".*", phase=~"running"}) by (cluster,phase,node))`
+	singleClusterVMsByStatusStarting  = `sum(count by (cluster, name, namespace)(kubevirt_vm_starting_status_last_transition_timestamp_seconds{cluster=~"$cluster"} > 0)) or vector(0)`
+	singleClusterVMsByStatusRunning   = `sum(count by (cluster, name, namespace)(kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=~"$cluster"} > 0)) or vector(0)`
+	singleClusterVMsByStatusMigrating = `sum(count by (cluster, name, namespace)(kubevirt_vm_migrating_status_last_transition_timestamp_seconds{cluster=~"$cluster"} > 0)) or vector(0)`
+	singleClusterVMsByStatusError     = `sum(count by (cluster, name, namespace)(kubevirt_vm_error_status_last_transition_timestamp_seconds{cluster=~"$cluster"} > 0)) or vector(0)`
+	singleClusterVMsByStatusStopped   = `sum(count by (cluster, name, namespace)(kubevirt_vm_non_running_status_last_transition_timestamp_seconds{cluster=~"$cluster"} > 0)) or vector(0)`
+)
+
+// CPU
+const (
+	singleClusterNodesCPUUtilizationRate1m = `topk(20,sum(label_replace(instance:node_cpu_utilisation:rate1m{cluster=~"$cluster"}, "node", "$1", "instance", "(.*)")) by (node, cluster)
++ on(node, cluster) group_left()
+0*sum(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster"}) by (node, cluster))`
+	singleClusterVMsTotalCPUUsage     = `topk(20,sum by (namespace, name) (rate(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster",namespace=~".*"}[10m])))`
+	singleClusterNodesCPUUsagePercent = `topk(20, (sum by (node, cluster)(label_replace(rate(node_cpu_seconds_total{cluster=~"$cluster", mode!="idle"}[10m]), "node", "$1", "instance", "(.*)")) 
+  / 
+  sum by (node, cluster)(label_replace(rate(node_cpu_seconds_total{cluster=~"$cluster"}[10m]), "node", "$1", "instance", "(.*)"))
++ on(node, cluster) group_left()
+0*sum by (node, cluster)(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster"}))
+)`
+	singleClusterVMsCPUUsagePercent = `topk(20, 
+  sum by (cluster, name, namespace) (rate(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster"}[10m]))
+  / ` + allocatedCPUClusterExpr + `
+)`
+	singleClusterNodesCPUStealPercent = `topk(20, (sum by (node, cluster)(label_replace(rate(node_cpu_seconds_total{cluster=~"$cluster", mode="steal"}[10m]), "node", "$1", "instance", "(.*)")) 
+  / 
+  sum by (node, cluster)(label_replace(rate(node_cpu_seconds_total{cluster=~"$cluster"}[10m]), "node", "$1", "instance", "(.*)"))
++ on(node, cluster) group_left()
+0*sum by (node, cluster)(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster"}))
+)`
+	singleClusterVMsCPUReadyPercent = `topk(20, sum by (name, namespace, cluster) (
+  sum by (name, namespace, cluster)(rate(kubevirt_vmi_vcpu_delay_seconds_total{cluster=~"$cluster", namespace=~".*"}[10m]))
+  / ` + allocatedCPUClusterExpr + `
+  )
+)`
+)
+
+// Memory
+const (
+	singleClusterNodesMemoryUsageBytes = `topk(20,sum(label_replace(instance:node_memory_utilisation:ratio{cluster=~"$cluster"}, "node", "$1", "instance", "(.*)")) by (node, cluster)
+* sum by (node, cluster)(label_replace(node_memory_MemTotal_bytes{cluster=~"$cluster"}, "node", "$1", "instance", "(.*)"))
++ on(node, cluster) group_left()
+0*sum(kubevirt_vmi_memory_used_bytes{cluster=~"$cluster"}) by (node, cluster)
+)`
+	singleClusterVMsMemoryUsageBytes = `topk(20,(sum by (namespace, name) (
+kubevirt_vmi_memory_available_bytes{cluster=~"$cluster",namespace=~".*"} - kubevirt_vmi_memory_unused_bytes{cluster=~"$cluster",namespace=~".*"} -kubevirt_vmi_memory_cached_bytes{cluster=~"$cluster",namespace=~".*"})))`
+	singleClusterNodesMemoryUsagePercent = `topk(20,(
+  sum(label_replace(instance:node_memory_utilisation:ratio{cluster=~"$cluster"}, "node", "$1", "instance", "(.*)")) by (node, cluster)
++ on(node, cluster) group_left()
+0*sum(kubevirt_vmi_memory_used_bytes{cluster=~"$cluster"}) by (node, cluster)
+ )
+)`
+	singleClusterVMsMemoryUsagePercent = `topk(20,(
+  sum by (namespace, name) (
+    kubevirt_vmi_memory_available_bytes{cluster=~"$cluster",namespace=~".*"} -        
+    kubevirt_vmi_memory_unused_bytes{cluster=~"$cluster",namespace=~".*"} - 
+    kubevirt_vmi_memory_cached_bytes{cluster=~"$cluster",namespace=~".*"}
+  )
+  / ` + allocatedMemoryClusterExpr + `
+ )
+)`
+)
+
+// Network
+const (
+	singleClusterNodesNetworkReceivedRate = `topk(20,sum(label_replace(instance:node_network_receive_bytes_excluding_lo:rate1m{cluster=~"$cluster"}, "node", "$1", "instance", "(.*)")) by (node, cluster)
++ on(node, cluster) group_left()
+0*sum(kubevirt_vmi_network_receive_packets_total{cluster=~"$cluster"}) by (node, cluster))`
+	singleClusterVMsNetworkReceivedRate   = `topk(20,sum(rate(kubevirt_vmi_network_receive_bytes_total{cluster=~"$cluster"}[10m])) by (namespace, name))`
+	singleClusterNodesNetworkTransmitRate = `topk(20,sum(label_replace(instance:node_network_transmit_bytes_excluding_lo:rate1m{cluster=~"$cluster"}, "node", "$1", "instance", "(.*)")) by (node, cluster)
++ on(node, cluster) group_left()
+0*sum(kubevirt_vmi_network_transmit_packets_total{cluster=~"$cluster"}) by (node, cluster))`
+	singleClusterVMsNetworkTransmitRate = `topk(20,sum(rate(kubevirt_vmi_network_transmit_bytes_total{cluster=~"$cluster"}[10m])) by (namespace, name))`
+)
+
+// Storage
+const (
+	singleClusterNodesStorageIOPS    = `topk(20,sum by (node) (rate(kubevirt_vmi_storage_iops_read_total{cluster=~"$cluster"}[10m]) + rate(kubevirt_vmi_storage_iops_write_total{cluster=~"$cluster"}[10m])))`
+	singleClusterVMsStorageIOPS      = `topk(20,sum by (namespace, name) (rate(kubevirt_vmi_storage_iops_read_total{cluster=~"$cluster"}[10m]) + rate(kubevirt_vmi_storage_iops_write_total{cluster=~"$cluster"}[10m])))`
+	singleClusterNodesStorageTraffic = `topk(20,sum by (node) (rate(kubevirt_vmi_storage_read_traffic_bytes_total{cluster=~"$cluster"}[10m]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{cluster=~"$cluster"}[10m])))`
+	singleClusterVMsStorageTraffic   = `topk(20,sum by (namespace, name) (rate(kubevirt_vmi_storage_read_traffic_bytes_total{cluster=~"$cluster"}[10m]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{cluster=~"$cluster"}[10m])))`
+)
+
+// Alerts
+const (
+	singleClusterAlertsCritical             = `sum (ALERTS{kubernetes_operator_part_of="kubevirt", alertstate="firing",cluster=~"$cluster",severity="critical"}) or vector(0)`
+	singleClusterAlertsWarning              = `sum (ALERTS{kubernetes_operator_part_of="kubevirt", alertstate="firing",cluster=~"$cluster",severity="warning",operator_health_impact=~"$health_impact"}) or vector(0)`
+	singleClusterAlertsInfo                 = `sum (ALERTS{kubernetes_operator_part_of="kubevirt", alertstate="firing",cluster=~"$cluster",severity="info"}) or vector(0)`
+	singleClusterOperatorHealthImpactAlerts = `sum(ALERTS{cluster=~"$cluster",alertstate="firing",kubernetes_operator_part_of="kubevirt",operator_health_impact=~"$health_impact",operator_health_impact!="none", severity=~"$severity", severity!="info"}) by (cluster,alertname,alertstate,severity,namespace,name,operator_health_impact)`
+	singleClusterOperatorCSVAbnormal        = `count by (version,phase, reason) (csv_abnormal{name=~".*hyperconverged.*",cluster=~"$cluster"}>0)`
+	singleClusterAllAlerts                  = `sum(ALERTS{cluster=~"$cluster",alertstate="firing",kubernetes_operator_part_of="kubevirt",operator_health_impact=~"$health_impact", severity=~"$severity"}) by (cluster,alertname,alertstate,severity,namespace,name,operator_health_impact)`
+)

--- a/internal/perses/panels/virtualization/single-vm-panel.go
+++ b/internal/perses/panels/virtualization/single-vm-panel.go
@@ -1,0 +1,761 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	apicommon "github.com/perses/perses/pkg/model/api/v1/common"
+	gaugePanel "github.com/perses/plugins/gaugechart/sdk/go"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	timeSeriesPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+// Perses unit string not exported by community-mixins.
+
+func singleVMTimeSeriesLegend() timeSeriesPanel.Legend {
+	return timeSeriesPanel.Legend{
+		Position: timeSeriesPanel.RightPosition,
+		Mode:     timeSeriesPanel.TableMode,
+		Values: []commonSdk.Calculation{
+			commonSdk.LastNumberCalculation,
+			commonSdk.MaxCalculation,
+		},
+	}
+}
+
+func singleVMGaugeThresholds802090() commonSdk.Thresholds {
+	return commonSdk.Thresholds{
+		Steps: []commonSdk.StepOption{
+			{Value: 0, Color: "#73bf69"},
+			{Value: 0.80, Color: "#EAB839"},
+			{Value: 0.90, Color: "#f2495c"},
+		},
+	}
+}
+
+func singleVMGaugeThresholdsCPUdelay() commonSdk.Thresholds {
+	return commonSdk.Thresholds{
+		Steps: []commonSdk.StepOption{
+			{Value: 0, Color: "#73bf69"},
+			{Value: 0.05, Color: "#EAB839"},
+			{Value: 0.10, Color: "#f2495c"},
+		},
+	}
+}
+
+// SingleVMStatus displays the current VM status as text (default black).
+func SingleVMStatus(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Status",
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+		),
+		mergePluginSpecFields(map[string]any{
+			"metricLabel": "status",
+			"colorMode":   "none",
+		}),
+		panel.AddQuery(query.PromQL(
+			singleVMStatusQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMCriticalSeverityAlerts counts firing critical alerts for the VM.
+func SingleVMCriticalSeverityAlerts(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Critical Severity Alerts",
+		panel.Description("Total number of alerts that are firing with the severity level: critical."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0, Color: "#f2495c"},
+				},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "value"}),
+		panel.AddQuery(query.PromQL(
+			singleVMCriticalAlertsQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMWarningSeverityAlerts counts firing warning alerts for the VM.
+func SingleVMWarningSeverityAlerts(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Warning Severity Alerts",
+		panel.Description("Total number of alerts that are firing with the severity level: warning."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0, Color: "#FF9F1C"},
+				},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "value"}),
+		panel.AddQuery(query.PromQL(
+			singleVMWarningAlertsQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMInfoSeverityAlerts counts firing info alerts for the VM.
+func SingleVMInfoSeverityAlerts(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Info Severity Alerts",
+		panel.Description("Total number of alerts that are firing with the severity level: info."),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0, Color: "#6E9FFF"},
+				},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "value"}),
+		panel.AddQuery(query.PromQL(
+			singleVMInfoAlertsQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMMemoryUsagePercentGauge shows memory usage vs requested memory.
+func SingleVMMemoryUsagePercentGauge(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage (%)",
+		panel.Description("This panel displays the VM memory usage Percentage. The memory usage is calculated as the allocated memory minus unused and cached memory. The data is based on the most recent metrics collected."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{
+				Unit:          &dashboards.PercentDecimalUnit,
+				DecimalPlaces: 2,
+			}),
+			gaugePanel.Thresholds(singleVMGaugeThresholds802090()),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMMemoryUsagePercentGaugeQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMCPUUsagePercentGauge shows CPU usage vs allocated CPU.
+func SingleVMCPUUsagePercentGauge(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage (%)",
+		panel.Description("This panel displays the VM CPU Usage Percentage. CPU Usage Percentage measures how much of the allocated CPU resources (cores, sockets, and threads) each VM is actively utilizing. It helps identify VMs with high or low CPU utilization relative to their allocated capacity."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{
+				Unit:          &dashboards.PercentDecimalUnit,
+				DecimalPlaces: 2,
+			}),
+			gaugePanel.Thresholds(singleVMGaugeThresholds802090()),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMCPUUsagePercentRatioQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMVMInformationTable shows label-based VM fields (name, status, OS, etc.).
+func SingleVMVMInformationTable(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VM Information",
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "timestamp", Hide: true},
+				{Name: "Field", EnableSorting: true},
+				{Name: "Value", EnableSorting: true},
+			}),
+			tablePanel.Transform([]commonSdk.Transform{
+				{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+				{Kind: commonSdk.MergeByColumnsKind, Spec: commonSdk.MergeColumnsSpec{
+					Columns: []string{"name", "status", "guest_os_name", "guest_os_version_id", "instance_type", "workload", "flavor"},
+					Name:    "Value",
+				}},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"defaultColumnHidden": true}),
+		panel.AddQuery(query.PromQL(singleVMVMInformationNameQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMVMInformationStatusQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMVMInformationGuestOSQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMVMInformationGuestOSVersionQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMVMInformationInstanceTypeQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMVMInformationWorkloadQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMVMInformationFlavorQuery, dashboards.AddQueryDataSource(datasourceName))),
+	)
+}
+
+// SingleVMAllocatedResourcesTable shows numeric allocated resources (CPU, memory, disk).
+func SingleVMAllocatedResourcesTable(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Allocated Resources",
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "timestamp", Hide: true},
+				{Name: "Field", EnableSorting: true},
+				{Name: "value", Header: "Value", EnableSorting: true},
+			}),
+			tablePanel.Transform([]commonSdk.Transform{
+				{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+				{Kind: commonSdk.MergeIndexedColumnsKind, Spec: commonSdk.MergeIndexedColumnsSpec{
+					Column: "value",
+				}},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"defaultColumnHidden": true}),
+		panel.AddQuery(query.PromQL(singleVMVMInformationAllocatedCPUQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMVMInformationAllocatedMemoryQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMVMInformationAllocatedDiskQuery, dashboards.AddQueryDataSource(datasourceName))),
+	)
+}
+
+// SingleVMGeneralInformationTable merges namespace, node, pod, and related fields.
+func SingleVMGeneralInformationTable(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("General Information",
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "timestamp", Hide: true},
+				{Name: "Field", EnableSorting: true},
+				{Name: "Value", EnableSorting: true},
+			}),
+			tablePanel.Transform([]commonSdk.Transform{
+				{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+				{Kind: commonSdk.MergeByColumnsKind, Spec: commonSdk.MergeColumnsSpec{
+					Columns: []string{"namespace", "node", "pod", "evictable", "machine_type", "outdated"},
+					Name:    "Value",
+				}},
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"defaultColumnHidden": true}),
+		panel.AddQuery(query.PromQL(singleVMGeneralInformationNamespaceQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMGeneralInformationNodeQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMGeneralInformationPodQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMGeneralInformationEvictableQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMGeneralInformationMachineTypeQuery, dashboards.AddQueryDataSource(datasourceName))),
+		panel.AddQuery(query.PromQL(singleVMGeneralInformationOutdatedQuery, dashboards.AddQueryDataSource(datasourceName))),
+	)
+}
+
+// SingleVMFilesystemUsagePercentGauge shows max filesystem usage ratio.
+func SingleVMFilesystemUsagePercentGauge(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("File System Usage (%)",
+		panel.Description("This panel displays the VM File System usage percentage for the disk that has the highest usage percentage."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{
+				Unit:          &dashboards.PercentDecimalUnit,
+				DecimalPlaces: 2,
+			}),
+			gaugePanel.Thresholds(singleVMGaugeThresholds802090()),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMFilesystemUsagePercentQuery,
+			query.SeriesNameFormat("{{disk_name}} (highest)"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMCPUDelayPercentGauge shows CPU delay as a percent of allocated CPU.
+func SingleVMCPUDelayPercentGauge(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Delay (%)",
+		panel.Description("This panel shows the VM CPU Delay Percentage. CPU Delay indicates the proportion of time a VM's virtual CPUs were ready to execute but had to wait for physical CPU resources due to contention."),
+		gaugePanel.Chart(
+			gaugePanel.Calculation("last-number"),
+			gaugePanel.Format(commonSdk.Format{
+				Unit:          &dashboards.PercentDecimalUnit,
+				DecimalPlaces: 2,
+			}),
+			gaugePanel.Thresholds(singleVMGaugeThresholdsCPUdelay()),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMCPUDelayPercentRatioQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMNetworkTable lists network addresses for the VM.
+func SingleVMNetworkTable(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Network",
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "type", Header: "Network Type", EnableSorting: true},
+				{Name: "network_name", Header: "Network Name", EnableSorting: true},
+				{Name: "address", Header: "IP Address", EnableSorting: true},
+				{Name: "timestamp", Hide: true},
+				{Name: "cluster", Hide: true},
+				{Name: "name", Hide: true},
+				{Name: "namespace", Hide: true},
+				{Name: "value", Hide: true},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMNetworkAddressesQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMSnapshotsTable lists VM snapshots with create timestamps.
+func SingleVMSnapshotsTable(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VM Snapshots",
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "timestamp", Hide: true},
+				{Name: "cluster", Hide: true},
+				{Name: "clusterID", Hide: true},
+				{Name: "container", Hide: true},
+				{Name: "endpoint", Hide: true},
+				{Name: "instance", Hide: true},
+				{Name: "job", Hide: true},
+				{Name: "name", Hide: true},
+				{Name: "namespace", Hide: true},
+				{Name: "pod", Hide: true},
+				{Name: "receive", Hide: true},
+				{Name: "service", Hide: true},
+				{
+					Name: "value", Header: "Snapshot Create Date", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: &dateTimeLocalFormatUnit},
+				},
+				{Name: "snapshot_name", Header: "Snapshot Name", EnableSorting: true, Width: 436},
+				{Name: "tenant_id", Hide: true},
+				{Name: "__name__", Hide: true},
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMSnapshotsQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMTotalCPUUsage plots CPU usage rate in seconds.
+func SingleVMTotalCPUUsage(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total CPU Usage",
+		panel.Description("This panel displays the total VM CPU Usage. CPU Usage represents the rate of CPU time consumed by each VM, providing insight into the most resource-intensive workloads in the cluster during the recent period."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.SecondsUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMTotalCPUUsageQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMCPUUsagePercentTimeSeries plots CPU usage percentage over time.
+func SingleVMCPUUsagePercentTimeSeries(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage (%)",
+		panel.Description("This panel displays the VM CPU Usage Percentage. CPU Usage Percentage measures how much of the allocated CPU resources (cores, sockets, and threads) each VM is actively utilizing. It helps identify VMs with high or low CPU utilization relative to their allocated capacity."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMCPUUsagePercentRatioQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMCPUReadyTime plots CPU ready / delay related time series (source dashboard uses seconds axis).
+func SingleVMCPUReadyTime(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Ready Time (%)",
+		panel.Description("This panel shows the VM CPU Ready Time percentage. CPU Ready indicates the proportion of time a VM's virtual CPUs were ready to execute but had to wait for physical CPU resources due to contention."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0, Color: "#73bf69"},
+				},
+			}),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMCPUReadyTimeQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMCPUDelayPercentTimeSeries plots vCPU delay as a percentage of allocation.
+func SingleVMCPUDelayPercentTimeSeries(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Delay (%)",
+		panel.Description("This panel shows the VM CPU Delay Percentage. CPU Delay indicates the proportion of time a VM's virtual CPUs were ready to execute but had to wait for physical CPU resources due to contention."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Min:  0,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMCPUDelayPercentRatioQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMMemoryUsage plots used memory (excl. unused/cache) in bytes.
+func SingleVMMemoryUsage(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage",
+		panel.Description("This panel displays the VM memory usage. The memory usage is calculated as the allocated memory minus unused and cached memory. The data is based on the most recent metrics collected."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMMemoryUsageBytesQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMMemoryUsagePercentTimeSeries plots memory usage vs request.
+func SingleVMMemoryUsagePercentTimeSeries(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Memory Usage (%)",
+		panel.Description("This panel displays the VM memory usage Percentage. The memory usage is calculated as the allocated memory minus unused and cached memory. The data is based on the most recent metrics collected."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.Thresholds(commonSdk.Thresholds{
+				Steps: []commonSdk.StepOption{
+					{Value: 0, Color: "#73bf69"},
+				},
+			}),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMMemoryUsagePercentTimeSeriesQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMNetworkTransmit plots transmit throughput (decbytes/sec).
+func SingleVMNetworkTransmit(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Network Usage - Transmit",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &decBytesPerSecUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: true,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMNetworkTransmitQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMNetworkReceive plots receive throughput (decbytes/sec).
+func SingleVMNetworkReceive(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Network Usage - Receive",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &decBytesPerSecUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: true,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMNetworkReceiveQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMNetworkTransmitPacketsDropped plots dropped transmit packets rate.
+func SingleVMNetworkTransmitPacketsDropped(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Network Usage - Transmit Packets Dropped",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: true,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMNetworkTransmitPacketsDroppedQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMNetworkReceivePacketsDropped plots dropped receive packets rate.
+func SingleVMNetworkReceivePacketsDropped(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Network Usage - Receive Packets Dropped",
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.DecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: true,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMNetworkReceivePacketsDroppedQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMStorageTraffic plots read+write bytes per second.
+func SingleVMStorageTraffic(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Storage Traffic",
+		panel.Description("This panel displays the VM storage traffic (read + write) over the past 10 minutes. The metric aggregates the total input/output operations, helping identify workloads with the highest storage activity and potential hotspots for performance optimization."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &decBytesPerSecUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMStorageTrafficQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMStorageIOPs plots read+write IOPS.
+func SingleVMStorageIOPs(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Storage IOPS",
+		panel.Description("This panel displays the VM storage IOPS (read + write) over the past 10 minutes. The metric aggregates the total input/output operations per second, helping identify workloads with the highest storage activity and potential hotspots for performance optimization."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &commonSdk.Format{Unit: &opsPerSecUnit, ShortValues: true},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0.1,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMStorageIOPsQuery,
+			query.SeriesNameFormat("{{name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMFilesystemUsage plots used bytes per disk.
+func SingleVMFilesystemUsage(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("File System Usage",
+		panel.Description("This panel displays the VM file system usage. The data is based on the most recent metrics collected."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.BytesUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMFilesystemUsedBytesQuery,
+			query.SeriesNameFormat("{{disk_name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMFilesystemUsagePercentTimeSeries plots usage vs capacity per disk.
+func SingleVMFilesystemUsagePercentTimeSeries(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("File System Usage (%)",
+		panel.Description("This panel displays the VM file system usage Percentage. The data is based on the most recent metrics collected."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(singleVMTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show: true,
+				Format: &commonSdk.Format{
+					Unit: &dashboards.PercentDecimalUnit,
+				},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				AreaOpacity:  0,
+				ConnectNulls: false,
+				LineWidth:    1,
+			}),
+		),
+		panel.AddQuery(query.PromQL(
+			singleVMFilesystemUsagePercentQuery,
+			query.SeriesNameFormat("{{disk_name}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// SingleVMVMAlertsTable lists firing alerts for the VM.
+func SingleVMVMAlertsTable(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("VM Alerts",
+		panel.Plugin(apicommon.Plugin{
+			Kind: "Table",
+			Spec: map[string]any{
+				"columnSettings": []any{
+					map[string]any{
+						"name": "alertname", "header": "Name", "enableSorting": true,
+						"dataLink": map[string]any{
+							"openNewTab": true,
+							"title":      "Alert Runbook",
+							"url":        `https://kubevirt.io/monitoring/runbooks/${__data.fields["alertname"]}`,
+						},
+					},
+					map[string]any{
+						"name": "severity", "header": "Severity", "enableSorting": true, "width": 150,
+						"cellSettings": []any{
+							map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "critical"}}, "textColor": "#f2495c"},
+							map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "warning"}}, "textColor": "#ff9830"},
+							map[string]any{"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "info"}}, "textColor": "#6ed0e0"},
+						},
+					},
+					map[string]any{"name": "operator_health_impact", "header": "Operator Health Impact", "enableSorting": true},
+					map[string]any{"name": "namespace", "header": "Namespace", "enableSorting": true},
+					map[string]any{"name": "pod", "enableSorting": true, "width": 330},
+					map[string]any{"name": "alertstate", "hide": true},
+					map[string]any{"name": "name", "hide": true},
+					map[string]any{"name": "timestamp", "hide": true},
+					map[string]any{"name": "value", "hide": true},
+					map[string]any{"name": "cluster", "hide": true},
+				},
+			},
+		}),
+		panel.AddQuery(query.PromQL(
+			singleVMVMAlertsTableQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}

--- a/internal/perses/panels/virtualization/single-vm-queries.go
+++ b/internal/perses/panels/virtualization/single-vm-queries.go
@@ -1,0 +1,164 @@
+package virtualization
+
+const singleVMMemoryUsedExpr = `sum by (name) (
+kubevirt_vmi_memory_available_bytes{cluster=~"$cluster",namespace="$namespace", name="$name"} - kubevirt_vmi_memory_unused_bytes{cluster=~"$cluster",namespace="$namespace", name="$name"} -kubevirt_vmi_memory_cached_bytes{cluster=~"$cluster",namespace="$namespace", name="$name"})`
+
+// Status & alert stats
+const (
+	singleVMStatusQuery = `label_replace(sum(kubevirt_vm_info{cluster="$cluster",namespace="$namespace",name="$name",status_group="running"}>0) * 0 + 1, "status", "Running", "", "")
+or label_replace(sum(kubevirt_vm_info{cluster="$cluster",namespace="$namespace",name="$name",status_group="non_running"}>0) * 0 + 1, "status", "Stopped", "", "")
+or label_replace(sum(kubevirt_vm_info{cluster="$cluster",namespace="$namespace",name="$name",status_group="starting"}>0) * 0 + 1, "status", "Starting", "", "")
+or label_replace(sum(kubevirt_vm_info{cluster="$cluster",namespace="$namespace",name="$name",status_group="migrating"}>0) * 0 + 1, "status", "Migrating", "", "")
+or label_replace(sum(kubevirt_vm_info{cluster="$cluster",namespace="$namespace",name="$name",status_group="error"}>0) * 0 + 1, "status", "Error", "", "")`
+
+	singleVMCriticalAlertsQuery = `sum(sum by (cluster,alertname,alertstate,severity,namespace,name,operator_health_impact)(ALERTS{cluster=~"$cluster",kubernetes_operator_part_of="kubevirt",alertstate="firing",name=~"$name",namespace=~"$namespace",severity="critical"})) or vector(0)`
+
+	singleVMWarningAlertsQuery = `sum(sum by (cluster,alertname,alertstate,severity,namespace,name,operator_health_impact)(ALERTS{cluster=~"$cluster",kubernetes_operator_part_of="kubevirt",alertstate="firing",name=~"$name",namespace=~"$namespace",severity="warning"})) or vector(0)`
+
+	singleVMInfoAlertsQuery = `sum(sum by (cluster,alertname,alertstate,severity,namespace,name,operator_health_impact)(ALERTS{cluster=~"$cluster",kubernetes_operator_part_of="kubevirt",alertstate="firing",name=~"$name",namespace=~"$namespace",severity="info"})) or vector(0)`
+)
+
+// Shared allocation expressions: prefer guest_effective, fall back to old source labels.
+const singleVMAllocatedCPUExpr = `(
+sum by (name)(kubevirt_vm_resource_requests{cluster=~"$cluster", name="$name", namespace="$namespace", resource="cpu", unit="cores", source="guest_effective"})
+or
+sum by (name)(
+(kubevirt_vm_resource_requests{cluster=~"$cluster", name="$name", namespace="$namespace", resource="cpu", unit="cores", source=~"default|domain"})
+* ignoring (unit)(kubevirt_vm_resource_requests{cluster=~"$cluster", name="$name", namespace="$namespace", resource="cpu", unit="sockets", source=~"default|domain"})
+* ignoring (unit)(kubevirt_vm_resource_requests{cluster=~"$cluster", name="$name", namespace="$namespace", resource="cpu", unit="threads", source=~"default|domain"})
+) or
+sum by (name)(
+(kubevirt_vm_resource_requests{cluster=~"$cluster", name="$name", namespace="$namespace", resource="cpu", unit="cores", source=~"default|domain"})
+* ignoring (unit)(kubevirt_vm_resource_requests{cluster=~"$cluster", name="$name", namespace="$namespace", resource="cpu", unit="sockets", source=~"default|domain"})
+) or
+sum by (name)(
+kubevirt_vm_resource_requests{cluster=~"$cluster", name="$name", namespace="$namespace", resource="cpu", unit="cores", source=~"default|domain"})
+)`
+
+const singleVMAllocatedMemoryExpr = `(
+sum by (name)(kubevirt_vm_resource_requests{cluster=~"$cluster", name="$name", namespace="$namespace", resource="memory", source="guest_effective"})
+or
+sum by (name)(kubevirt_vm_resource_requests{cluster=~"$cluster", name="$name", namespace="$namespace", resource="memory", source=~"default|domain"})
+)`
+
+// Gauge / ratio queries
+const (
+	singleVMMemoryUsagePercentGaugeQuery = `(` + singleVMMemoryUsedExpr + `)
+/` + singleVMAllocatedMemoryExpr
+
+	singleVMCPUUsagePercentRatioQuery = `(sum by (name)(rate(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster", name="$name", namespace="$namespace"}[10m]))>0)
+/` + singleVMAllocatedCPUExpr
+
+	singleVMCPUDelayPercentRatioQuery = `(sum by (name)(rate(kubevirt_vmi_vcpu_delay_seconds_total{cluster=~"$cluster", name="$name", namespace="$namespace"}[10m]))>0)
+/` + singleVMAllocatedCPUExpr
+)
+
+// VM Information table (0_6)
+const (
+	singleVMVMInformationNameQuery = `label_replace(sum by (name)(kubevirt_vm_info{cluster="$cluster", namespace="$namespace", name="$name"}), "Field", "Name", "name", ".*")`
+
+	singleVMVMInformationStatusQuery = `label_replace(sum by (status)(label_replace(max by (cluster,namespace,name)(kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster="$cluster",namespace="$namespace",name="$name"})>0,"status", "Running", "", "") or label_replace(max by (cluster,namespace,name)(kubevirt_vm_non_running_status_last_transition_timestamp_seconds{cluster="$cluster",namespace="$namespace",name="$name"})>0,"status", "Stopped", "", "") or label_replace(max by (cluster,namespace,name)(kubevirt_vm_error_status_last_transition_timestamp_seconds{cluster="$cluster",namespace="$namespace",name="$name"})>0,"status", "Error", "", "") or label_replace(max by (cluster,namespace,name)(kubevirt_vm_starting_status_last_transition_timestamp_seconds{cluster="$cluster",namespace="$namespace",name="$name"})>0,"status", "Starting", "", "") or label_replace(max by (cluster,namespace,name)(kubevirt_vm_migrating_status_last_transition_timestamp_seconds{cluster="$cluster",namespace="$namespace",name="$name"})>0,"status", "Migrating", "", "") ), "Field", "Status", "name", ".*")`
+
+	singleVMVMInformationGuestOSQuery = `label_replace(sum by (guest_os_name)(kubevirt_vm_info{cluster="$cluster", namespace="$namespace", name="$name", guest_os_name!=""} or kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name", guest_os_name!=""}), "Field", "Operating System", "name", ".*")`
+
+	singleVMVMInformationGuestOSVersionQuery = `label_replace(sum by (guest_os_version_id)(kubevirt_vm_info{cluster="$cluster", namespace="$namespace", name="$name", guest_os_version_id!=""} or kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name", guest_os_version_id!=""}), "Field", "Operating System Version", "name", ".*")`
+
+	singleVMVMInformationAllocatedCPUQuery = `label_replace(` + singleVMAllocatedCPUExpr + `, "Field", "Allocated CPU", "", ".*")`
+
+	singleVMVMInformationAllocatedMemoryQuery = `label_replace(` + singleVMAllocatedMemoryExpr + ` / (1024^3), "Field", "Allocated Memory (GB)", "", ".*")`
+
+	singleVMVMInformationAllocatedDiskQuery = `label_replace(sum(kubevirt_vm_disk_allocated_size_bytes{cluster="$cluster", namespace="$namespace", name="$name"})/ (1024^3), "Field", "Allocated Disk (GB)", "", ".*")`
+
+	singleVMVMInformationInstanceTypeQuery = `label_replace(sum by (instance_type)(kubevirt_vm_info{cluster="$cluster", namespace="$namespace", name="$name", instance_type!="<none>"} or kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name", instance_type!="<none>"}), "Field", "Instance Type", "name", ".*")`
+
+	singleVMVMInformationWorkloadQuery = `label_replace(sum by (workload)(kubevirt_vm_info{cluster="$cluster", namespace="$namespace", name="$name", workload!="<none>"}) or sum by (workload)(kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name", workload!="<none>"}), "Field", "Template Workload", "name", ".*")`
+
+	singleVMVMInformationFlavorQuery = `label_replace(sum by (flavor)(kubevirt_vm_info{cluster="$cluster", namespace="$namespace", name="$name", flavor!="<none>"}) or sum by (flavor)(kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name", flavor!="<none>"}), "Field", "Template Flavor", "name", ".*")`
+)
+
+// General Information table (0_7)
+const (
+	singleVMGeneralInformationNamespaceQuery = `label_replace(sum by (namespace)(kubevirt_vm_info{cluster="$cluster", namespace="$namespace", name="$name"}), "Field", "Namespace", "name", ".*")`
+
+	singleVMGeneralInformationNodeQuery = `label_replace(sum by (node)(kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name"}), "Field", "Node", "name", ".*")`
+
+	singleVMGeneralInformationPodQuery = `label_replace(sum by(pod)(kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name"}), "Field", "Pod", "name", ".*")`
+
+	singleVMGeneralInformationEvictableQuery = `label_replace(sum by (evictable)(kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name"}), "Field", "Evictable", "name", ".*")`
+
+	singleVMGeneralInformationMachineTypeQuery = `label_replace(sum by (machine_type)(kubevirt_vm_info{cluster="$cluster", namespace="$namespace", name="$name", machine_type!=""}) or sum by (machine_type)(kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name", machine_type!=""}), "Field", "Machine Type", "name", ".*")`
+
+	singleVMGeneralInformationOutdatedQuery = `label_replace(sum by (outdated)(kubevirt_vmi_info{cluster="$cluster", namespace="$namespace", name="$name"}), "Field", "Outdated", "name", ".*")`
+)
+
+// Network & snapshots
+const (
+	singleVMNetworkAddressesQuery = `sum by(cluster,name,namespace,address,network_name, type)(kubevirt_vmi_status_addresses{cluster="$cluster",namespace="$namespace",name="$name"})`
+
+	singleVMSnapshotsQuery = `kubevirt_vmsnapshot_succeeded_timestamp_seconds{cluster=~"$cluster",namespace="$namespace", name="$name"}*1000`
+)
+
+// CPU time series
+const (
+	singleVMTotalCPUUsageQuery = `sum by (name) (rate(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster",namespace="$namespace", name="$name"}[10m]))`
+
+	singleVMCPUReadyTimeQuery = `(sum by (name)(rate(kubevirt_vmi_vcpu_delay_seconds_total{cluster=~"$cluster", namespace="$namespace", name="$name"}[10m]))>0)
+/` + singleVMAllocatedCPUExpr
+)
+
+// Memory time series
+const (
+	singleVMMemoryUsageBytesQuery = singleVMMemoryUsedExpr
+
+	singleVMMemoryUsagePercentTimeSeriesQuery = `(` + singleVMMemoryUsedExpr + `)/` + singleVMAllocatedMemoryExpr
+)
+
+// Network time series
+const (
+	singleVMNetworkTransmitQuery = `sum(rate(kubevirt_vmi_network_transmit_bytes_total{cluster=~"$cluster",namespace="$namespace", name="$name"}[10m])) by (name)`
+
+	singleVMNetworkReceiveQuery = `sum(rate(kubevirt_vmi_network_receive_bytes_total{cluster=~"$cluster",namespace="$namespace", name="$name"}[10m])) by (name)`
+
+	singleVMNetworkTransmitPacketsDroppedQuery = `sum(rate(kubevirt_vmi_network_transmit_packets_dropped_total{cluster=~"$cluster",namespace="$namespace", name="$name"}[10m])) by (name)`
+
+	singleVMNetworkReceivePacketsDroppedQuery = `sum(rate(kubevirt_vmi_network_receive_packets_dropped_total{cluster=~"$cluster",namespace="$namespace", name="$name"}[10m])) by (name)`
+)
+
+// Storage time series
+const (
+	singleVMStorageTrafficQuery = `sum by (name)(rate(kubevirt_vmi_storage_read_traffic_bytes_total{cluster="$cluster",namespace="$namespace", name="$name"}[10m]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{cluster="$cluster",namespace="$namespace", name="$name"}[10m]))`
+
+	singleVMStorageIOPsQuery = `sum by (name) (rate(kubevirt_vmi_storage_iops_read_total{cluster=~"$cluster",namespace="$namespace", name="$name"}[10m]) + rate(kubevirt_vmi_storage_iops_write_total{cluster=~"$cluster",namespace="$namespace", name="$name"}[10m]))`
+)
+
+// File system
+const (
+	singleVMFilesystemUsedBytesQuery = `max by (disk_name) (
+  avg_over_time(kubevirt_vmi_filesystem_used_bytes{
+    cluster="$cluster", 
+    namespace="$namespace", 
+    name="$name"
+  }[10m])
+)`
+
+	singleVMFilesystemUsagePercentQuery = `topk(1,
+  (max by (disk_name) (
+    avg_over_time(kubevirt_vmi_filesystem_used_bytes{
+      cluster="$cluster",
+      namespace="$namespace",
+      name="$name"
+    }[10m])
+  ))
+  /
+  (max by (disk_name) (
+    avg_over_time(kubevirt_vmi_filesystem_capacity_bytes{
+      cluster="$cluster",
+      namespace="$namespace",
+      name="$name"
+    }[10m])
+  ))
+)`
+)
+
+// VM Alerts table
+const singleVMVMAlertsTableQuery = `sum by (cluster,alertname,alertstate,severity,namespace,name,operator_health_impact)(ALERTS{cluster=~"$cluster",kubernetes_operator_part_of="kubevirt",alertstate="firing",name=~"$name",namespace=~"$namespace"})`

--- a/internal/perses/panels/virtualization/top-consumers-panel.go
+++ b/internal/perses/panels/virtualization/top-consumers-panel.go
@@ -1,0 +1,221 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+	timeSeriesPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+func topConsumersTimeSeriesLegend() timeSeriesPanel.Legend {
+	return timeSeriesPanel.Legend{
+		Position: timeSeriesPanel.RightPosition,
+		Mode:     timeSeriesPanel.TableMode,
+		Values: []commonSdk.Calculation{
+			commonSdk.LastNumberCalculation,
+			commonSdk.MaxCalculation,
+		},
+	}
+}
+
+func topConsumersTimeSeriesVisual() timeSeriesPanel.Visual {
+	return timeSeriesPanel.Visual{
+		Display:      timeSeriesPanel.LineDisplay,
+		AreaOpacity:  0.1,
+		ConnectNulls: false,
+		LineWidth:    1,
+	}
+}
+
+// buildTopConsumersTable centralizes the boilerplate shared by every
+// Top Consumers table panel. The caller only supplies the per-panel
+// metadata (title, description, value-column header and format) plus
+// the PromQL query string.
+func buildTopConsumersTable(
+	title, description, valueHeader string,
+	valueFmt commonSdk.Format,
+	promQL, datasourceName, project string,
+) panelgroup.Option {
+	return panelgroup.AddPanel(title,
+		panel.Description(description),
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "timestamp", Hide: true},
+				{Name: "cluster", Header: "Cluster", EnableSorting: true},
+				{Name: "namespace", Header: "Namespace", EnableSorting: true},
+				{Name: "name", Header: "Virtual Machine", EnableSorting: true},
+				{Name: "value", Header: valueHeader, EnableSorting: true, Format: &valueFmt},
+			}),
+		),
+		addColumnDataLink("name", tableDataLink("Virtual Machine Details", vmDetailsDashboardLinkByValueURL(project))),
+		panel.AddQuery(query.PromQL(
+			promQL,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// buildTopConsumersTimeSeries centralizes the boilerplate shared by
+// every Top Consumers time-series panel.
+func buildTopConsumersTimeSeries(
+	title, description string,
+	yAxisFmt commonSdk.Format,
+	promQL, datasourceName string,
+) panelgroup.Option {
+	return panelgroup.AddPanel(title,
+		panel.Description(description),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithLegend(topConsumersTimeSeriesLegend()),
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Show:   true,
+				Format: &yAxisFmt,
+			}),
+			timeSeriesPanel.WithVisual(topConsumersTimeSeriesVisual()),
+		),
+		panel.AddQuery(query.PromQL(
+			promQL,
+			query.SeriesNameFormat("{{name}} / {{namespace}}"),
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+// --- Table panels (Top Consumers) ---
+
+func TopConsumersMemoryTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Memory",
+		"Virtual machines with the highest memory consumption.",
+		"Avg Memory Usage",
+		commonSdk.Format{Unit: &dashboards.BytesUnit},
+		topConsumersMemoryTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersCPUTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of CPU",
+		"Virtual machines with the highest CPU usage in cores. A value of 2.0 means two full CPU cores are in use.",
+		"CPU Usage (cores)",
+		commonSdk.Format{Unit: &dashboards.DecimalUnit, DecimalPlaces: 3},
+		topConsumersCPUTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersStorageTrafficTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Storage Traffic",
+		"Virtual machines with the highest storage traffic (read + write).",
+		"Storage Traffic",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersStorageTrafficTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersStorageIOPSTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Storage IOPS",
+		"Virtual machines with the highest storage IOPS (read + write).",
+		"Storage IOPS",
+		commonSdk.Format{Unit: &opsPerSecUnit},
+		topConsumersStorageIOPSTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersNetworkTrafficTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Network Traffic",
+		"Virtual machines with the highest network traffic (receive + transmit).",
+		"Network Traffic",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersNetworkTrafficTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersVCPUWaitTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of vCPU Wait",
+		"Virtual machines with the highest vCPU wait time, indicating CPU contention.",
+		"vCPU Wait Time",
+		commonSdk.Format{Unit: &dashboards.SecondsUnit},
+		topConsumersVCPUWaitTableQuery, datasourceName, project,
+	)
+}
+
+func TopConsumersMemorySwapTable(datasourceName, project string) panelgroup.Option {
+	return buildTopConsumersTable(
+		"Top Consumers of Memory Swap Traffic",
+		"Virtual machines with the highest memory swap traffic (in + out). High swap activity may indicate memory pressure.",
+		"Avg Memory Swap Traffic",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersMemorySwapTableQuery, datasourceName, project,
+	)
+}
+
+// --- Time-series panels (Top Consumers Over Time) ---
+
+func TopConsumersMemoryTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Memory Usage Over Time",
+		"Top virtual machines by memory consumption over time.",
+		commonSdk.Format{Unit: &dashboards.BytesUnit},
+		topConsumersMemoryTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersCPUTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"CPU Usage Over Time",
+		"Top virtual machines by CPU usage in cores over time. A value of 2.0 means two full CPU cores are in use.",
+		commonSdk.Format{Unit: &dashboards.DecimalUnit},
+		topConsumersCPUTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersStorageTrafficTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Storage Traffic Over Time",
+		"Top virtual machines by storage traffic (read + write) over time.",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersStorageTrafficTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersStorageIOPSTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Storage IOPS Over Time",
+		"Top virtual machines by storage IOPS (read + write) over time.",
+		commonSdk.Format{Unit: &opsPerSecUnit},
+		topConsumersStorageIOPSTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersNetworkTrafficTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Network Traffic Over Time",
+		"Top virtual machines by network traffic (receive + transmit) over time.",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersNetworkTrafficTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersVCPUWaitTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"vCPU Wait Over Time",
+		"Top virtual machines by vCPU wait time over time, indicating CPU contention.",
+		commonSdk.Format{Unit: &dashboards.SecondsUnit},
+		topConsumersVCPUWaitTimeSeriesQuery, datasourceName,
+	)
+}
+
+func TopConsumersMemorySwapTimeSeries(datasourceName string) panelgroup.Option {
+	return buildTopConsumersTimeSeries(
+		"Memory Swap Traffic Over Time",
+		"Top virtual machines by memory swap traffic (in + out) over time. High swap activity may indicate memory pressure.",
+		commonSdk.Format{Unit: &decBytesPerSecUnit},
+		topConsumersMemorySwapTimeSeriesQuery, datasourceName,
+	)
+}

--- a/internal/perses/panels/virtualization/top-consumers-queries.go
+++ b/internal/perses/panels/virtualization/top-consumers-queries.go
@@ -1,0 +1,174 @@
+package virtualization
+
+// Top Consumers queries adapted from the Grafana
+// "KubeVirt / Infrastructure Resources / Top Consumers" dashboard.
+//
+// Each resource category has a hidden PrometheusPromQLVariable that
+// evaluates topk($topn, <base_expr>) and exposes the resulting VM
+// names as $topn_<resource>. Both the table and time-series panels
+// for that resource filter by name=~"$topn_<resource>" so they always
+// show the same set of VMs.
+
+// clusterNSMatchers is the label matcher fragment shared by all
+// top-consumer queries.
+const clusterNSMatchers = `cluster=~"$cluster", namespace=~"$namespace"`
+
+// --- Metric builder helpers ---
+
+// topnNameFilter builds a name=~"$<varName>" matcher fragment to inject
+// into a metric selector so only the VMs chosen by the hidden variable
+// are returned.
+func topnNameFilter(varName string) string {
+	return `, name=~"$` + varName + `"`
+}
+
+// cpuMetric returns the kubevirt_vmi_cpu_usage_seconds_total selector
+// with optional extra matchers appended inside the braces.
+func cpuMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_cpu_usage_seconds_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func networkMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_network_receive_bytes_total{` + clusterNSMatchers + extra + `}[10m]) + rate(kubevirt_vmi_network_transmit_bytes_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func storageTrafficMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_read_traffic_bytes_total{` + clusterNSMatchers + extra + `}[10m]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func storageIOPSMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_iops_read_total{` + clusterNSMatchers + extra + `}[10m]) + rate(kubevirt_vmi_storage_iops_write_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func vcpuWaitMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_vcpu_wait_seconds_total{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+func memorySwapMetric(extra string) string {
+	return `sum by (cluster,namespace,name)(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes{` + clusterNSMatchers + extra + `}[10m]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+// memoryUsageMetric uses memory_used_bytes (MCO allowlisted, no guest agent).
+func memoryUsageMetric(extra string) string {
+	return `avg by (cluster,namespace,name)(avg_over_time(kubevirt_vmi_memory_used_bytes{` + clusterNSMatchers + extra + `}[10m]))`
+}
+
+// Instant-vector metric helpers for hidden-variable ranking queries.
+//
+// In multi-replica Thanos receive setups, range functions (rate,
+// avg_over_time) over broad selectors trigger "vector cannot contain
+// metrics with the same labelset" because duplicate series from
+// different store replicas are not merged before the range function
+// evaluates.  Instant-vector queries are immune because Thanos dedup
+// collapses identical labelsets at query time.
+//
+// These produce the same top-N VM ranking while remaining Thanos-safe.
+
+func cpuMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_cpu_usage_seconds_total{` + clusterNSMatchers + extra + `})`
+}
+
+func networkMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_network_receive_bytes_total{` + clusterNSMatchers + extra + `} + kubevirt_vmi_network_transmit_bytes_total{` + clusterNSMatchers + extra + `})`
+}
+
+func storageTrafficMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_storage_read_traffic_bytes_total{` + clusterNSMatchers + extra + `} + kubevirt_vmi_storage_write_traffic_bytes_total{` + clusterNSMatchers + extra + `})`
+}
+
+func storageIOPSMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_storage_iops_read_total{` + clusterNSMatchers + extra + `} + kubevirt_vmi_storage_iops_write_total{` + clusterNSMatchers + extra + `})`
+}
+
+func vcpuWaitMetricInstant(extra string) string {
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_vcpu_wait_seconds_total{` + clusterNSMatchers + extra + `})`
+}
+
+func memorySwapMetricInstant(extra string) string {
+	return `max by (cluster,namespace,name)(kubevirt_vmi_memory_swap_in_traffic_bytes{` + clusterNSMatchers + extra + `}) + max by (cluster,namespace,name)(kubevirt_vmi_memory_swap_out_traffic_bytes{` + clusterNSMatchers + extra + `})`
+}
+
+func memoryUsageMetricInstant(extra string) string {
+	return `avg by (cluster,namespace,name)(kubevirt_vmi_memory_used_bytes{` + clusterNSMatchers + extra + `})`
+}
+
+// --- Hidden-variable expressions ---
+// Each evaluates topk($topn, <base_expr>) without the name filter.
+// The PrometheusPromQLVariable extracts the "name" label, producing
+// a pipe-separated regex used by both table and time-series panels.
+
+const TopNMemoryVarName = "topn_memory"
+
+var TopNMemoryVarExpr = `topk($topn, ` + memoryUsageMetricNoFilter + `)`
+
+const TopNCPUVarName = "topn_cpu"
+
+var TopNCPUVarExpr = `topk($topn, ` + cpuMetricNoFilter + `)`
+
+const TopNStorageTrafficVarName = "topn_storage_traffic"
+
+var TopNStorageTrafficVarExpr = `topk($topn, ` + storageTrafficMetricNoFilter + `)`
+
+const TopNStorageIOPSVarName = "topn_storage_iops"
+
+var TopNStorageIOPSVarExpr = `topk($topn, ` + storageIOPSMetricNoFilter + `)`
+
+const TopNNetworkTrafficVarName = "topn_network_traffic"
+
+var TopNNetworkTrafficVarExpr = `topk($topn, ` + networkMetricNoFilter + `)`
+
+const TopNVCPUWaitVarName = "topn_vcpu_wait"
+
+var TopNVCPUWaitVarExpr = `topk($topn, ` + vcpuWaitMetricNoFilter + `)`
+
+const TopNMemorySwapVarName = "topn_memory_swap"
+
+var TopNMemorySwapVarExpr = `topk($topn, ` + memorySwapMetricNoFilter + `)`
+
+// Pre-computed base expressions without the name filter (for variables).
+// These use instant-vector helpers so the topk ranking query is safe
+// in multi-replica Thanos environments (see comment above).
+var (
+	memoryUsageMetricNoFilter    = memoryUsageMetricInstant("")
+	cpuMetricNoFilter            = cpuMetricInstant("")
+	storageTrafficMetricNoFilter = storageTrafficMetricInstant("")
+	storageIOPSMetricNoFilter    = storageIOPSMetricInstant("")
+	networkMetricNoFilter        = networkMetricInstant("")
+	vcpuWaitMetricNoFilter       = vcpuWaitMetricInstant("")
+	memorySwapMetricNoFilter     = memorySwapMetricInstant("")
+)
+
+// --- Table queries (instant) ---
+// Tables filter by the hidden variable's name list to show exactly N rows.
+
+var topConsumersMemoryTableQuery = memoryUsageMetric(topnNameFilter(TopNMemoryVarName)) + ` > 0`
+
+var topConsumersCPUTableQuery = cpuMetric(topnNameFilter(TopNCPUVarName)) + ` > 0`
+
+var topConsumersStorageTrafficTableQuery = storageTrafficMetric(topnNameFilter(TopNStorageTrafficVarName)) + ` > 0`
+
+var topConsumersStorageIOPSTableQuery = storageIOPSMetric(topnNameFilter(TopNStorageIOPSVarName)) + ` > 0`
+
+var topConsumersNetworkTrafficTableQuery = networkMetric(topnNameFilter(TopNNetworkTrafficVarName)) + ` > 0`
+
+var topConsumersVCPUWaitTableQuery = vcpuWaitMetric(topnNameFilter(TopNVCPUWaitVarName)) + ` > 0`
+
+var topConsumersMemorySwapTableQuery = memorySwapMetric(topnNameFilter(TopNMemorySwapVarName)) + ` > 0`
+
+// --- Time-series queries (range) ---
+// Time-series filter by the same hidden variable so they plot the
+// exact same VMs as the paired table.
+
+var topConsumersMemoryTimeSeriesQuery = memoryUsageMetric(topnNameFilter(TopNMemoryVarName))
+
+var topConsumersCPUTimeSeriesQuery = cpuMetric(topnNameFilter(TopNCPUVarName))
+
+var topConsumersStorageTrafficTimeSeriesQuery = storageTrafficMetric(topnNameFilter(TopNStorageTrafficVarName))
+
+var topConsumersStorageIOPSTimeSeriesQuery = storageIOPSMetric(topnNameFilter(TopNStorageIOPSVarName))
+
+var topConsumersNetworkTrafficTimeSeriesQuery = networkMetric(topnNameFilter(TopNNetworkTrafficVarName))
+
+var topConsumersVCPUWaitTimeSeriesQuery = vcpuWaitMetric(topnNameFilter(TopNVCPUWaitVarName))
+
+var topConsumersMemorySwapTimeSeriesQuery = memorySwapMetric(topnNameFilter(TopNMemorySwapVarName))

--- a/internal/perses/panels/virtualization/units.go
+++ b/internal/perses/panels/virtualization/units.go
@@ -1,0 +1,16 @@
+package virtualization
+
+import commonSdk "github.com/perses/perses/go-sdk/common"
+
+// strPtr returns a pointer to a copy of s, allowing string constants to be
+// used where *string is required (e.g. commonSdk.Format.Unit).
+func strPtr(s string) *string { return &s }
+
+// Package-level unit strings. All panel files in this package reference these
+// rather than declaring their own locals, so the unit catalog stays in one place.
+var (
+	opsPerSecUnit      = "ops/sec"
+	decBytesPerSecUnit = string(commonSdk.BytesDecPerSecondsUnit) // "decbytes/sec"
+	dateTimeLocalUnit  = "datetime-local"
+	relativeTimeUnit   = "relative-time"
+)

--- a/internal/perses/panels/virtualization/vm-by-time-in-status-panel.go
+++ b/internal/perses/panels/virtualization/vm-by-time-in-status-panel.go
@@ -1,0 +1,144 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+)
+
+func TotalAllocatedCPU(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Allocated CPU",
+		panel.Description("The total CPUs of the VMs that are listed in the dashboard"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{
+				Unit: &dashboards.DecimalUnit,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			vmByTimeInStatusTotalAllocatedCPUStatQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func TotalAllocatedMemory(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Allocated Memory",
+		panel.Description("The total Memory of the VMs that are listed in the dashboard"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{
+				Unit: &dashboards.BytesUnit,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			vmByTimeInStatusTotalAllocatedMemoryStatQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func TotalAllocatedDisk(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Allocated Disk",
+		panel.Description("The total disk size of the VMs that are listed in the dashboard"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{
+				Unit: &dashboards.BytesUnit,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			vmByTimeInStatusTotalAllocatedDiskStatQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func TimeInStatusTable(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Virtual Machines List by Time In Status",
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "timestamp", Hide: true},
+				{Name: "cluster", Header: "Cluster", EnableSorting: true},
+				{Name: "clusterID", Hide: true},
+				{Name: "container", Hide: true},
+				{Name: "endpoint", Hide: true},
+				{Name: "instance", Hide: true},
+				{Name: "job", Hide: true},
+				{Name: "namespace", Header: "Namespace", EnableSorting: true},
+				{Name: "name", Header: "VM Name", EnableSorting: true},
+				{Name: "pod", Hide: true},
+				{Name: "receive", Hide: true},
+				{Name: "service", Hide: true},
+				{Name: "status", Header: "Status", EnableSorting: true},
+				{Name: "tenant_id", Hide: true},
+				{Name: "clusterType", Hide: true},
+				{
+					Name: "value #6", Header: "Allocated CPU", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: &dashboards.DecimalUnit, DecimalPlaces: 0},
+				},
+				{
+					Name: "value #5", Header: "Allocated Memory", EnableSorting: true,
+					Format: &commonSdk.Format{ShortValues: true, Unit: &dashboards.BytesUnit},
+				},
+				{
+					Name: "value #1", Header: "Allocated Disk", EnableSorting: true,
+					Format: &commonSdk.Format{ShortValues: true, Unit: &dashboards.BytesUnit},
+				},
+				{
+					Name: "value #3", Header: "Time Since Last Migration", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: strPtr(relativeTimeUnit)},
+				},
+				{
+					Name: "value #4", Header: "Last Migration", Hide: true,
+					Format: &commonSdk.Format{Unit: strPtr(dateTimeLocalUnit)},
+				},
+				{
+					Name: "value #2", Header: "Time in Status", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: &dashboards.SecondsUnit},
+				},
+				{Name: "__name__", Hide: true},
+				{Name: "guest_os_kernel_release", Hide: true},
+				{Name: "guest_os_machine", Hide: true},
+				{Name: "os", Hide: true},
+				{Name: "disk_name", Hide: true},
+			}),
+			tablePanel.Transform([]commonSdk.Transform{
+				{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+				{Kind: commonSdk.JoinByColumValueKind, Spec: commonSdk.JoinByColumnValueSpec{Columns: []string{"cluster", "name", "namespace"}}},
+			}),
+		),
+		addColumnDataLink("name", tableDataLink("Virtual Machine Details", vmDetailsDashboardLinkByValueURL(project))),
+		panel.AddQuery(query.PromQL(
+			vmByTimeInStatusTableDiskQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			vmByTimeInStatusTableTimeInStatusQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			vmByTimeInStatusTableTimeSinceLastMigrationQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			vmByTimeInStatusTableMigrationEndMsQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			vmByTimeInStatusTableMemoryQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			vmByTimeInStatusTableCPUQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}

--- a/internal/perses/panels/virtualization/vm-by-time-in-status-queries.go
+++ b/internal/perses/panels/virtualization/vm-by-time-in-status-queries.go
@@ -1,0 +1,181 @@
+package virtualization
+
+// vmStatusLastTransitionExpr deduplicates kubevirt_vm_*_status_last_transition_timestamp_seconds
+// with max by (cluster, name, namespace) before label_replace to avoid many-to-many
+// join errors when multiple virt-controller pods emit the same series simultaneously.
+const (
+	vmStartingLastTransitionExpr  = `label_replace(max by (cluster, name, namespace)(kubevirt_vm_starting_status_last_transition_timestamp_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}) > 0, "status", "Starting", "", "")`
+	vmRunningLastTransitionExpr   = `label_replace(max by (cluster, name, namespace)(kubevirt_vm_running_status_last_transition_timestamp_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}) > 0, "status", "Running", "", "")`
+	vmStoppedLastTransitionExpr   = `label_replace(max by (cluster, name, namespace)(kubevirt_vm_non_running_status_last_transition_timestamp_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}) > 0, "status", "Stopped", "", "")`
+	vmErrorLastTransitionExpr     = `label_replace(max by (cluster, name, namespace)(kubevirt_vm_error_status_last_transition_timestamp_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}) > 0, "status", "Error", "", "")`
+	vmMigratingLastTransitionExpr = `label_replace(max by (cluster, name, namespace)(kubevirt_vm_migrating_status_last_transition_timestamp_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}) > 0, "status", "Migrating", "", "")`
+)
+
+const vmByTimeInStatusStatusJoin = `
+  + on(cluster, name, namespace) group_left(status)
+  (0 * (
+    (
+      (
+        (time() - ` + vmStartingLastTransitionExpr + `)
+        > ($days_in_status_gt * 24 * 60 * 60)
+      ) and (
+        (time() - ` + vmStartingLastTransitionExpr + `)
+        < ($days_in_status_lt * 24 * 60 * 60)
+      ) and on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="starting"} > 0)
+      unless on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"running|non_running|error|migrating"} > 0)
+    )
+    or
+    (
+      (
+        (time() - ` + vmRunningLastTransitionExpr + `)
+        > ($days_in_status_gt * 24 * 60 * 60)
+      ) and (
+        (time() - ` + vmRunningLastTransitionExpr + `)
+        < ($days_in_status_lt * 24 * 60 * 60)
+      ) and on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="running"} > 0)
+      unless on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|non_running|error|migrating"} > 0)
+    )
+    or
+    (
+      (
+        (time() - ` + vmStoppedLastTransitionExpr + `)
+        > ($days_in_status_gt * 24 * 60 * 60)
+      ) and (
+        (time() - ` + vmStoppedLastTransitionExpr + `)
+        < ($days_in_status_lt * 24 * 60 * 60)
+      ) and on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="non_running"} > 0)
+      unless on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|running|error|migrating"} > 0)
+    )
+    or
+    (
+      (
+        (time() - ` + vmErrorLastTransitionExpr + `)
+        > ($days_in_status_gt * 24 * 60 * 60)
+      ) and (
+        (time() - ` + vmErrorLastTransitionExpr + `)
+        < ($days_in_status_lt * 24 * 60 * 60)
+      ) and on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="error"} > 0)
+      unless on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|running|non_running|migrating"} > 0)
+    )
+    or
+    (
+      (
+        (time() - ` + vmMigratingLastTransitionExpr + `)
+        > ($days_in_status_gt * 24 * 60 * 60)
+      ) and (
+        (time() - ` + vmMigratingLastTransitionExpr + `)
+        < ($days_in_status_lt * 24 * 60 * 60)
+      ) and on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="migrating"} > 0)
+      unless on(cluster, name, namespace)
+      (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|running|non_running|error"} > 0)
+    )
+  ) and on(cluster, name, namespace)
+  (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"$status"} > 0))`
+
+const vmByTimeInStatusTotalAllocatedCPUStatQuery = `sum (
+max by (cluster, namespace, name)(` + allocatedCPUMultiVMExpr + `)
+` + vmByTimeInStatusStatusJoin + `
+) or vector(0)`
+
+const vmByTimeInStatusTotalAllocatedMemoryStatQuery = `sum(
+max by (cluster, namespace, name, status)(
+  max by (cluster, namespace, name)(` + allocatedMemoryMultiVMExpr + `)
+` + vmByTimeInStatusStatusJoin + `
+)) or vector(0)`
+
+const vmByTimeInStatusTotalAllocatedDiskStatQuery = `sum (
+  sum by (cluster, namespace, name)(kubevirt_vm_disk_allocated_size_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})
+` + vmByTimeInStatusStatusJoin + `
+) or vector(0)`
+
+const vmByTimeInStatusTableDiskQuery = `sum by (cluster, namespace, name, status)(
+  sum by (cluster, namespace, name)(kubevirt_vm_disk_allocated_size_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})
+` + vmByTimeInStatusStatusJoin + `
+)`
+
+const vmByTimeInStatusTableTimeInStatusQuery = `(
+  (
+    (
+      (time() - ` + vmStartingLastTransitionExpr + `) > $days_in_status_gt * 24 * 60 * 60
+    ) and (
+      (time() - ` + vmStartingLastTransitionExpr + `) < $days_in_status_lt * 24 * 60 * 60
+    ) and on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="starting"} > 0)
+    unless on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"running|non_running|error|migrating"} > 0)
+  )
+  or
+  (
+    (
+      (time() - ` + vmRunningLastTransitionExpr + `) > $days_in_status_gt * 24 * 60 * 60
+    ) and (
+      (time() - ` + vmRunningLastTransitionExpr + `) < $days_in_status_lt * 24 * 60 * 60
+    ) and on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="running"} > 0)
+    unless on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|non_running|error|migrating"} > 0)
+  )
+  or
+  (
+    (
+      (time() - ` + vmStoppedLastTransitionExpr + `) > $days_in_status_gt * 24 * 60 * 60
+    ) and (
+      (time() - ` + vmStoppedLastTransitionExpr + `) < $days_in_status_lt * 24 * 60 * 60
+    ) and on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="non_running"} > 0)
+    unless on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|running|error|migrating"} > 0)
+  )
+  or
+  (
+    (
+      (time() - ` + vmErrorLastTransitionExpr + `) > $days_in_status_gt * 24 * 60 * 60
+    ) and (
+      (time() - ` + vmErrorLastTransitionExpr + `) < $days_in_status_lt * 24 * 60 * 60
+    ) and on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="error"} > 0)
+    unless on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|running|non_running|migrating"} > 0)
+  )
+  or
+  (
+    (
+      (time() - ` + vmMigratingLastTransitionExpr + `) > $days_in_status_gt * 24 * 60 * 60
+    ) and (
+      (time() - ` + vmMigratingLastTransitionExpr + `) < $days_in_status_lt * 24 * 60 * 60
+    ) and on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="migrating"} > 0)
+    unless on(cluster, name, namespace)
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|running|non_running|error"} > 0)
+  )
+) and on(cluster, name, namespace)
+(kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"$status"} > 0)`
+
+const vmByTimeInStatusTableTimeSinceLastMigrationQuery = `sum by (cluster, namespace, name, status)(
+  (time() - kubevirt_vmi_migration_end_time_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})
+` + vmByTimeInStatusStatusJoin + `
+)`
+
+const vmByTimeInStatusTableMigrationEndMsQuery = `sum by (cluster, namespace, name, status)(
+  (kubevirt_vmi_migration_end_time_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}*1000)
+` + vmByTimeInStatusStatusJoin + `
+)`
+
+const vmByTimeInStatusTableMemoryQuery = `max by (cluster, namespace, name, status)(
+  max by (cluster, namespace, name)(` + allocatedMemoryMultiVMExpr + `)
+` + vmByTimeInStatusStatusJoin + `
+)`
+
+const vmByTimeInStatusTableCPUQuery = `max by (cluster, namespace, name, status)(
+  max by (cluster, namespace, name)(` + allocatedCPUMultiVMExpr + `)
+` + vmByTimeInStatusStatusJoin + `
+)`

--- a/internal/perses/panels/virtualization/vm-inventory-panel.go
+++ b/internal/perses/panels/virtualization/vm-inventory-panel.go
@@ -1,0 +1,168 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	apicommon "github.com/perses/perses/pkg/model/api/v1/common"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+)
+
+func VMInventoryTable(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Virtual Machines Inventory",
+		panel.Plugin(apicommon.Plugin{
+			Kind: "Table",
+			Spec: map[string]any{
+				"columnSettings": []any{
+					map[string]any{"name": "timestamp", "hide": true},
+					map[string]any{"name": "cluster", "header": "Cluster", "enableSorting": true},
+					map[string]any{"name": "namespace", "header": "Namespace", "enableSorting": true},
+					map[string]any{"name": "name", "header": "VM Name", "enableSorting": true},
+					map[string]any{"name": "status", "header": "Status", "enableSorting": true},
+					map[string]any{"name": "instance_type", "header": "Instance Type", "enableSorting": true},
+					map[string]any{"name": "preference", "header": "Preference", "enableSorting": true},
+					map[string]any{"name": "workload", "header": "Workload", "enableSorting": true},
+					map[string]any{"name": "flavor", "header": "Flavor", "enableSorting": true},
+					map[string]any{
+						"name": "live_migratable", "header": "Live Migratable", "enableSorting": true,
+						"cellSettings": []any{
+							map[string]any{
+								"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "false"}},
+								"textColor": "#f2495c",
+							},
+						},
+					},
+					map[string]any{"name": "evictable", "header": "Evictable", "enableSorting": true},
+					map[string]any{"name": "outdated", "header": "Outdated", "enableSorting": true},
+					map[string]any{"name": "guest_os_name", "header": "OS Name", "enableSorting": true},
+					map[string]any{"name": "guest_os_version_id", "header": "OS Version", "enableSorting": true},
+					map[string]any{"name": "guest_os_arch", "header": "OS Arch", "enableSorting": true},
+					map[string]any{"name": "value #5", "header": "Create Date", "enableSorting": true, "format": map[string]any{"unit": "datetime-local"}},
+					map[string]any{
+						"name": "value #4", "header": "Guest Agent", "enableSorting": true,
+						"cellSettings": []any{
+							map[string]any{
+								"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "1"}},
+								"text":      "Reporting",
+							},
+							map[string]any{
+								"condition": map[string]any{"kind": "Misc", "spec": map[string]any{"value": "null"}},
+								"text":      "Not Reporting",
+								"textColor": "#F2495C",
+							},
+						},
+					},
+					map[string]any{"name": "value #2", "header": "CPU", "enableSorting": true, "format": map[string]any{"unit": "decimal", "decimalPlaces": 0}},
+					map[string]any{"name": "value #3", "header": "Memory", "enableSorting": true, "format": map[string]any{"unit": "bytes", "shortValues": true}},
+					map[string]any{"name": "value #6", "header": "Disk", "enableSorting": true, "format": map[string]any{"unit": "bytes", "shortValues": true}},
+					map[string]any{"name": "value #1", "hide": true},
+					map[string]any{"name": "value #8", "hide": true},
+					map[string]any{"name": "value #7", "hide": true},
+					map[string]any{"name": "value #9", "hide": true},
+					map[string]any{"name": "value #10", "hide": true},
+					map[string]any{"name": "value #11", "hide": true},
+					map[string]any{"name": "value #12", "hide": true},
+					map[string]any{"name": "__name__", "hide": true},
+					map[string]any{"name": "clusterID", "hide": true},
+					map[string]any{"name": "container", "hide": true},
+					map[string]any{"name": "endpoint", "hide": true},
+					map[string]any{"name": "instance", "hide": true},
+					map[string]any{"name": "job", "hide": true},
+					map[string]any{"name": "pod", "hide": true},
+					map[string]any{"name": "receive", "hide": true},
+					map[string]any{"name": "service", "hide": true},
+					map[string]any{"name": "tenant_id", "hide": true},
+					map[string]any{"name": "guest_os_kernel_release", "hide": true},
+					map[string]any{"name": "guest_os_machine", "hide": true},
+					map[string]any{"name": "os", "hide": true},
+					map[string]any{"name": "disk_name", "hide": true},
+				},
+				"transforms": []any{
+					map[string]any{"kind": string(commonSdk.MergeSeriesKind), "spec": map[string]any{}},
+					map[string]any{"kind": string(commonSdk.JoinByColumValueKind), "spec": map[string]any{"columns": []string{"cluster", "name", "namespace"}}},
+				},
+			},
+		}),
+		addColumnDataLink("name", tableDataLink("Virtual Machine Details", vmDetailsDashboardLinkByValueURL(project))),
+		// Column "value #N" → query N mapping (positional; keep in sync with columns above):
+		//   value #1  → (hidden) Query 1: VM info series value
+		//   value #2  → CPU            Query 2: inventoryCPUQuery
+		//   value #3  → Memory         Query 3: inventoryMemoryQuery
+		//   value #4  → Guest Agent    Query 4: inventoryGuestAgentQuery
+		//   value #5  → Create Date    Query 5: inventoryCreateDateQuery
+		//   value #6  → Disk           Query 6: inventoryDiskQuery
+		//   value #7  → (hidden)       Query 7: inventoryFlavorQuery
+		//   value #8  → (hidden)       Query 8: inventoryWorkloadQuery
+		//   value #9  → (hidden)       Query 9: inventoryInstanceTypeQuery
+		//   value #10 → (hidden)       Query 10: inventoryPreferenceQuery
+		//   value #11 → (hidden)       Query 11: inventoryGuestOSQuery
+		//   value #12 → (hidden)       Query 12: inventoryEvictableOutdatedQuery
+		//   value #13 → Live Migratable Query 13: inventoryLiveMigratableQuery
+		// Query 1: VM info with status
+		panel.AddQuery(query.PromQL(
+			inventoryInfoQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 2: CPU (cores * sockets * threads)
+		panel.AddQuery(query.PromQL(
+			inventoryCPUQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 3: Memory
+		panel.AddQuery(query.PromQL(
+			inventoryMemoryQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 4: Guest Agent indicator
+		panel.AddQuery(query.PromQL(
+			inventoryGuestAgentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 5: Create Date
+		panel.AddQuery(query.PromQL(
+			inventoryCreateDateQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 6: Disk
+		panel.AddQuery(query.PromQL(
+			inventoryDiskQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 7: Flavor
+		panel.AddQuery(query.PromQL(
+			inventoryFlavorQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 8: Workload
+		panel.AddQuery(query.PromQL(
+			inventoryWorkloadQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 9: Instance Type
+		panel.AddQuery(query.PromQL(
+			inventoryInstanceTypeQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 10: Preference
+		panel.AddQuery(query.PromQL(
+			inventoryPreferenceQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 11: Guest OS info
+		panel.AddQuery(query.PromQL(
+			inventoryGuestOSQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 12: Evictable/Outdated
+		panel.AddQuery(query.PromQL(
+			inventoryEvictableOutdatedQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		// Query 13: Live Migratable (derived from kubevirt_vmi_non_evictable)
+		panel.AddQuery(query.PromQL(
+			inventoryLiveMigratableQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}

--- a/internal/perses/panels/virtualization/vm-inventory-queries.go
+++ b/internal/perses/panels/virtualization/vm-inventory-queries.go
@@ -1,0 +1,63 @@
+package virtualization
+
+const statusFilterJoin = `+on(cluster,name,namespace) group_left()(0*(sum by(cluster,namespace,name)(kubevirt_vm_info{status_group=~"$status"})))`
+
+const inventoryDimensionFilterJoin = `+on(cluster, namespace, name) group_left()(0*sum by (cluster, namespace, name)(kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"} or kubevirt_vmi_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}))`
+
+const inventoryStatusAndDimensionFilterJoin = statusFilterJoin + `
+` + inventoryDimensionFilterJoin
+
+const inventoryInfoQuery = vmInfoStatusExpr + `
+` + inventoryDimensionFilterJoin
+
+// inventoryLiveMigratableQuery derives live_migratable from
+// kubevirt_vmi_non_evictable: 1 = not migratable (false), 0 = migratable (true).
+// Only running VMIs expose this metric; stopped VMs will show null in the column.
+const inventoryLiveMigratableQuery = `(
+  label_replace(sum by (cluster, namespace, name)(kubevirt_vmi_non_evictable{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"} == 1), "live_migratable", "false", "__name__", ".*")
+  or
+  label_replace(sum by (cluster, namespace, name)(kubevirt_vmi_non_evictable{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"} == 0), "live_migratable", "true",  "__name__", ".*")
+)` + inventoryStatusAndDimensionFilterJoin
+
+const inventoryCPUQuery = allocatedCPUMultiVMExpr + `
+` + inventoryStatusAndDimensionFilterJoin
+
+const inventoryMemoryQuery = allocatedMemoryMultiVMExpr + `
+` + inventoryStatusAndDimensionFilterJoin
+
+const inventoryGuestAgentQuery = `sum by (cluster, namespace, name)(kubevirt_vmi_memory_available_bytes{cluster=~"$cluster", namespace=~"$namespace", name=~"$name"}*0+1)` + inventoryStatusAndDimensionFilterJoin
+
+const inventoryCreateDateQuery = `sum by (cluster, namespace, name)(kubevirt_vm_create_date_timestamp_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}*1000)
+` + inventoryStatusAndDimensionFilterJoin
+
+const inventoryDiskQuery = `sum by (cluster, namespace, name)(kubevirt_vm_disk_allocated_size_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})` + inventoryStatusAndDimensionFilterJoin
+
+const inventoryFlavorQuery = `sum by (cluster,namespace,name,flavor) (
+  kubevirt_vmi_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", flavor!="<none>",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+  or on(cluster,namespace,name) kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", flavor!="<none>",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+)` + statusFilterJoin
+
+const inventoryWorkloadQuery = `sum by (cluster,namespace,name,workload) (
+  kubevirt_vmi_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", workload!="<none>",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+  or on(cluster,namespace,name) kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", workload!="<none>",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+)` + statusFilterJoin
+
+const inventoryInstanceTypeQuery = `sum by (cluster,namespace,name,instance_type) (
+  kubevirt_vmi_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", instance_type!="<none>",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+  or on(cluster,namespace,name) kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", instance_type!="<none>",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+)` + statusFilterJoin
+
+const inventoryPreferenceQuery = `sum by (cluster,namespace,name,preference) (
+  kubevirt_vmi_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", preference!="<none>",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+  or on(cluster,namespace,name) kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", preference!="<none>",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+)` + statusFilterJoin
+
+const inventoryGuestOSQuery = `sum by (cluster,namespace,name,guest_os_name ,guest_os_version_id, guest_os_arch) (
+  kubevirt_vmi_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace",guest_os_name!="" ,guest_os_version_id!="",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+  or on(cluster,namespace,name) kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace",guest_os_name!="" ,guest_os_version_id!="",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+)` + statusFilterJoin
+
+const inventoryEvictableOutdatedQuery = `sum by (cluster,namespace,name,outdated ,evictable) (
+  kubevirt_vmi_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+  or on(cluster,namespace,name) kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace",flavor=~"$flavor",workload=~"$workload", instance_type=~"$instance_type", preference=~"$preference",guest_os_name=~"$guest_os_name" ,guest_os_version_id=~"$guest_os_version_id"}
+)` + statusFilterJoin

--- a/internal/perses/panels/virtualization/vm-service-level-panel.go
+++ b/internal/perses/panels/virtualization/vm-service-level-panel.go
@@ -1,0 +1,219 @@
+package virtualization
+
+import (
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	tablePanel "github.com/perses/plugins/table/sdk/go"
+)
+
+// community-mixins dashboards helpers do not export these format units yet.
+var (
+	dateTimeLocalFormatUnit = "datetime-local"
+	hoursFormatUnit         = string(commonSdk.HoursUnit)
+)
+
+func TotalUptimePercent(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Uptime %",
+		panel.Description("The total uptime % of the VMs that are listed in the dashboard"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			serviceLevelUptimePercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func TotalPlannedDowntimePercent(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Planned Downtime %",
+		panel.Description("The total planned downtime % of the VMs that are listed in the dashboard"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			serviceLevelPlannedDowntimePercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func TotalUnplannedDowntimePercent(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Unplanned Downtime %",
+		panel.Description("The total unplanned downtime % of the VMs that are listed in the dashboard"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{
+				Unit: &dashboards.PercentDecimalUnit,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			serviceLevelUnplannedDowntimePercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func TotalUptimeHours(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Uptime (Hours)",
+		panel.Description("The total uptime hours of the VMs that are listed in the dashboard"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{
+				Unit: &hoursFormatUnit,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			serviceLevelUptimeHoursQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func TotalPlannedDowntimeHours(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Planned Downtime (Hours)",
+		panel.Description("The total planned downtime hours of the VMs that are listed in the dashboard"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{
+				Unit: &hoursFormatUnit,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			serviceLevelPlannedDowntimeHoursQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func TotalUnplannedDowntimeHours(datasourceName string) panelgroup.Option {
+	return panelgroup.AddPanel("Total Unplanned Downtime (Hours)",
+		panel.Description("The total unplanned downtime hours of the VMs that are listed in the dashboard"),
+		statPanel.Chart(
+			statPanel.Calculation("last-number"),
+			statPanel.Format(commonSdk.Format{
+				Unit: &hoursFormatUnit,
+			}),
+		),
+		mergePluginSpecFields(map[string]any{"colorMode": "none"}),
+		panel.AddQuery(query.PromQL(
+			serviceLevelUnplannedDowntimeHoursQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}
+
+func ServiceLevelTable(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Virtual Machines Service Level Summary",
+		tablePanel.Table(
+			tablePanel.WithColumnSettings([]tablePanel.ColumnSettings{
+				{Name: "timestamp", Hide: true},
+				{Name: "cluster", Header: "Cluster", EnableSorting: true},
+				{Name: "namespace", Header: "Namespace", EnableSorting: true},
+				{Name: "name", Header: "VM Name", EnableSorting: true},
+				{Name: "status_group", Header: "Status", EnableSorting: true},
+				{Name: "status", Header: "Reason", EnableSorting: true},
+				{Name: "clusterID", Hide: true},
+				{Name: "container", Hide: true},
+				{Name: "endpoint", Hide: true},
+				{Name: "instance", Hide: true},
+				{Name: "job", Hide: true},
+				{Name: "pod", Hide: true},
+				{Name: "receive", Hide: true},
+				{Name: "service", Hide: true},
+				{Name: "tenant_id", Hide: true},
+				{
+					Name: "value #6", Header: "VM Create Date", Hide: true,
+					Format: &commonSdk.Format{Unit: &dateTimeLocalFormatUnit},
+				},
+				{Name: "value #1", Hide: true},
+				{
+					Name: "value #7", Header: "Uptime", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: &hoursFormatUnit},
+				},
+				{
+					Name: "value #8", Header: "Uptime %", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: &dashboards.PercentDecimalUnit},
+				},
+				{
+					Name: "value #2", Header: "Planned Downtime", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: &hoursFormatUnit},
+				},
+				{
+					Name: "value #3", Header: "Planned Downtime %", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: &dashboards.PercentDecimalUnit},
+				},
+				{
+					Name: "value #4", Header: "Unplanned Downtime", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: &hoursFormatUnit},
+				},
+				{
+					Name: "value #5", Header: "Unplanned Downtime %", EnableSorting: true,
+					Format: &commonSdk.Format{Unit: &dashboards.PercentDecimalUnit},
+				},
+				{Name: "__name__", Hide: true},
+				{Name: "guest_os_kernel_release", Hide: true},
+				{Name: "guest_os_machine", Hide: true},
+				{Name: "os", Hide: true},
+				{Name: "disk_name", Hide: true},
+				{Name: "value #9", Hide: true},
+			}),
+			tablePanel.Transform([]commonSdk.Transform{
+				{Kind: commonSdk.MergeSeriesKind, Spec: commonSdk.MergeSeriesSpec{}},
+				{Kind: commonSdk.JoinByColumValueKind, Spec: commonSdk.JoinByColumnValueSpec{Columns: []string{"cluster", "name", "namespace"}}},
+			}),
+		),
+		addColumnDataLink("name", tableDataLink("Virtual Machine Details", vmDetailsDashboardLinkByValueURL(project))),
+		panel.AddQuery(query.PromQL(
+			serviceLevelTableVMInfoQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			serviceLevelTablePlannedDowntimeHoursQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			serviceLevelTablePlannedDowntimePercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			serviceLevelTableUnplannedDowntimeHoursQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			serviceLevelTableUnplannedDowntimePercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			serviceLevelTableCreateDateQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			serviceLevelTableUptimeHoursQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			serviceLevelTableUptimePercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			serviceLevelTableErrorStatusQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}

--- a/internal/perses/panels/virtualization/vm-service-level-queries.go
+++ b/internal/perses/panels/virtualization/vm-service-level-queries.go
@@ -1,0 +1,129 @@
+package virtualization
+
+// Step/scalar coupling: the subquery step [24h:5m] (5 minutes = 300 seconds)
+// is paired with the multiplier *300 and divisor /3600 to convert samples to
+// hours. These three values must stay in sync: step_seconds × scalar = 3600.
+// If the step changes, update *300 in every hours query accordingly.
+
+// serviceLevelStatusFilter is appended to every per-VM expression to apply
+// the Status dropdown. $status comes from VMStatusVariableStaticSingleSelect
+// (values: running / non_running / starting / migrating / error / .* for All).
+const serviceLevelStatusFilter = ` and on(cluster, name, namespace)
+  (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"$status"} > 0)`
+
+// Shared service-level sub-expressions.
+const serviceLevelTotalSamplesExpr = `sum by (cluster, name , namespace)(
+    sum_over_time(
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"} > bool 0) 
+    [24h:5m]
+    ))` + serviceLevelStatusFilter
+
+const serviceLevelRunningSamplesExpr = `sum by (cluster, name , namespace)(
+    sum_over_time(
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"running"} > bool 0) 
+    [24h:5m]
+    ))` + serviceLevelStatusFilter
+
+const serviceLevelPlannedDowntimeSamplesExpr = `sum by (cluster, name , namespace)(
+    sum_over_time(
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|migrating|non_running"} > bool 0) 
+    [24h:5m]
+    ))` + serviceLevelStatusFilter
+
+const serviceLevelUnplannedDowntimeSamplesExpr = `sum by (cluster, name , namespace)(
+    sum_over_time(
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"error"} > bool 0) 
+    [24h:5m]
+    ))` + serviceLevelStatusFilter
+
+const serviceLevelUptimePercentQuery = `sum(` + serviceLevelRunningSamplesExpr + `)/ 
+sum(` + serviceLevelTotalSamplesExpr + `) or vector(0)`
+
+const serviceLevelPlannedDowntimePercentQuery = `sum(` + serviceLevelPlannedDowntimeSamplesExpr + `)/ 
+sum(` + serviceLevelTotalSamplesExpr + `) or vector(0)`
+
+const serviceLevelUnplannedDowntimePercentQuery = `sum(` + serviceLevelUnplannedDowntimeSamplesExpr + `)/ 
+sum(` + serviceLevelTotalSamplesExpr + `) or vector(0)`
+
+const serviceLevelUptimeHoursQuery = `sum(
+(` + serviceLevelRunningSamplesExpr + ` *300 )/3600
+) or vector(0)`
+
+const serviceLevelPlannedDowntimeHoursQuery = `sum(
+(` + serviceLevelPlannedDowntimeSamplesExpr + ` *300 )/3600
+) or vector(0)`
+
+const serviceLevelUnplannedDowntimeHoursQuery = `sum(
+(` + serviceLevelUnplannedDowntimeSamplesExpr + ` *300 )/3600
+) or vector(0)`
+
+// Per-VM table sample sub-expressions (no status filter appended — composed below).
+// These count 5-minute samples over 24 h for each status bucket per VM.
+const (
+	tableTotalSamples = `sum by (cluster, name, namespace)(
+    sum_over_time(
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"} > bool 0)
+    [24h:5m]
+    )
+  )`
+
+	tableRunningSamples = `sum by (cluster, name, namespace)(
+    sum_over_time(
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"running"} > bool 0)
+    [24h:5m]
+    )
+  )`
+
+	tablePlannedSamples = `sum by (cluster, name, namespace)(
+    sum_over_time(
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"starting|migrating|non_running"} > bool 0)
+    [24h:5m]
+    )
+  )`
+
+	tableUnplannedSamples = `sum by (cluster, name, namespace)(
+    sum_over_time(
+    (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"error"} > bool 0)
+    [24h:5m]
+    )
+  )`
+)
+
+const serviceLevelTableVMInfoQuery = `label_replace(label_replace(label_replace(label_replace(label_replace(
+  sum by (cluster, namespace, name, status_group)(kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})` + serviceLevelStatusFilter + `,
+  "status_group","Running","status_group","running"),
+  "status_group","Stopped","status_group","non_running"),
+  "status_group","Starting","status_group","starting"),
+  "status_group","Migrating","status_group","migrating"),
+  "status_group","Error","status_group","error")`
+
+const serviceLevelTablePlannedDowntimeHoursQuery = `(` + tablePlannedSamples + ` * 300
+) / 3600` + serviceLevelStatusFilter
+
+const serviceLevelTablePlannedDowntimePercentQuery = `(
+  (` + tablePlannedSamples + ` * 300)
+  /
+  (` + tableTotalSamples + ` * 300)
+)` + serviceLevelStatusFilter
+
+const serviceLevelTableUnplannedDowntimeHoursQuery = `(` + tableUnplannedSamples + ` * 300
+) / 3600` + serviceLevelStatusFilter
+
+const serviceLevelTableUnplannedDowntimePercentQuery = `(
+  (` + tableUnplannedSamples + ` * 300)
+  /
+  (` + tableTotalSamples + ` * 300)
+)` + serviceLevelStatusFilter
+
+const serviceLevelTableCreateDateQuery = `sum by (cluster, namespace, name)((kubevirt_vm_create_date_timestamp_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}>0)*1000)` + serviceLevelStatusFilter
+
+const serviceLevelTableUptimeHoursQuery = `(` + tableRunningSamples + ` * 300
+) / 3600` + serviceLevelStatusFilter
+
+const serviceLevelTableUptimePercentQuery = `(
+  (` + tableRunningSamples + ` * 300)
+  /
+  (` + tableTotalSamples + ` * 300)
+)` + serviceLevelStatusFilter
+
+const serviceLevelTableErrorStatusQuery = `sum by (cluster, namespace, name, status)(kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group="error"})` + serviceLevelStatusFilter

--- a/internal/perses/panels/virtualization/vm-utilization-panel.go
+++ b/internal/perses/panels/virtualization/vm-utilization-panel.go
@@ -1,0 +1,185 @@
+package virtualization
+
+import (
+	"encoding/json"
+
+	"github.com/perses/community-mixins/pkg/dashboards"
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	apicommon "github.com/perses/perses/pkg/model/api/v1/common"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+)
+
+func utilizationVMNameDataLink(project string) panel.Option {
+	return addColumnDataLink("name", tableDataLink("Virtual Machine Details", vmDetailsDashboardLinkByValueURL(project)))
+}
+
+func addColumnDataLink(columnName string, dataLink map[string]any) panel.Option {
+	return func(b *panel.Builder) error {
+		raw, err := json.Marshal(b.Spec.Plugin.Spec)
+		if err != nil {
+			return err
+		}
+		spec := map[string]any{}
+		if len(raw) > 0 && string(raw) != "null" {
+			if err := json.Unmarshal(raw, &spec); err != nil {
+				return err
+			}
+		}
+		cols, _ := spec["columnSettings"].([]any)
+		for i, c := range cols {
+			col, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			if col["name"] == columnName {
+				col["dataLink"] = dataLink
+				cols[i] = col
+				break
+			}
+		}
+		spec["columnSettings"] = cols
+		b.Spec.Plugin.Spec = spec
+		return nil
+	}
+}
+
+func VMUtilizationTable(datasourceName, project string) panelgroup.Option {
+	return panelgroup.AddPanel("Virtual Machines Utilization",
+		panel.Plugin(apicommon.Plugin{
+			Kind: "Table",
+			Spec: map[string]any{
+				"columnSettings": []any{
+					map[string]any{"name": "timestamp", "hide": true},
+					map[string]any{"name": "cluster", "header": "Cluster", "enableSorting": true},
+					map[string]any{"name": "namespace", "header": "Namespace", "enableSorting": true},
+					map[string]any{"name": "name", "header": "VM Name", "enableSorting": true},
+					map[string]any{"name": "status", "header": "Status", "enableSorting": true},
+					map[string]any{
+						"name": "value #18", "header": "Guest Agent", "enableSorting": true,
+						"cellSettings": []any{
+							map[string]any{
+								"condition": map[string]any{"kind": "Value", "spec": map[string]any{"value": "1"}},
+								"text":      "Reporting",
+							},
+							map[string]any{
+								"condition": map[string]any{"kind": "Misc", "spec": map[string]any{"value": "null"}},
+								"text":      "Not Reporting",
+								"textColor": "#F2495C",
+							},
+						},
+					},
+					map[string]any{"name": "value #3", "header": "Allocated vCPU", "hide": true},
+					map[string]any{"name": "value #2", "header": "CPU Usage", "hide": true, "format": map[string]any{"unit": "seconds"}},
+					map[string]any{"name": "value #4", "header": "CPU Usage (%)", "enableSorting": true, "format": map[string]any{"unit": "percent-decimal"}},
+					map[string]any{"name": "value #11", "header": "CPU Delay Time", "hide": true, "format": map[string]any{"unit": "seconds"}},
+					map[string]any{"name": "value #12", "header": "CPU Delay (%)", "enableSorting": true, "format": map[string]any{"unit": "percent-decimal"}},
+					map[string]any{"name": "value #6", "header": "Allocated Memory", "hide": true, "format": map[string]any{"unit": "bytes", "shortValues": true}},
+					map[string]any{"name": "value #5", "header": "Memory Usage", "hide": true, "format": map[string]any{"unit": "bytes", "shortValues": true}},
+					map[string]any{"name": "value #7", "header": "Memory Usage (%)", "enableSorting": true, "format": map[string]any{"unit": "percent-decimal"}},
+					map[string]any{"name": "value #14", "header": "Memory Swap Traffic", "enableSorting": true, "format": map[string]any{"unit": "bytes/sec", "shortValues": true}},
+					map[string]any{"name": "value #13", "header": "CPU I/O Wait", "enableSorting": true, "format": map[string]any{"unit": "seconds"}},
+					map[string]any{"name": "value #9", "header": "Storage Traffic", "enableSorting": true, "format": map[string]any{"unit": "bytes/sec", "shortValues": true}},
+					map[string]any{"name": "value #10", "header": "Storage IOPs", "enableSorting": true, "format": map[string]any{"unit": "decimal", "decimalPlaces": 5}},
+					map[string]any{"name": "value #8", "header": "Network Traffic", "enableSorting": true, "format": map[string]any{"unit": "bytes/sec", "shortValues": true}},
+					map[string]any{"name": "value #1", "hide": true},
+					map[string]any{"name": "value #15", "header": "File System Capacity", "hide": true, "format": map[string]any{"unit": "bytes", "shortValues": true}},
+					map[string]any{"name": "value #16", "header": "File System Usage", "hide": true, "format": map[string]any{"unit": "bytes", "shortValues": true}},
+					map[string]any{"name": "value #17", "header": "File System Usage (Max %)", "enableSorting": true, "format": map[string]any{"unit": "percent-decimal"}},
+					map[string]any{"name": "__name__", "hide": true},
+					map[string]any{"name": "clusterID", "hide": true},
+					map[string]any{"name": "container", "hide": true},
+					map[string]any{"name": "endpoint", "hide": true},
+					map[string]any{"name": "instance", "hide": true},
+					map[string]any{"name": "job", "hide": true},
+					map[string]any{"name": "pod", "hide": true},
+					map[string]any{"name": "receive", "hide": true},
+					map[string]any{"name": "service", "hide": true},
+					map[string]any{"name": "tenant_id", "hide": true},
+					map[string]any{"name": "guest_os_kernel_release", "hide": true},
+					map[string]any{"name": "guest_os_machine", "hide": true},
+					map[string]any{"name": "os", "hide": true},
+					map[string]any{"name": "disk_name", "hide": true},
+				},
+				"transforms": []any{
+					map[string]any{"kind": string(commonSdk.MergeSeriesKind), "spec": map[string]any{}},
+					map[string]any{"kind": string(commonSdk.JoinByColumValueKind), "spec": map[string]any{"columns": []string{"cluster", "name", "namespace"}}},
+				},
+			},
+		}),
+		utilizationVMNameDataLink(project),
+		panel.AddQuery(query.PromQL(
+			utilizationInfoQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationCPUUsageQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationAllocatedVCPUQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationCPUUsagePercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationMemoryUsageQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationAllocatedMemoryQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationMemoryUsagePercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationNetworkTrafficQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationStorageTrafficQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationStorageIOPsQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationCPUDelayQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationCPUDelayPercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationCPUIOWaitQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationMemorySwapQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationFSCapacityQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationFSUsageQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationFSUsageMaxPercentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+		panel.AddQuery(query.PromQL(
+			utilizationGuestAgentQuery,
+			dashboards.AddQueryDataSource(datasourceName),
+		)),
+	)
+}

--- a/internal/perses/panels/virtualization/vm-utilization-queries.go
+++ b/internal/perses/panels/virtualization/vm-utilization-queries.go
@@ -1,0 +1,45 @@
+package virtualization
+
+const utilizationInfoQuery = vmInfoStatusExpr
+
+// All utilization queries append statusFilterJoin, which is a zero-add PromQL
+// join ("+on(...) group_left()(0*(...))") defined in vm-inventory-queries.go.
+// This inner-joins each series to the $status selection without altering
+// numeric values, so queries like utilizationCPUUsageQuery retain their unit.
+const utilizationCPUUsageQuery = `sum by (cluster,namespace,name)(rate(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))` + statusFilterJoin
+
+const utilizationAllocatedVCPUQuery = allocatedCPUMultiVMExpr + statusFilterJoin
+
+const utilizationCPUUsagePercentQuery = `(sum by (cluster,namespace,name)(rate(kubevirt_vmi_cpu_usage_seconds_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))>0) / ` + allocatedCPUMultiVMExpr + statusFilterJoin
+
+const utilizationMemoryUsageQuery = `avg by (cluster,namespace,name) (avg_over_time(kubevirt_vmi_memory_used_bytes{cluster=~"$cluster",namespace=~"$namespace", name=~"$name"}[10m]))` + statusFilterJoin
+
+const utilizationAllocatedMemoryQuery = allocatedMemoryMultiVMExpr + statusFilterJoin
+
+const utilizationMemoryUsagePercentQuery = `(avg by (cluster,namespace,name) (avg_over_time(kubevirt_vmi_memory_used_bytes{cluster=~"$cluster",namespace=~"$namespace", name=~"$name"}[10m]))) / ` + allocatedMemoryMultiVMExpr + statusFilterJoin
+
+const utilizationNetworkTrafficQuery = `sum by (cluster,namespace,name)(rate(kubevirt_vmi_network_transmit_bytes_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]) + rate(kubevirt_vmi_network_receive_bytes_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))` + statusFilterJoin
+
+const utilizationStorageTrafficQuery = `sum by (cluster, namespace, name)(rate(kubevirt_vmi_storage_read_traffic_bytes_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))` + statusFilterJoin
+
+const utilizationStorageIOPsQuery = `sum by (cluster,namespace,name) (rate(kubevirt_vmi_storage_iops_read_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]) + rate(kubevirt_vmi_storage_iops_write_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))` + statusFilterJoin
+
+const utilizationCPUDelayQuery = `sum by (cluster,namespace,name) (rate(kubevirt_vmi_vcpu_delay_seconds_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))` + statusFilterJoin
+
+const utilizationCPUDelayPercentQuery = `(sum by (name, namespace, cluster)(rate(kubevirt_vmi_vcpu_delay_seconds_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))>0) / ` + allocatedCPUMultiVMExpr + statusFilterJoin
+
+const utilizationCPUIOWaitQuery = `sum by (cluster,namespace,name)(rate(kubevirt_vmi_vcpu_wait_seconds_total{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))` + statusFilterJoin
+
+const utilizationMemorySwapQuery = `sum by (cluster,namespace,name) (avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))` + statusFilterJoin
+
+const utilizationFSCapacityQuery = `avg by (cluster, namespace, name) (avg_over_time(kubevirt_vmi_filesystem_capacity_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))` + statusFilterJoin
+
+const utilizationFSUsageQuery = `avg by (cluster, namespace, name) (avg_over_time(kubevirt_vmi_filesystem_used_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m]))` + statusFilterJoin
+
+const utilizationFSUsageMaxPercentQuery = `max by (cluster, namespace, name) (
+  (max by (cluster, namespace, name, disk_name) (avg_over_time(kubevirt_vmi_filesystem_used_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m])))
+  /
+  (max by (cluster, namespace, name, disk_name) (avg_over_time(kubevirt_vmi_filesystem_capacity_bytes{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}[10m])))
+)` + statusFilterJoin
+
+const utilizationGuestAgentQuery = `sum by (cluster, namespace, name)(kubevirt_vmi_memory_available_bytes{cluster=~"$cluster", namespace=~"$namespace", name=~"$name"}*0+1)` + statusFilterJoin


### PR DESCRIPTION
## Summary

Backport of Perses virtualization dashboards from main to release-2.17.

Cherry-picks the following commits (adapting `pkg/perses/` → `internal/perses/` paths where needed):

- Add Perses Virtualization dashboards (original PR #466)
- refactor(perses): address code review comments
- fix: resolve PromQL many-to-many and duplicate series errors in Nodes Memory (PR #487)
- fix time-in-status PromQL value inflation (PR #489)
- feat: add Top Consumers Perses dashboard (PR #490)
- fix: deduplicate left-side vectors in time-in-status group_left joins (PR #491)
- fix(perses): use scalar() for overcommit percentage in max VM memory query (PR #497)

### Dashboards added
- Virtualization Overview
- Single Cluster View
- Single VM View
- Nodes Memory Overview
- Virtual Machines Inventory
- Virtual Machines Utilization
- Virtual Machines Service Level
- Virtual Machines by Time in Status
- Top Consumers

## Test plan
- [ ] Verify dashboards render correctly on a 2.17 environment
- [ ] Confirm PromQL queries return expected results
- [ ] Run `go test ./internal/perses/dashboards/virtualization/...` (passes locally)


Made with [Cursor](https://cursor.com)