### PR TITLE
fix(perses): fix Time Since Migration unit, hide value #13, increase stat font size

### DIFF
--- a/pkg/perses/panels/virtualization/units.go
+++ b/pkg/perses/panels/virtualization/units.go
@@ -12,5 +12,4 @@ var (
 	opsPerSecUnit      = "ops/sec"
 	decBytesPerSecUnit = string(commonSdk.BytesDecPerSecondsUnit) // "decbytes/sec"
 	dateTimeLocalUnit  = "datetime-local"
-	relativeTimeUnit   = "relative-time"
 )

--- a/pkg/perses/panels/virtualization/vm-by-time-in-status-panel.go
+++ b/pkg/perses/panels/virtualization/vm-by-time-in-status-panel.go
@@ -15,6 +15,7 @@ func TotalAllocatedCPU(datasourceName string) panelgroup.Option {
 		panel.Description("The total CPUs of the VMs that are listed in the dashboard"),
 		statPanel.Chart(
 			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
 			statPanel.Format(commonSdk.Format{
 				Unit: &dashboards.DecimalUnit,
 			}),
@@ -32,6 +33,7 @@ func TotalAllocatedMemory(datasourceName string) panelgroup.Option {
 		panel.Description("The total Memory of the VMs that are listed in the dashboard"),
 		statPanel.Chart(
 			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
 			statPanel.Format(commonSdk.Format{
 				Unit: &dashboards.BytesUnit,
 			}),
@@ -49,6 +51,7 @@ func TotalAllocatedDisk(datasourceName string) panelgroup.Option {
 		panel.Description("The total disk size of the VMs that are listed in the dashboard"),
 		statPanel.Chart(
 			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
 			statPanel.Format(commonSdk.Format{
 				Unit: &dashboards.BytesUnit,
 			}),
@@ -94,7 +97,7 @@ func TimeInStatusTable(datasourceName, project string) panelgroup.Option {
 				},
 				{
 					Name: "value #3", Header: "Time Since Last Migration", EnableSorting: true,
-					Format: &commonSdk.Format{Unit: strPtr(relativeTimeUnit)},
+					Format: &commonSdk.Format{Unit: &dashboards.SecondsUnit},
 				},
 				{
 					Name: "value #4", Header: "Last Migration", Hide: true,

--- a/pkg/perses/panels/virtualization/vm-by-time-in-status-queries.go
+++ b/pkg/perses/panels/virtualization/vm-by-time-in-status-queries.go
@@ -161,12 +161,12 @@ const vmByTimeInStatusTableTimeInStatusQuery = `(
 (kubevirt_vm_info{cluster=~"$cluster", name=~"$name", namespace=~"$namespace", status_group=~"$status"} > 0)`
 
 const vmByTimeInStatusTableTimeSinceLastMigrationQuery = `sum by (cluster, namespace, name, status)(
-  (time() - kubevirt_vmi_migration_end_time_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"})
+  (time() - (kubevirt_vmi_migration_end_time_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"} > 0))
 ` + vmByTimeInStatusStatusJoin + `
 )`
 
 const vmByTimeInStatusTableMigrationEndMsQuery = `sum by (cluster, namespace, name, status)(
-  (kubevirt_vmi_migration_end_time_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"}*1000)
+  ((kubevirt_vmi_migration_end_time_seconds{cluster=~"$cluster", name=~"$name", namespace=~"$namespace"} > 0)*1000)
 ` + vmByTimeInStatusStatusJoin + `
 )`
 

--- a/pkg/perses/panels/virtualization/vm-inventory-panel.go
+++ b/pkg/perses/panels/virtualization/vm-inventory-panel.go
@@ -63,6 +63,7 @@ func VMInventoryTable(datasourceName, project string) panelgroup.Option {
 					map[string]any{"name": "value #10", "hide": true},
 					map[string]any{"name": "value #11", "hide": true},
 					map[string]any{"name": "value #12", "hide": true},
+					map[string]any{"name": "value #13", "hide": true},
 					map[string]any{"name": "__name__", "hide": true},
 					map[string]any{"name": "clusterID", "hide": true},
 					map[string]any{"name": "container", "hide": true},
@@ -98,7 +99,7 @@ func VMInventoryTable(datasourceName, project string) panelgroup.Option {
 		//   value #10 → (hidden)       Query 10: inventoryPreferenceQuery
 		//   value #11 → (hidden)       Query 11: inventoryGuestOSQuery
 		//   value #12 → (hidden)       Query 12: inventoryEvictableOutdatedQuery
-		//   value #13 → Live Migratable Query 13: inventoryLiveMigratableQuery
+		//   value #13 → (hidden)       Query 13: inventoryLiveMigratableQuery (label column: live_migratable)
 		// Query 1: VM info with status
 		panel.AddQuery(query.PromQL(
 			inventoryInfoQuery,

--- a/pkg/perses/panels/virtualization/vm-service-level-panel.go
+++ b/pkg/perses/panels/virtualization/vm-service-level-panel.go
@@ -21,6 +21,7 @@ func TotalUptimePercent(datasourceName string) panelgroup.Option {
 		panel.Description("The total uptime % of the VMs that are listed in the dashboard"),
 		statPanel.Chart(
 			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
 			statPanel.Format(commonSdk.Format{
 				Unit: &dashboards.PercentDecimalUnit,
 			}),
@@ -38,6 +39,7 @@ func TotalPlannedDowntimePercent(datasourceName string) panelgroup.Option {
 		panel.Description("The total planned downtime % of the VMs that are listed in the dashboard"),
 		statPanel.Chart(
 			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
 			statPanel.Format(commonSdk.Format{
 				Unit: &dashboards.PercentDecimalUnit,
 			}),
@@ -55,6 +57,7 @@ func TotalUnplannedDowntimePercent(datasourceName string) panelgroup.Option {
 		panel.Description("The total unplanned downtime % of the VMs that are listed in the dashboard"),
 		statPanel.Chart(
 			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
 			statPanel.Format(commonSdk.Format{
 				Unit: &dashboards.PercentDecimalUnit,
 			}),
@@ -72,6 +75,7 @@ func TotalUptimeHours(datasourceName string) panelgroup.Option {
 		panel.Description("The total uptime hours of the VMs that are listed in the dashboard"),
 		statPanel.Chart(
 			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
 			statPanel.Format(commonSdk.Format{
 				Unit: &hoursFormatUnit,
 			}),
@@ -89,6 +93,7 @@ func TotalPlannedDowntimeHours(datasourceName string) panelgroup.Option {
 		panel.Description("The total planned downtime hours of the VMs that are listed in the dashboard"),
 		statPanel.Chart(
 			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
 			statPanel.Format(commonSdk.Format{
 				Unit: &hoursFormatUnit,
 			}),
@@ -106,6 +111,7 @@ func TotalUnplannedDowntimeHours(datasourceName string) panelgroup.Option {
 		panel.Description("The total unplanned downtime hours of the VMs that are listed in the dashboard"),
 		statPanel.Chart(
 			statPanel.Calculation("last-number"),
+			statPanel.ValueFontSize(20),
 			statPanel.Format(commonSdk.Format{
 				Unit: &hoursFormatUnit,
 			}),


### PR DESCRIPTION
- Switch Time Since Last Migration column from `relative-time` to
  `seconds` unit to correctly format elapsed seconds as human-readable
  duration. Filter out zero-valued `kubevirt_vmi_migration_end_time_seconds`
  so VMs that were never migrated show an empty cell instead of a bogus value.

- Hide `value #13` column in VM Inventory table since the `live_migratable`
  label column already displays the correct true/false value.

- Add `valueFontSize(20)` to all stat panels in the Service Level (6 panels)
  and Time in Status (3 panels) dashboards so text is readable without
  toggling to view mode.

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>