### PR TITLE
Fix invalid servicemonitor group non ocp

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/platform-agent/metrics-service-monitor.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/platform-agent/metrics-service-monitor.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.platformEnabled }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ if .Values.deployNonOCPStack }}monitoring.rhobs/v1{{ else }}monitoring.coreos.com/v1{{ end }}
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.platform.appName }}
@@ -9,6 +9,11 @@ metadata:
     {{ include "metricshelm.labels" . | nindent 4 }}
 spec:
   endpoints:
+  {{- if .Values.deployNonOCPStack }}
+  - interval: 30s
+    port: metrics
+    scheme: http
+  {{- else }}
   - interval: 30s
     port: metrics
     scheme: https
@@ -16,6 +21,7 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: "{{ .Values.platform.appName }}.{{ .Release.Namespace }}.svc"
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/component: {{ .Values.platform.component }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/prometheus-operator/operator/metrics-service-monitor.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/prometheus-operator/operator/metrics-service-monitor.yaml
@@ -1,5 +1,5 @@
 {{- if  .Values.deployCOOResources }}
-apiVersion: monitoring.coreos.com/v1
+apiVersion: {{ if .Values.deployNonOCPStack }}monitoring.rhobs/v1{{ else }}monitoring.coreos.com/v1{{ end }}
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.prometheusOperator.appName }}

--- a/internal/metrics/helm_test.go
+++ b/internal/metrics/helm_test.go
@@ -283,12 +283,22 @@ func TestHelmBuild_Metrics_All(t *testing.T) {
 				}
 
 				// Ensure the ServiceMonitor is configured for HTTP
-				sms := common.FilterResourcesByLabelSelector[*prometheusv1.ServiceMonitor](objects, matchLabels)
+				sms := common.FilterResourcesByLabelSelector[*cooprometheusv1.ServiceMonitor](objects, matchLabels)
 				assert.Len(t, sms, 1)
 				operatorSM := sms[0]
 				assert.NotNil(t, operatorSM.Spec.Endpoints[0].Scheme)
-				assert.Equal(t, prometheusv1.Scheme("http"), *operatorSM.Spec.Endpoints[0].Scheme)
+				assert.Equal(t, cooprometheusv1.Scheme("http"), *operatorSM.Spec.Endpoints[0].Scheme)
 				assert.Nil(t, operatorSM.Spec.Endpoints[0].TLSConfig)
+
+				// Ensure the platform-metrics-collector ServiceMonitor is also configured for HTTP
+				platformSMs := common.FilterResourcesByLabelSelector[*cooprometheusv1.ServiceMonitor](objects, map[string]string{
+					"app.kubernetes.io/component": "platform-metrics-collector",
+				})
+				assert.Len(t, platformSMs, 1)
+				platformSM := platformSMs[0]
+				assert.NotNil(t, platformSM.Spec.Endpoints[0].Scheme)
+				assert.Equal(t, cooprometheusv1.Scheme("http"), *platformSM.Spec.Endpoints[0].Scheme)
+				assert.Nil(t, platformSM.Spec.Endpoints[0].TLSConfig)
 
 				// Ensure the Service is targeting the correct port
 				svcs := common.FilterResourcesByLabelSelector[*corev1.Service](objects, matchLabels)
@@ -839,6 +849,10 @@ func TestHelmBuild_Metrics_All(t *testing.T) {
 			for _, obj := range objects {
 				accessor, err := meta.Accessor(obj)
 				require.NoError(t, err)
+
+				if !tc.IsOCP {
+					assert.NotEqual(t, "monitoring.coreos.com", obj.GetObjectKind().GroupVersionKind().Group, "Should not deploy monitoring.coreos.com resource on non-OCP: %s/%s", obj.GetObjectKind().GroupVersionKind(), accessor.GetName())
+				}
 
 				// if not a global object, check namespace
 				// secrets are possible to install in multiple namespaces (such as openshift-monitoring)


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ACM-35868

This PR fixes a deployment failure on non-OpenShift clusters (such as AKS) where the `ManifestWork` fails to apply because of unrecognized `monitoring.coreos.com` ServiceMonitor resources.

#### **Problem & Root Cause**
* **On OCP:** We integrate directly with OpenShift's platform cluster-monitoring stack, which uses standard `monitoring.coreos.com` ServiceMonitors secured by OpenShift's Service CA (HTTPS/TLS).
* **On non-OCP (e.g., AKS):** We deploy our own standalone Prometheus server and operator using the **Red Hat Observability (RHOBS) Prometheus Operator**. This operator registers and reconciles resources under the **`monitoring.rhobs`** API group instead of `monitoring.coreos.com`.

Since the templates for the `prometheus-operator` and `platform-metrics-collector` ServiceMonitors had their API versions hardcoded to `monitoring.coreos.com/v1`, they failed to apply on AKS because the corresponding CRD is missing. Additionally, even if the CRD were present, our RHOBS Prometheus wouldn't scrape them because it only watches the `monitoring.rhobs` group. 

Furthermore, non-OCP agents are exposed over plain HTTP (no `kube-rbac-proxy` or OCP platform TLS certificates are deployed on non-OCP), so they must use the `http` scrape scheme instead of `https`.

#### **Changes Introduced**
1. **Dynamic ServiceMonitor API Group:** Updated the `prometheus-operator` and `platform-agent` ServiceMonitor templates to dynamically output `monitoring.rhobs/v1` when deploying on non-OCP (`deployNonOCPStack: true`), and standard `monitoring.coreos.com/v1` on OCP.
2. **Dynamic Scrape Scheme:** Adjusted the endpoints configurations in the ServiceMonitors to target plain **`http`** on non-OCP, and secure **`https`** (with OCP Service CA certificate configurations) on OCP.
3. **Unit Tests & Regression Guard:**
   * Added explicit assertions in `internal/metrics/helm_test.go` to ensure that both non-OCP ServiceMonitors are rendered with `http` scheme and no TLS configurations.
   * Introduced a global regression guard to guarantee that **zero** resources of the `monitoring.coreos.com` API group are ever generated for non-OCP managed cluster targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metrics monitoring service configuration to correctly apply based on platform enablement and deployment stack type
  * Corrected monitoring service API version selection to use the appropriate configuration for your deployment environment
  * Improved validation to ensure monitoring configurations are correctly applied to relevant deployment scenarios only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->