### PR TITLE
ACM-34753-Auto-Discovery-Of-Observability-For-Placements

### DIFF
--- a/internal/addon/common/clustermanagementaddon.go
+++ b/internal/addon/common/clustermanagementaddon.go
@@ -12,6 +12,7 @@ import (
 	cooprometheusv1alpha1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
@@ -64,6 +65,10 @@ func EnsureAddonConfig(ctx context.Context, logger logr.Logger, k8s client.Clien
 	desiredCmao.ManagedFields = nil // required for patching with ssa
 	ensureConfigsInAddon(desiredCmao, configs)
 
+	if err := removeStaleConfigs(ctx, k8s, desiredCmao); err != nil {
+		return fmt.Errorf("failed to remove stale configs: %w", err)
+	}
+
 	// If there are no changes, nothing to do
 	if equality.Semantic.DeepEqual(cmao.Spec.InstallStrategy.Placements, desiredCmao.Spec.InstallStrategy.Placements) {
 		return nil
@@ -82,6 +87,7 @@ func EnsureAddonConfig(ctx context.Context, logger logr.Logger, k8s client.Clien
 
 func ensureConfigsInAddon(cmao *addonv1beta1.ClusterManagementAddOn, configs []DefaultConfig) {
 	containsConfig := func(configs []addonv1beta1.AddOnConfig, cfg addonv1beta1.AddOnConfig) bool {
+		// Loops through each of the configs and checks if config is equal to the config passed in
 		return slices.ContainsFunc(configs, func(e addonv1beta1.AddOnConfig) bool {
 			return e == cfg
 		})
@@ -90,6 +96,8 @@ func ensureConfigsInAddon(cmao *addonv1beta1.ClusterManagementAddOn, configs []D
 	// Group configs by placement.
 	placementConfigs := map[addonv1beta1.PlacementRef][]addonv1beta1.AddOnConfig{}
 	for _, cfg := range configs {
+		// If the config is already present in the placement, skip it
+		// Why is this necessary?
 		if containsConfig(placementConfigs[cfg.PlacementRef], cfg.Config) {
 			continue
 		}
@@ -107,9 +115,56 @@ func ensureConfigsInAddon(cmao *addonv1beta1.ClusterManagementAddOn, configs []D
 			}
 			dedupConfigs = append(dedupConfigs, cfg)
 		}
-
 		cmao.Spec.InstallStrategy.Placements[i].Configs = append(cmao.Spec.InstallStrategy.Placements[i].Configs, dedupConfigs...)
 	}
+}
+
+// removeStaleConfigs removes any user-defined PrometheusRule or ScrapeConfig
+// entries from the CMAO placements whose underlying resource no longer exists.
+func removeStaleConfigs(ctx context.Context, k8s client.Client, cmao *addonv1beta1.ClusterManagementAddOn) error {
+	for i, placement := range cmao.Spec.InstallStrategy.Placements {
+		filtered := make([]addonv1beta1.AddOnConfig, 0, len(placement.Configs))
+		for _, cfg := range placement.Configs {
+			_, err := isUserDefinedConfig(ctx, k8s, cfg)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return fmt.Errorf("failed to check config %s/%s: %w", cfg.Namespace, cfg.Name, err)
+			}
+			filtered = append(filtered, cfg)
+		}
+		cmao.Spec.InstallStrategy.Placements[i].Configs = filtered
+	}
+	return nil
+}
+
+// isUserDefinedConfig checks whether the config references a user-defined PrometheusRule
+// or ScrapeConfig by fetching the resource and looking for the placement annotation.
+// Returns the raw API error on failure so callers can distinguish NotFound from other errors.
+func isUserDefinedConfig(ctx context.Context, k8s client.Client, cfg addonv1beta1.AddOnConfig) (bool, error) {
+	key := types.NamespacedName{Name: cfg.Name, Namespace: cfg.Namespace}
+
+	var annotations map[string]string
+	switch cfg.Resource {
+	case cooprometheusv1alpha1.ScrapeConfigName:
+		sc := &cooprometheusv1alpha1.ScrapeConfig{}
+		if err := k8s.Get(ctx, key, sc); err != nil {
+			return false, err
+		}
+		annotations = sc.Annotations
+	case prometheusv1.PrometheusRuleName:
+		rule := &prometheusv1.PrometheusRule{}
+		if err := k8s.Get(ctx, key, rule); err != nil {
+			return false, err
+		}
+		annotations = rule.Annotations
+	default:
+		return false, nil
+	}
+
+	_, hasPlacementAnnotation := annotations[addoncfg.PlacementAnnotationKey]
+	return hasPlacementAnnotation, nil
 }
 
 func ObjectToAddonConfig(obj client.Object) (addonv1beta1.AddOnConfig, error) {

--- a/internal/addon/common/clustermanagementaddon.go
+++ b/internal/addon/common/clustermanagementaddon.go
@@ -96,11 +96,6 @@ func ensureConfigsInAddon(cmao *addonv1beta1.ClusterManagementAddOn, configs []D
 	// Group configs by placement.
 	placementConfigs := map[addonv1beta1.PlacementRef][]addonv1beta1.AddOnConfig{}
 	for _, cfg := range configs {
-		// If the config is already present in the placement, skip it
-		// Why is this necessary?
-		if containsConfig(placementConfigs[cfg.PlacementRef], cfg.Config) {
-			continue
-		}
 		placementConfigs[cfg.PlacementRef] = append(placementConfigs[cfg.PlacementRef], cfg.Config)
 	}
 
@@ -125,7 +120,7 @@ func removeStaleConfigs(ctx context.Context, k8s client.Client, cmao *addonv1bet
 	for i, placement := range cmao.Spec.InstallStrategy.Placements {
 		filtered := make([]addonv1beta1.AddOnConfig, 0, len(placement.Configs))
 		for _, cfg := range placement.Configs {
-			_, err := isUserDefinedConfig(ctx, k8s, cfg)
+			_, err := doesScrapeConfigOrPrometheusRuleExist(ctx, k8s, cfg)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					continue
@@ -139,32 +134,28 @@ func removeStaleConfigs(ctx context.Context, k8s client.Client, cmao *addonv1bet
 	return nil
 }
 
-// isUserDefinedConfig checks whether the config references a user-defined PrometheusRule
-// or ScrapeConfig by fetching the resource and looking for the placement annotation.
+// doesScrapeConfigOrPrometheusRuleExist checks whether the config references an existing ScrapeConfig or PrometheusRule
 // Returns the raw API error on failure so callers can distinguish NotFound from other errors.
-func isUserDefinedConfig(ctx context.Context, k8s client.Client, cfg addonv1beta1.AddOnConfig) (bool, error) {
+func doesScrapeConfigOrPrometheusRuleExist(ctx context.Context, k8s client.Client, cfg addonv1beta1.AddOnConfig) (bool, error) {
 	key := types.NamespacedName{Name: cfg.Name, Namespace: cfg.Namespace}
-
-	var annotations map[string]string
 	switch cfg.Resource {
 	case cooprometheusv1alpha1.ScrapeConfigName:
 		sc := &cooprometheusv1alpha1.ScrapeConfig{}
 		if err := k8s.Get(ctx, key, sc); err != nil {
 			return false, err
+		} else {
+			return true, nil
 		}
-		annotations = sc.Annotations
 	case prometheusv1.PrometheusRuleName:
 		rule := &prometheusv1.PrometheusRule{}
 		if err := k8s.Get(ctx, key, rule); err != nil {
 			return false, err
+		} else {
+			return true, nil
 		}
-		annotations = rule.Annotations
 	default:
 		return false, nil
 	}
-
-	_, hasPlacementAnnotation := annotations[addoncfg.PlacementAnnotationKey]
-	return hasPlacementAnnotation, nil
 }
 
 func ObjectToAddonConfig(obj client.Object) (addonv1beta1.AddOnConfig, error) {

--- a/internal/addon/common/clustermanagementaddon.go
+++ b/internal/addon/common/clustermanagementaddon.go
@@ -96,6 +96,10 @@ func ensureConfigsInAddon(cmao *addonv1beta1.ClusterManagementAddOn, configs []D
 	// Group configs by placement.
 	placementConfigs := map[addonv1beta1.PlacementRef][]addonv1beta1.AddOnConfig{}
 	for _, cfg := range configs {
+		if containsConfig(placementConfigs[cfg.PlacementRef], cfg.Config) {
+			continue
+		}
+
 		placementConfigs[cfg.PlacementRef] = append(placementConfigs[cfg.PlacementRef], cfg.Config)
 	}
 

--- a/internal/addon/common/clustermanagementaddon_test.go
+++ b/internal/addon/common/clustermanagementaddon_test.go
@@ -1,13 +1,20 @@
 package common
 
 import (
+	"context"
 	"testing"
 
+	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	cooprometheusv1alpha1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestEnsureConfigsInAddon(t *testing.T) {
@@ -46,7 +53,7 @@ func TestEnsureConfigsInAddon(t *testing.T) {
 		expectedPlacements []addonv1beta1.PlacementStrategy
 	}{
 		{
-			name: "empty config list",
+			name: "empty config list - no change",
 			initialPlacements: []addonv1beta1.PlacementStrategy{
 				{
 					PlacementRef: placementRefA,
@@ -93,8 +100,8 @@ func TestEnsureConfigsInAddon(t *testing.T) {
 			},
 			expectedPlacements: []addonv1beta1.PlacementStrategy{
 				{
-					Configs:      []addonv1beta1.AddOnConfig{platformConfig, uwlConfig},
 					PlacementRef: placementRefA,
+					Configs:      []addonv1beta1.AddOnConfig{platformConfig, uwlConfig},
 				},
 			},
 		},
@@ -206,6 +213,304 @@ func TestEnsureConfigsInAddon(t *testing.T) {
 
 			ensureConfigsInAddon(cmao, tt.inputConfigs)
 			assert.ElementsMatch(t, tt.expectedPlacements, cmao.Spec.InstallStrategy.Placements)
+		})
+	}
+}
+
+func newCMAOTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, prometheusv1.AddToScheme(scheme))
+	require.NoError(t, cooprometheusv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func TestRemoveStaleConfigs(t *testing.T) {
+	scheme := newCMAOTestScheme(t)
+
+	placementRefA := addonv1beta1.PlacementRef{Namespace: "ns", Name: "a"}
+
+	scrapeConfigCfg := addonv1beta1.AddOnConfig{
+		ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+			Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
+			Resource: cooprometheusv1alpha1.ScrapeConfigName,
+		},
+		ConfigReferent: addonv1beta1.ConfigReferent{
+			Name:      "my-scrapeconfig",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
+	promRuleCfg := addonv1beta1.AddOnConfig{
+		ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+			Group:    prometheusv1.SchemeGroupVersion.Group,
+			Resource: prometheusv1.PrometheusRuleName,
+		},
+		ConfigReferent: addonv1beta1.ConfigReferent{
+			Name:      "my-promrule",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
+	agentCfg := addonv1beta1.AddOnConfig{
+		ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+			Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
+			Resource: cooprometheusv1alpha1.PrometheusAgentName,
+		},
+		ConfigReferent: addonv1beta1.ConfigReferent{
+			Name:      "my-agent",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
+	existingScrapeConfig := &cooprometheusv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-scrapeconfig",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
+	existingPromRule := &prometheusv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-promrule",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
+	testCases := []struct {
+		name            string
+		existingObjects []client.Object
+		initialConfigs  []addonv1beta1.AddOnConfig
+		expectedConfigs []addonv1beta1.AddOnConfig
+		expectError     bool
+	}{
+		{
+			name:            "existing resources are kept",
+			existingObjects: []client.Object{existingScrapeConfig.DeepCopy(), existingPromRule.DeepCopy()},
+			initialConfigs:  []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
+			expectedConfigs: []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
+		},
+		{
+			name:            "non-existent scrapeconfig is removed",
+			existingObjects: []client.Object{existingPromRule.DeepCopy()},
+			initialConfigs:  []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
+			expectedConfigs: []addonv1beta1.AddOnConfig{promRuleCfg, agentCfg},
+		},
+		{
+			name:            "non-existent prometheusrule is removed",
+			existingObjects: []client.Object{existingScrapeConfig.DeepCopy()},
+			initialConfigs:  []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
+			expectedConfigs: []addonv1beta1.AddOnConfig{scrapeConfigCfg, agentCfg},
+		},
+		{
+			name:            "all stale configs removed",
+			existingObjects: []client.Object{},
+			initialConfigs:  []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
+			expectedConfigs: []addonv1beta1.AddOnConfig{agentCfg},
+		},
+		{
+			name:            "non-scrapeconfig-or-promrule configs are never removed",
+			existingObjects: []client.Object{},
+			initialConfigs:  []addonv1beta1.AddOnConfig{agentCfg},
+			expectedConfigs: []addonv1beta1.AddOnConfig{agentCfg},
+		},
+		{
+			name:            "empty configs - no change",
+			existingObjects: []client.Object{},
+			initialConfigs:  []addonv1beta1.AddOnConfig{},
+			expectedConfigs: []addonv1beta1.AddOnConfig{},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existingObjects...).Build()
+
+			cmao := &addonv1beta1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{Name: addoncfg.Name},
+				Spec: addonv1beta1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonv1beta1.InstallStrategy{
+						Placements: []addonv1beta1.PlacementStrategy{
+							{
+								PlacementRef: placementRefA,
+								Configs:      tt.initialConfigs,
+							},
+						},
+					},
+				},
+			}
+
+			err := removeStaleConfigs(context.Background(), fakeClient, cmao)
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expectedConfigs, cmao.Spec.InstallStrategy.Placements[0].Configs)
+		})
+	}
+}
+
+func TestIsUserDefinedConfig(t *testing.T) {
+	scheme := newCMAOTestScheme(t)
+
+	scrapeConfigWithAnnotation := &cooprometheusv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-sc",
+			Namespace: addoncfg.InstallNamespace,
+			Annotations: map[string]string{
+				addoncfg.PlacementAnnotationKey: "ns/placement-a",
+			},
+		},
+	}
+
+	scrapeConfigWithoutAnnotation := &cooprometheusv1alpha1.ScrapeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mco-sc",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
+	promRuleWithAnnotation := &prometheusv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "user-rule",
+			Namespace: addoncfg.InstallNamespace,
+			Annotations: map[string]string{
+				addoncfg.PlacementAnnotationKey: "ns/placement-a,ns/placement-b",
+			},
+		},
+	}
+
+	promRuleWithoutAnnotation := &prometheusv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mco-rule",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		scrapeConfigWithAnnotation,
+		scrapeConfigWithoutAnnotation,
+		promRuleWithAnnotation,
+		promRuleWithoutAnnotation,
+	).Build()
+
+	testCases := []struct {
+		name           string
+		cfg            addonv1beta1.AddOnConfig
+		expected       bool
+		expectNotFound bool
+	}{
+		{
+			name: "scrapeconfig with placement annotation",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
+					Resource: cooprometheusv1alpha1.ScrapeConfigName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "user-sc",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "scrapeconfig without placement annotation",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
+					Resource: cooprometheusv1alpha1.ScrapeConfigName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "mco-sc",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "non-existent scrapeconfig returns not found",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
+					Resource: cooprometheusv1alpha1.ScrapeConfigName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "does-not-exist",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expectNotFound: true,
+		},
+		{
+			name: "prometheusrule with placement annotation",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    prometheusv1.SchemeGroupVersion.Group,
+					Resource: prometheusv1.PrometheusRuleName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "user-rule",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "prometheusrule without placement annotation",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    prometheusv1.SchemeGroupVersion.Group,
+					Resource: prometheusv1.PrometheusRuleName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "mco-rule",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "non-existent prometheusrule returns not found",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    prometheusv1.SchemeGroupVersion.Group,
+					Resource: prometheusv1.PrometheusRuleName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "gone-rule",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expectNotFound: true,
+		},
+		{
+			name: "other resource type returns false with no error",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
+					Resource: cooprometheusv1alpha1.PrometheusAgentName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "some-agent",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := isUserDefinedConfig(context.Background(), fakeClient, tt.cfg)
+			if tt.expectNotFound {
+				require.Error(t, err)
+				assert.True(t, apierrors.IsNotFound(err), "expected NotFound error, got: %v", err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/addon/common/clustermanagementaddon_test.go
+++ b/internal/addon/common/clustermanagementaddon_test.go
@@ -351,48 +351,26 @@ func TestRemoveStaleConfigs(t *testing.T) {
 	}
 }
 
-func TestIsUserDefinedConfig(t *testing.T) {
+func TestDoesScrapeConfigOrPrometheusRuleExist(t *testing.T) {
 	scheme := newCMAOTestScheme(t)
 
-	scrapeConfigWithAnnotation := &cooprometheusv1alpha1.ScrapeConfig{
+	existingScrapeConfig := &cooprometheusv1alpha1.ScrapeConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-sc",
-			Namespace: addoncfg.InstallNamespace,
-			Annotations: map[string]string{
-				addoncfg.PlacementAnnotationKey: "ns/placement-a",
-			},
-		},
-	}
-
-	scrapeConfigWithoutAnnotation := &cooprometheusv1alpha1.ScrapeConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mco-sc",
+			Name:      "existing-sc",
 			Namespace: addoncfg.InstallNamespace,
 		},
 	}
 
-	promRuleWithAnnotation := &prometheusv1.PrometheusRule{
+	existingPromRule := &prometheusv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "user-rule",
-			Namespace: addoncfg.InstallNamespace,
-			Annotations: map[string]string{
-				addoncfg.PlacementAnnotationKey: "ns/placement-a,ns/placement-b",
-			},
-		},
-	}
-
-	promRuleWithoutAnnotation := &prometheusv1.PrometheusRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mco-rule",
+			Name:      "existing-rule",
 			Namespace: addoncfg.InstallNamespace,
 		},
 	}
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
-		scrapeConfigWithAnnotation,
-		scrapeConfigWithoutAnnotation,
-		promRuleWithAnnotation,
-		promRuleWithoutAnnotation,
+		existingScrapeConfig,
+		existingPromRule,
 	).Build()
 
 	testCases := []struct {
@@ -402,32 +380,18 @@ func TestIsUserDefinedConfig(t *testing.T) {
 		expectNotFound bool
 	}{
 		{
-			name: "scrapeconfig with placement annotation",
+			name: "existing scrapeconfig returns true",
 			cfg: addonv1beta1.AddOnConfig{
 				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
 					Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
 					Resource: cooprometheusv1alpha1.ScrapeConfigName,
 				},
 				ConfigReferent: addonv1beta1.ConfigReferent{
-					Name:      "user-sc",
+					Name:      "existing-sc",
 					Namespace: addoncfg.InstallNamespace,
 				},
 			},
 			expected: true,
-		},
-		{
-			name: "scrapeconfig without placement annotation",
-			cfg: addonv1beta1.AddOnConfig{
-				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
-					Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
-					Resource: cooprometheusv1alpha1.ScrapeConfigName,
-				},
-				ConfigReferent: addonv1beta1.ConfigReferent{
-					Name:      "mco-sc",
-					Namespace: addoncfg.InstallNamespace,
-				},
-			},
-			expected: false,
 		},
 		{
 			name: "non-existent scrapeconfig returns not found",
@@ -444,32 +408,18 @@ func TestIsUserDefinedConfig(t *testing.T) {
 			expectNotFound: true,
 		},
 		{
-			name: "prometheusrule with placement annotation",
+			name: "existing prometheusrule returns true",
 			cfg: addonv1beta1.AddOnConfig{
 				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
 					Group:    prometheusv1.SchemeGroupVersion.Group,
 					Resource: prometheusv1.PrometheusRuleName,
 				},
 				ConfigReferent: addonv1beta1.ConfigReferent{
-					Name:      "user-rule",
+					Name:      "existing-rule",
 					Namespace: addoncfg.InstallNamespace,
 				},
 			},
 			expected: true,
-		},
-		{
-			name: "prometheusrule without placement annotation",
-			cfg: addonv1beta1.AddOnConfig{
-				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
-					Group:    prometheusv1.SchemeGroupVersion.Group,
-					Resource: prometheusv1.PrometheusRuleName,
-				},
-				ConfigReferent: addonv1beta1.ConfigReferent{
-					Name:      "mco-rule",
-					Namespace: addoncfg.InstallNamespace,
-				},
-			},
-			expected: false,
 		},
 		{
 			name: "non-existent prometheusrule returns not found",
@@ -503,7 +453,7 @@ func TestIsUserDefinedConfig(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := isUserDefinedConfig(context.Background(), fakeClient, tt.cfg)
+			result, err := doesScrapeConfigOrPrometheusRuleExist(context.Background(), fakeClient, tt.cfg)
 			if tt.expectNotFound {
 				require.Error(t, err)
 				assert.True(t, apierrors.IsNotFound(err), "expected NotFound error, got: %v", err)

--- a/internal/addon/config/config.go
+++ b/internal/addon/config/config.go
@@ -57,6 +57,7 @@ const (
 	PartOfK8sLabelKey             = "app.kubernetes.io/part-of"
 	BackupLabelKey                = "cluster.open-cluster-management.io/backup"
 	BackupLabelValue              = ""
+	PlacementAnnotationKey        = "observability.open-cluster-management.io/placements"
 
 	ClusterClaimClusterID        = "id.k8s.io"
 	ManagedClusterLabelClusterID = "clusterID"

--- a/internal/controllers/resourcecreator/controller.go
+++ b/internal/controllers/resourcecreator/controller.go
@@ -176,7 +176,7 @@ func (r *ResourceCreatorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile right-sizing resources: %w", err)
 	}
 
-	if err := common.x(ctx, r.Log, r.Client, objs); err != nil {
+	if err := common.EnsureAddonConfig(ctx, r.Log, r.Client, objs); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to patch default configs of the clustermanageraddon: %w", err)
 	}
 

--- a/internal/controllers/resourcecreator/controller.go
+++ b/internal/controllers/resourcecreator/controller.go
@@ -176,7 +176,7 @@ func (r *ResourceCreatorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, fmt.Errorf("failed to reconcile right-sizing resources: %w", err)
 	}
 
-	if err := common.EnsureAddonConfig(ctx, r.Log, r.Client, objs); err != nil {
+	if err := common.x(ctx, r.Log, r.Client, objs); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to patch default configs of the clustermanageraddon: %w", err)
 	}
 

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -397,18 +397,20 @@ func (d DefaultStackResources) generatePlacementRefs(placementAnnotations string
 	if placementAnnotations == "" {
 		return nil, nil
 	}
-	// Compute configs to add to each placement
 	placements := strings.Split(placementAnnotations, ",")
 	placementRefs := []addonv1beta1.PlacementRef{}
 	for _, placement := range placements {
-		nameNamespacePair := strings.Split(placement, "/")
-		placementNamespace := nameNamespacePair[0]
-		placementName := nameNamespacePair[1]
-		placementRef := addonv1beta1.PlacementRef{
-			Namespace: placementNamespace,
-			Name:      placementName,
+		if placement == "" {
+			continue
 		}
-		placementRefs = append(placementRefs, placementRef)
+		nameNamespacePair := strings.SplitN(placement, "/", 2)
+		if len(nameNamespacePair) != 2 || nameNamespacePair[0] == "" || nameNamespacePair[1] == "" {
+			return nil, fmt.Errorf("invalid placement reference %q: expected format namespace/name", placement)
+		}
+		placementRefs = append(placementRefs, addonv1beta1.PlacementRef{
+			Namespace: nameNamespacePair[0],
+			Name:      nameNamespacePair[1],
+		})
 	}
 	return placementRefs, nil
 }

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -92,12 +92,6 @@ func (d DefaultStackResources) Reconcile(ctx context.Context) ([]common.DefaultC
 			return configs, fmt.Errorf("failed to reconcile scrapeConfigs: %w", err)
 		}
 		configs = append(configs, scConfigs...)
-
-		userScrapeConfigs, err := d.reconcileUserScrapeConfigs(ctx, mcoUID)
-		if err != nil {
-			return configs, fmt.Errorf("failed to reconcile user-defined scrapeConfigs: %w", err)
-		}
-		configs = append(configs, userScrapeConfigs...)
 	}
 
 	if d.AddonOptions.Platform.Metrics.CollectionEnabled || d.AddonOptions.UserWorkloads.Metrics.CollectionEnabled {
@@ -107,6 +101,11 @@ func (d DefaultStackResources) Reconcile(ctx context.Context) ([]common.DefaultC
 			return configs, fmt.Errorf("failed to get prometheusRules: %w", err)
 		}
 		configs = append(configs, ruleConfigs...)
+		userScrapeConfigs, err := d.reconcileUserScrapeConfigs(ctx, mcoUID)
+		if err != nil {
+			return configs, fmt.Errorf("failed to reconcile user-defined scrapeConfigs: %w", err)
+		}
+		configs = append(configs, userScrapeConfigs...)
 	}
 
 	return configs, nil

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -140,9 +140,11 @@ func (d DefaultStackResources) reconcileScrapeConfigs(ctx context.Context, mcoUI
 		return nil, fmt.Errorf("failed to list scrapeConfigs: %w", err)
 	}
 
-	scrapeConfigs := []client.Object{}
+	mcoManagedScrapeConfigs := []client.Object{}
+	userDefinedScrapeConfigs := []client.Object{}
 	for _, existingSC := range scrapeConfigsList.Items {
-		if !hasControllerUID(existingSC.OwnerReferences, mcoUID) {
+		// Ensures that we only filter for MCO-managed scrape configs or user-defined scrape configs that have at least one of these labels along with the required annotation for user-defined scrape configs
+		if !hasControllerUID(existingSC.OwnerReferences, mcoUID) && existingSC.Labels[addoncfg.PartOfK8sLabelKey] == addoncfg.Name {
 			continue
 		}
 
@@ -175,13 +177,32 @@ func (d DefaultStackResources) reconcileScrapeConfigs(ctx context.Context, mcoUI
 			}
 			d.Logger.Info("updated scrapeConfig with server-side apply", "namespace", desiredSC.Namespace, "name", desiredSC.Name)
 		}
-
-		scrapeConfigs = append(scrapeConfigs, desiredSC)
+		if hasControllerUID(existingSC.OwnerReferences, mcoUID) {
+			mcoManagedScrapeConfigs = append(mcoManagedScrapeConfigs, desiredSC)
+		} else {
+			userDefinedScrapeConfigs = append(userDefinedScrapeConfigs, desiredSC)
+		}
 	}
-
-	configs, err := d.generateConfigsForAllPlacements(scrapeConfigs)
+	configs, err := d.generateConfigsForAllPlacements(mcoManagedScrapeConfigs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate default configs: %w", err)
+	}
+	for _, userDefinedSC := range userDefinedScrapeConfigs {
+		placementAnnotations := userDefinedSC.(*cooprometheusv1alpha1.ScrapeConfig).Annotations[addoncfg.PlacementAnnotationKey]
+		placementRefs, err := d.generatePlacementRefs(placementAnnotations)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate placement refs: %w", err)
+		}
+		cfg, err := common.ObjectToAddonConfig(userDefinedSC)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate addon config for %s: %w", userDefinedSC.(*cooprometheusv1alpha1.ScrapeConfig).Name, err)
+		}
+		for _, placementRef := range placementRefs {
+			configs = append(configs, common.DefaultConfig{
+				PlacementRef: placementRef,
+				Config:       cfg,
+			})
+		}
 	}
 
 	return configs, nil
@@ -394,6 +415,22 @@ func (d DefaultStackResources) generateConfigsForAllPlacements(object []client.O
 	}
 
 	return defaultConfigs, nil
+}
+func (d DefaultStackResources) generatePlacementRefs(placementAnnotations string) ([]addonv1beta1.PlacementRef, error) {
+	// Compute configs to add to each placement
+	placements := strings.Split(placementAnnotations, ",")
+	placementRefs := []addonv1beta1.PlacementRef{}
+	for _, placement := range placements {
+		nameNamespacePair := strings.Split(placement, "/")
+		placementNamespace := nameNamespacePair[0]
+		placementName := nameNamespacePair[1]
+		placementRef := addonv1beta1.PlacementRef{
+			Namespace: placementNamespace,
+			Name:      placementName,
+		}
+		placementRefs = append(placementRefs, placementRef)
+	}
+	return placementRefs, nil
 }
 
 func makeAgentName(app, placement string) string {

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -392,7 +392,11 @@ func (d DefaultStackResources) generateConfigsForAllPlacements(object []client.O
 
 	return defaultConfigs, nil
 }
+
 func (d DefaultStackResources) generatePlacementRefs(placementAnnotations string) ([]addonv1beta1.PlacementRef, error) {
+	if placementAnnotations == "" {
+		return nil, nil
+	}
 	// Compute configs to add to each placement
 	placements := strings.Split(placementAnnotations, ",")
 	placementRefs := []addonv1beta1.PlacementRef{}

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -101,11 +101,6 @@ func (d DefaultStackResources) Reconcile(ctx context.Context) ([]common.DefaultC
 			return configs, fmt.Errorf("failed to get prometheusRules: %w", err)
 		}
 		configs = append(configs, ruleConfigs...)
-		userScrapeConfigs, err := d.reconcileUserScrapeConfigs(ctx, mcoUID)
-		if err != nil {
-			return configs, fmt.Errorf("failed to reconcile user-defined scrapeConfigs: %w", err)
-		}
-		configs = append(configs, userScrapeConfigs...)
 	}
 
 	return configs, nil
@@ -205,48 +200,6 @@ func (d DefaultStackResources) reconcileScrapeConfigs(ctx context.Context, mcoUI
 		}
 	}
 
-	return configs, nil
-}
-
-// This function is used to generate a config for each user-defined scrape config with the appropriate labels
-func (d DefaultStackResources) reconcileUserScrapeConfigs(ctx context.Context, mcoUID types.UID) ([]common.DefaultConfig, error) {
-	labelVals := []string{"multicluster-observability-addon"}
-	d.Logger.V(2).Info("reconciling User-Defined ScrapeConfigs", "mcoUID", mcoUID)
-	req, err := labels.NewRequirement(addoncfg.PartOfK8sLabelKey, selection.In, labelVals)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create labels requirement for scrapeConfigs: %w", err)
-	}
-	labelsSelector := labels.NewSelector().Add(*req)
-
-	scrapeConfigsList := &cooprometheusv1alpha1.ScrapeConfigList{}
-	if err = d.Client.List(ctx, scrapeConfigsList, client.InNamespace(addoncfg.InstallNamespace), client.MatchingLabelsSelector{Selector: labelsSelector}); err != nil {
-		return nil, fmt.Errorf("failed to list scrapeConfigs: %w", err)
-	}
-	configs := []common.DefaultConfig{}
-	for _, existingSC := range scrapeConfigsList.Items {
-		if hasControllerUID(existingSC.OwnerReferences, mcoUID) {
-			continue
-		}
-		placementAnnotations := existingSC.Annotations[addoncfg.PlacementAnnotationKey]
-		placements := strings.Split(placementAnnotations, ",")
-		cfg, err := common.ObjectToAddonConfig(&existingSC)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate addon config for %s: %w", existingSC.Name, err)
-		}
-		for _, placement := range placements {
-			nameNamespacePair := strings.Split(placement, "/")
-			placementNamespace := nameNamespacePair[0]
-			placementName := nameNamespacePair[1]
-			placementRef := addonv1beta1.PlacementRef{
-				Namespace: placementNamespace,
-				Name:      placementName,
-			}
-			configs = append(configs, common.DefaultConfig{
-				PlacementRef: placementRef,
-				Config:       cfg,
-			})
-		}
-	}
 	return configs, nil
 }
 

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -237,18 +237,41 @@ func (d DefaultStackResources) getPrometheusRules(ctx context.Context, mcoUID ty
 		return nil, fmt.Errorf("failed to list prometheusRules: %w", err)
 	}
 
-	promRules := []client.Object{}
-	for _, sc := range promRuleList.Items {
-		if !hasControllerUID(sc.OwnerReferences, mcoUID) {
+	mcoManagedRules := []client.Object{}
+	userDefinedRules := []client.Object{}
+	for _, rule := range promRuleList.Items {
+		if !hasControllerUID(rule.OwnerReferences, mcoUID) && rule.Labels[addoncfg.PartOfK8sLabelKey] == addoncfg.Name {
 			continue
 		}
 
-		promRules = append(promRules, &sc)
+		if hasControllerUID(rule.OwnerReferences, mcoUID) {
+			mcoManagedRules = append(mcoManagedRules, &rule)
+		} else {
+			userDefinedRules = append(userDefinedRules, &rule)
+		}
 	}
 
-	configs, err := d.generateConfigsForAllPlacements(promRules)
+	configs, err := d.generateConfigsForAllPlacements(mcoManagedRules)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate default configs for prometheusRules: %w", err)
+	}
+
+	for _, userDefinedRule := range userDefinedRules {
+		placementAnnotations := userDefinedRule.(*prometheusv1.PrometheusRule).Annotations[addoncfg.PlacementAnnotationKey]
+		placementRefs, err := d.generatePlacementRefs(placementAnnotations)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate placement refs: %w", err)
+		}
+		cfg, err := common.ObjectToAddonConfig(userDefinedRule)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate addon config for %s: %w", userDefinedRule.(*prometheusv1.PrometheusRule).Name, err)
+		}
+		for _, placementRef := range placementRefs {
+			configs = append(configs, common.DefaultConfig{
+				PlacementRef: placementRef,
+				Config:       cfg,
+			})
+		}
 	}
 
 	return configs, nil

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -139,7 +139,7 @@ func (d DefaultStackResources) reconcileScrapeConfigs(ctx context.Context, mcoUI
 	userDefinedScrapeConfigs := []client.Object{}
 	for _, existingSC := range scrapeConfigsList.Items {
 		// Ensures that we only filter for MCO-managed scrape configs or user-defined scrape configs that have at least one of these labels along with the required annotation for user-defined scrape configs
-		if !hasControllerUID(existingSC.OwnerReferences, mcoUID) && existingSC.Labels[addoncfg.PartOfK8sLabelKey] == addoncfg.Name {
+		if !hasControllerUID(existingSC.OwnerReferences, mcoUID) && !(existingSC.Labels[addoncfg.PartOfK8sLabelKey] == addoncfg.Name) {
 			continue
 		}
 
@@ -240,7 +240,7 @@ func (d DefaultStackResources) getPrometheusRules(ctx context.Context, mcoUID ty
 	mcoManagedRules := []client.Object{}
 	userDefinedRules := []client.Object{}
 	for _, rule := range promRuleList.Items {
-		if !hasControllerUID(rule.OwnerReferences, mcoUID) && rule.Labels[addoncfg.PartOfK8sLabelKey] == addoncfg.Name {
+		if !hasControllerUID(rule.OwnerReferences, mcoUID) && !(rule.Labels[addoncfg.PartOfK8sLabelKey] == addoncfg.Name) {
 			continue
 		}
 

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 
 	"github.com/go-logr/logr"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -91,6 +92,12 @@ func (d DefaultStackResources) Reconcile(ctx context.Context) ([]common.DefaultC
 			return configs, fmt.Errorf("failed to reconcile scrapeConfigs: %w", err)
 		}
 		configs = append(configs, scConfigs...)
+
+		userScrapeConfigs, err := d.reconcileUserScrapeConfigs(ctx, mcoUID)
+		if err != nil {
+			return configs, fmt.Errorf("failed to reconcile user-defined scrapeConfigs: %w", err)
+		}
+		configs = append(configs, userScrapeConfigs...)
 	}
 
 	if d.AddonOptions.Platform.Metrics.CollectionEnabled || d.AddonOptions.UserWorkloads.Metrics.CollectionEnabled {
@@ -178,6 +185,48 @@ func (d DefaultStackResources) reconcileScrapeConfigs(ctx context.Context, mcoUI
 		return nil, fmt.Errorf("failed to generate default configs: %w", err)
 	}
 
+	return configs, nil
+}
+
+// This function is used to generate a config for each user-defined scrape config with the appropriate labels
+func (d DefaultStackResources) reconcileUserScrapeConfigs(ctx context.Context, mcoUID types.UID) ([]common.DefaultConfig, error) {
+	labelVals := []string{"multicluster-observability-addon"}
+	d.Logger.V(2).Info("reconciling User-Defined ScrapeConfigs", "mcoUID", mcoUID)
+	req, err := labels.NewRequirement(addoncfg.PartOfK8sLabelKey, selection.In, labelVals)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create labels requirement for scrapeConfigs: %w", err)
+	}
+	labelsSelector := labels.NewSelector().Add(*req)
+
+	scrapeConfigsList := &cooprometheusv1alpha1.ScrapeConfigList{}
+	if err = d.Client.List(ctx, scrapeConfigsList, client.InNamespace(addoncfg.InstallNamespace), client.MatchingLabelsSelector{Selector: labelsSelector}); err != nil {
+		return nil, fmt.Errorf("failed to list scrapeConfigs: %w", err)
+	}
+	configs := []common.DefaultConfig{}
+	for _, existingSC := range scrapeConfigsList.Items {
+		if hasControllerUID(existingSC.OwnerReferences, mcoUID) {
+			continue
+		}
+		placementAnnotations := existingSC.Annotations[addoncfg.PlacementAnnotationKey]
+		placements := strings.Split(placementAnnotations, ",")
+		cfg, err := common.ObjectToAddonConfig(&existingSC)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate addon config for %s: %w", existingSC.Name, err)
+		}
+		for _, placement := range placements {
+			nameNamespacePair := strings.Split(placement, "/")
+			placementNamespace := nameNamespacePair[0]
+			placementName := nameNamespacePair[1]
+			placementRef := addonv1beta1.PlacementRef{
+				Namespace: placementNamespace,
+				Name:      placementName,
+			}
+			configs = append(configs, common.DefaultConfig{
+				PlacementRef: placementRef,
+				Config:       cfg,
+			})
+		}
+	}
 	return configs, nil
 }
 

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -408,10 +409,14 @@ func (d DefaultStackResources) generatePlacementRefs(placementAnnotations string
 		if len(nameNamespacePair) != 2 || nameNamespacePair[0] == "" || nameNamespacePair[1] == "" {
 			return nil, fmt.Errorf("%w %q: expected format namespace/name", errInvalidPlacementReference, placement)
 		}
-		placementRefs = append(placementRefs, addonv1beta1.PlacementRef{
+		ref := addonv1beta1.PlacementRef{
 			Namespace: nameNamespacePair[0],
 			Name:      nameNamespacePair[1],
-		})
+		}
+		if slices.Contains(placementRefs, ref) {
+			continue
+		}
+		placementRefs = append(placementRefs, ref)
 	}
 	return placementRefs, nil
 }

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -27,8 +27,9 @@ import (
 )
 
 var (
-	errTooManyConfigResources = errors.New("too many configuration resources")
-	errMissingHubEndpoint     = errors.New("hub endpoint is missing")
+	errTooManyConfigResources    = errors.New("too many configuration resources")
+	errMissingHubEndpoint        = errors.New("hub endpoint is missing")
+	errInvalidPlacementReference = errors.New("invalid placement reference")
 )
 
 // DefaultStackResources reconciles the configuration resources needed for metrics collection
@@ -139,7 +140,7 @@ func (d DefaultStackResources) reconcileScrapeConfigs(ctx context.Context, mcoUI
 	userDefinedScrapeConfigs := []client.Object{}
 	for _, existingSC := range scrapeConfigsList.Items {
 		// Ensures that we only filter for MCO-managed scrape configs or user-defined scrape configs that have at least one of these labels along with the required annotation for user-defined scrape configs
-		if !hasControllerUID(existingSC.OwnerReferences, mcoUID) && !(existingSC.Labels[addoncfg.PartOfK8sLabelKey] == addoncfg.Name) {
+		if !hasControllerUID(existingSC.OwnerReferences, mcoUID) && existingSC.Labels[addoncfg.PartOfK8sLabelKey] != addoncfg.Name {
 			continue
 		}
 
@@ -240,7 +241,7 @@ func (d DefaultStackResources) getPrometheusRules(ctx context.Context, mcoUID ty
 	mcoManagedRules := []client.Object{}
 	userDefinedRules := []client.Object{}
 	for _, rule := range promRuleList.Items {
-		if !hasControllerUID(rule.OwnerReferences, mcoUID) && !(rule.Labels[addoncfg.PartOfK8sLabelKey] == addoncfg.Name) {
+		if !hasControllerUID(rule.OwnerReferences, mcoUID) && rule.Labels[addoncfg.PartOfK8sLabelKey] != addoncfg.Name {
 			continue
 		}
 
@@ -405,7 +406,7 @@ func (d DefaultStackResources) generatePlacementRefs(placementAnnotations string
 		}
 		nameNamespacePair := strings.SplitN(placement, "/", 2)
 		if len(nameNamespacePair) != 2 || nameNamespacePair[0] == "" || nameNamespacePair[1] == "" {
-			return nil, fmt.Errorf("invalid placement reference %q: expected format namespace/name", placement)
+			return nil, fmt.Errorf("%w %q: expected format namespace/name", errInvalidPlacementReference, placement)
 		}
 		placementRefs = append(placementRefs, addonv1beta1.PlacementRef{
 			Namespace: nameNamespacePair[0],

--- a/internal/metrics/resource/resource_test.go
+++ b/internal/metrics/resource/resource_test.go
@@ -625,7 +625,7 @@ func TestReconcileScrapeConfigs(t *testing.T) {
 						Name:      "user-sc",
 						Labels: map[string]string{
 							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
-							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+							addoncfg.PartOfK8sLabelKey:    addoncfg.Name,
 						},
 						Annotations: map[string]string{
 							addoncfg.PlacementAnnotationKey: "ns/a",
@@ -652,7 +652,7 @@ func TestReconcileScrapeConfigs(t *testing.T) {
 						Name:      "user-sc-multi",
 						Labels: map[string]string{
 							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
-							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+							addoncfg.PartOfK8sLabelKey:    addoncfg.Name,
 						},
 						Annotations: map[string]string{
 							addoncfg.PlacementAnnotationKey: "ns/a,ns/b",
@@ -676,7 +676,7 @@ func TestReconcileScrapeConfigs(t *testing.T) {
 						Name:      "user-sc-no-annotation",
 						Labels: map[string]string{
 							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
-							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+							addoncfg.PartOfK8sLabelKey:    addoncfg.Name,
 						},
 					},
 				},
@@ -708,7 +708,7 @@ func TestReconcileScrapeConfigs(t *testing.T) {
 						Name:      "user-sc",
 						Labels: map[string]string{
 							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
-							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+							addoncfg.PartOfK8sLabelKey:    addoncfg.Name,
 						},
 						Annotations: map[string]string{
 							addoncfg.PlacementAnnotationKey: "ns/a",
@@ -904,7 +904,7 @@ func TestGetPrometheusRules(t *testing.T) {
 						Name:      "user-rule",
 						Labels: map[string]string{
 							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
-							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+							addoncfg.PartOfK8sLabelKey:    addoncfg.Name,
 						},
 						Annotations: map[string]string{
 							addoncfg.PlacementAnnotationKey: "ns/a",
@@ -930,7 +930,7 @@ func TestGetPrometheusRules(t *testing.T) {
 						Name:      "user-rule-multi",
 						Labels: map[string]string{
 							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
-							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+							addoncfg.PartOfK8sLabelKey:    addoncfg.Name,
 						},
 						Annotations: map[string]string{
 							addoncfg.PlacementAnnotationKey: "ns/a,ns/b",
@@ -955,7 +955,7 @@ func TestGetPrometheusRules(t *testing.T) {
 						Name:      "user-rule-no-annotation",
 						Labels: map[string]string{
 							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
-							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+							addoncfg.PartOfK8sLabelKey:    addoncfg.Name,
 						},
 					},
 				},
@@ -988,7 +988,7 @@ func TestGetPrometheusRules(t *testing.T) {
 						Name:      "user-rule",
 						Labels: map[string]string{
 							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
-							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+							addoncfg.PartOfK8sLabelKey:    addoncfg.Name,
 						},
 						Annotations: map[string]string{
 							addoncfg.PlacementAnnotationKey: "ns/a",

--- a/internal/metrics/resource/resource_test.go
+++ b/internal/metrics/resource/resource_test.go
@@ -614,6 +614,116 @@ func TestReconcileScrapeConfigs(t *testing.T) {
 			},
 		},
 		{
+			name: "user-defined SC with single placement annotation",
+			initObjs: []client.Object{
+				&cooprometheusv1alpha1.ScrapeConfig{
+					TypeMeta: metav1.TypeMeta{
+						Kind: cooprometheusv1alpha1.ScrapeConfigsKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: config.HubInstallNamespace,
+						Name:      "user-sc",
+						Labels: map[string]string{
+							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
+							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+						},
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: "ns/a",
+						},
+					},
+				},
+			},
+			expects: func(t *testing.T, objs []cooprometheusv1alpha1.ScrapeConfig) {
+				assert.Len(t, objs, 1)
+				assert.Equal(t, "user-sc", objs[0].Name)
+				assert.Contains(t, objs[0].Labels, addoncfg.BackupLabelKey)
+				assert.Equal(t, addoncfg.BackupLabelValue, objs[0].Labels[addoncfg.BackupLabelKey])
+			},
+		},
+		{
+			name: "user-defined SC with multiple placement annotations",
+			initObjs: []client.Object{
+				&cooprometheusv1alpha1.ScrapeConfig{
+					TypeMeta: metav1.TypeMeta{
+						Kind: cooprometheusv1alpha1.ScrapeConfigsKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: config.HubInstallNamespace,
+						Name:      "user-sc-multi",
+						Labels: map[string]string{
+							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
+							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+						},
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: "ns/a,ns/b",
+						},
+					},
+				},
+			},
+			expects: func(t *testing.T, objs []cooprometheusv1alpha1.ScrapeConfig) {
+				assert.Len(t, objs, 2)
+			},
+		},
+		{
+			name: "user-defined SC without placement annotation is skipped",
+			initObjs: []client.Object{
+				&cooprometheusv1alpha1.ScrapeConfig{
+					TypeMeta: metav1.TypeMeta{
+						Kind: cooprometheusv1alpha1.ScrapeConfigsKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: config.HubInstallNamespace,
+						Name:      "user-sc-no-annotation",
+						Labels: map[string]string{
+							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
+							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+						},
+					},
+				},
+			},
+			expects: func(t *testing.T, objs []cooprometheusv1alpha1.ScrapeConfig) {
+				assert.Empty(t, objs)
+			},
+		},
+		{
+			name: "user-defined SC coexists with MCO-managed SC",
+			initObjs: []client.Object{
+				&cooprometheusv1alpha1.ScrapeConfig{
+					TypeMeta: metav1.TypeMeta{
+						Kind: cooprometheusv1alpha1.ScrapeConfigsKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       config.HubInstallNamespace,
+						Name:            "mco-sc",
+						Labels:          config.PlatformPrometheusMatchLabels,
+						OwnerReferences: []metav1.OwnerReference{mcoOwnerRef},
+					},
+				},
+				&cooprometheusv1alpha1.ScrapeConfig{
+					TypeMeta: metav1.TypeMeta{
+						Kind: cooprometheusv1alpha1.ScrapeConfigsKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: config.HubInstallNamespace,
+						Name:      "user-sc",
+						Labels: map[string]string{
+							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
+							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+						},
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: "ns/a",
+						},
+					},
+				},
+			},
+			expects: func(t *testing.T, objs []cooprometheusv1alpha1.ScrapeConfig) {
+				assert.Len(t, objs, 2)
+				names := []string{objs[0].Name, objs[1].Name}
+				assert.Contains(t, names, "mco-sc")
+				assert.Contains(t, names, "user-sc")
+			},
+		},
+		{
 			name: "hcp SC is handled",
 			initObjs: []client.Object{
 				&cooprometheusv1alpha1.ScrapeConfig{
@@ -783,6 +893,118 @@ func TestGetPrometheusRules(t *testing.T) {
 			},
 		},
 		{
+			name: "user-defined rule with single placement annotation",
+			initObjs: []client.Object{
+				&prometheusv1.PrometheusRule{
+					TypeMeta: metav1.TypeMeta{
+						Kind: prometheusv1.PrometheusRuleKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: config.HubInstallNamespace,
+						Name:      "user-rule",
+						Labels: map[string]string{
+							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
+							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+						},
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: "ns/a",
+						},
+					},
+				},
+			},
+			platformEnabled: true,
+			expects: func(t *testing.T, objs []prometheusv1.PrometheusRule) {
+				assert.Len(t, objs, 1)
+				assert.Equal(t, "user-rule", objs[0].Name)
+			},
+		},
+		{
+			name: "user-defined rule with multiple placement annotations",
+			initObjs: []client.Object{
+				&prometheusv1.PrometheusRule{
+					TypeMeta: metav1.TypeMeta{
+						Kind: prometheusv1.PrometheusRuleKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: config.HubInstallNamespace,
+						Name:      "user-rule-multi",
+						Labels: map[string]string{
+							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
+							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+						},
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: "ns/a,ns/b",
+						},
+					},
+				},
+			},
+			platformEnabled: true,
+			expects: func(t *testing.T, objs []prometheusv1.PrometheusRule) {
+				assert.Len(t, objs, 2)
+			},
+		},
+		{
+			name: "user-defined rule without placement annotation is skipped",
+			initObjs: []client.Object{
+				&prometheusv1.PrometheusRule{
+					TypeMeta: metav1.TypeMeta{
+						Kind: prometheusv1.PrometheusRuleKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: config.HubInstallNamespace,
+						Name:      "user-rule-no-annotation",
+						Labels: map[string]string{
+							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
+							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+						},
+					},
+				},
+			},
+			platformEnabled: true,
+			expects: func(t *testing.T, objs []prometheusv1.PrometheusRule) {
+				assert.Empty(t, objs)
+			},
+		},
+		{
+			name: "user-defined rule coexists with MCO-managed rule",
+			initObjs: []client.Object{
+				&prometheusv1.PrometheusRule{
+					TypeMeta: metav1.TypeMeta{
+						Kind: prometheusv1.PrometheusRuleKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:       config.HubInstallNamespace,
+						Name:            "mco-rule",
+						Labels:          config.PlatformPrometheusMatchLabels,
+						OwnerReferences: []metav1.OwnerReference{mcoOwnerRef},
+					},
+				},
+				&prometheusv1.PrometheusRule{
+					TypeMeta: metav1.TypeMeta{
+						Kind: prometheusv1.PrometheusRuleKind,
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: config.HubInstallNamespace,
+						Name:      "user-rule",
+						Labels: map[string]string{
+							addoncfg.ComponentK8sLabelKey: config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey],
+							addoncfg.PartOfK8sLabelKey:   addoncfg.Name,
+						},
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: "ns/a",
+						},
+					},
+				},
+			},
+			platformEnabled: true,
+			expects: func(t *testing.T, objs []prometheusv1.PrometheusRule) {
+				assert.Len(t, objs, 2)
+				names := []string{objs[0].Name, objs[1].Name}
+				assert.Contains(t, names, "mco-rule")
+				assert.Contains(t, names, "user-rule")
+			},
+		},
+		{
 			name: "hcp rules are fetched",
 			initObjs: []client.Object{
 				&prometheusv1.PrometheusRule{
@@ -858,6 +1080,50 @@ func TestGetPrometheusRules(t *testing.T) {
 			if tc.expects != nil {
 				tc.expects(t, rules)
 			}
+		})
+	}
+}
+
+func TestGeneratePlacementRefs(t *testing.T) {
+	d := DefaultStackResources{}
+
+	testCases := []struct {
+		name        string
+		annotations string
+		expected    []addonv1beta1.PlacementRef
+		expectErr   bool
+	}{
+		{
+			name:        "empty string returns nil",
+			annotations: "",
+			expected:    nil,
+		},
+		{
+			name:        "single placement",
+			annotations: "ns-a/placement-a",
+			expected: []addonv1beta1.PlacementRef{
+				{Namespace: "ns-a", Name: "placement-a"},
+			},
+		},
+		{
+			name:        "multiple placements",
+			annotations: "ns-a/placement-a,ns-b/placement-b",
+			expected: []addonv1beta1.PlacementRef{
+				{Namespace: "ns-a", Name: "placement-a"},
+				{Namespace: "ns-b", Name: "placement-b"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			refs, err := d.generatePlacementRefs(tc.annotations)
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, refs)
 		})
 	}
 }

--- a/internal/metrics/resource/resource_test.go
+++ b/internal/metrics/resource/resource_test.go
@@ -1113,6 +1113,28 @@ func TestGeneratePlacementRefs(t *testing.T) {
 				{Namespace: "ns-b", Name: "placement-b"},
 			},
 		},
+		{
+			name:        "trailing comma is tolerated",
+			annotations: "ns-a/placement-a,",
+			expected: []addonv1beta1.PlacementRef{
+				{Namespace: "ns-a", Name: "placement-a"},
+			},
+		},
+		{
+			name:        "missing separator returns error",
+			annotations: "no-separator",
+			expectErr:   true,
+		},
+		{
+			name:        "empty namespace returns error",
+			annotations: "/placement-a",
+			expectErr:   true,
+		},
+		{
+			name:        "empty name returns error",
+			annotations: "ns-a/",
+			expectErr:   true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Summary:

Fixes [ACM-34753](https://redhat.atlassian.net/browse/ACM-34753) 

Problem:

Users currently lack an easy way to deploy their own prometheusRules and ScrapeConfigs onto managed clusters.

Root Cause:

The MCOA resource controller was only focusing on MCO-created prometheusRules and scrapeConfigs, it wasn't watching user-created resources.

Fix:

Edit the MCOA resource controller so that user-created prometheusRules and ScrapeConfigs with the appropriate label and annotations are watched and created on the appropriate placements based on the resource's placement annotation. Also, deletion of these resources is handled as well through deleting the actual resource on the spoke, as well as deleting the reference from the MCOA resource. 

Files Changed:

Modified:

`internal/addon/common/clustermanagementaddon.go`
 `internal/addon/common/clustermanagementaddon_test.go`
 `internal/addon/config/config.go`
 `internal/metrics/resource/resource.go`
  `internal/metrics/resource/resource_test.go`

Test Plan:
Tested end to end locally on the collective cluster and verified that the prometheusRules and scrapeConfigs created by the user appear on the spoke cluster when a placement is specified. I also tested that the deletion behavior works as expected, along with creating unit tests and verifying that unit tests run successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-defined scrape configurations and Prometheus rules are now automatically reconciled and expanded per placement using a standardized placement annotation.
* **Enhancements**
  * Resource reconciliation now more reliably distinguishes system-managed from user-defined objects to prevent unintended overwrites.
  * Added a dedicated placement annotation key to ensure consistent per-placement parsing.
* **Tests**
  * Expanded unit test coverage for placement-annotation parsing and mixed system/user scenarios for both scrape configurations and Prometheus rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[ACM-34753]: https://redhat.atlassian.net/browse/ACM-34753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ