### PR TITLE
fix(perses): fix top consumers dashboard variable resolution and query aggregation [release-2.17]

### DIFF
--- a/internal/perses/dashboards/virtualization/top-consumers.go
+++ b/internal/perses/dashboards/virtualization/top-consumers.go
@@ -25,7 +25,7 @@ func topNHiddenVariable(varName, expr, datasource string) dashboard.Option {
 				promqlVar.Datasource(datasource),
 			),
 			listVar.Hidden(true),
-			listVar.AllowAllValue(false),
+			listVar.AllowAllValue(true),
 			listVar.AllowMultiple(true),
 			listVar.DefaultValues("$__all"),
 		),

--- a/internal/perses/panels/virtualization/top-consumers-queries.go
+++ b/internal/perses/panels/virtualization/top-consumers-queries.go
@@ -29,15 +29,15 @@ func cpuMetric(extra string) string {
 }
 
 func networkMetric(extra string) string {
-	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_network_receive_bytes_total{` + clusterNSMatchers + extra + `}[10m]) + rate(kubevirt_vmi_network_transmit_bytes_total{` + clusterNSMatchers + extra + `}[10m]))`
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_network_receive_bytes_total{` + clusterNSMatchers + extra + `}[10m])) + sum by (cluster,namespace,name)(rate(kubevirt_vmi_network_transmit_bytes_total{` + clusterNSMatchers + extra + `}[10m]))`
 }
 
 func storageTrafficMetric(extra string) string {
-	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_read_traffic_bytes_total{` + clusterNSMatchers + extra + `}[10m]) + rate(kubevirt_vmi_storage_write_traffic_bytes_total{` + clusterNSMatchers + extra + `}[10m]))`
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_read_traffic_bytes_total{` + clusterNSMatchers + extra + `}[10m])) + sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_write_traffic_bytes_total{` + clusterNSMatchers + extra + `}[10m]))`
 }
 
 func storageIOPSMetric(extra string) string {
-	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_iops_read_total{` + clusterNSMatchers + extra + `}[10m]) + rate(kubevirt_vmi_storage_iops_write_total{` + clusterNSMatchers + extra + `}[10m]))`
+	return `sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_iops_read_total{` + clusterNSMatchers + extra + `}[10m])) + sum by (cluster,namespace,name)(rate(kubevirt_vmi_storage_iops_write_total{` + clusterNSMatchers + extra + `}[10m]))`
 }
 
 func vcpuWaitMetric(extra string) string {
@@ -45,7 +45,7 @@ func vcpuWaitMetric(extra string) string {
 }
 
 func memorySwapMetric(extra string) string {
-	return `sum by (cluster,namespace,name)(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes{` + clusterNSMatchers + extra + `}[10m]) + avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes{` + clusterNSMatchers + extra + `}[10m]))`
+	return `sum by (cluster,namespace,name)(avg_over_time(kubevirt_vmi_memory_swap_in_traffic_bytes{` + clusterNSMatchers + extra + `}[10m])) + sum by (cluster,namespace,name)(avg_over_time(kubevirt_vmi_memory_swap_out_traffic_bytes{` + clusterNSMatchers + extra + `}[10m]))`
 }
 
 // memoryUsageMetric uses memory_used_bytes (MCO allowlisted, no guest agent).
@@ -69,15 +69,15 @@ func cpuMetricInstant(extra string) string {
 }
 
 func networkMetricInstant(extra string) string {
-	return `sum by (cluster,namespace,name)(kubevirt_vmi_network_receive_bytes_total{` + clusterNSMatchers + extra + `} + kubevirt_vmi_network_transmit_bytes_total{` + clusterNSMatchers + extra + `})`
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_network_receive_bytes_total{` + clusterNSMatchers + extra + `}) + sum by (cluster,namespace,name)(kubevirt_vmi_network_transmit_bytes_total{` + clusterNSMatchers + extra + `})`
 }
 
 func storageTrafficMetricInstant(extra string) string {
-	return `sum by (cluster,namespace,name)(kubevirt_vmi_storage_read_traffic_bytes_total{` + clusterNSMatchers + extra + `} + kubevirt_vmi_storage_write_traffic_bytes_total{` + clusterNSMatchers + extra + `})`
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_storage_read_traffic_bytes_total{` + clusterNSMatchers + extra + `}) + sum by (cluster,namespace,name)(kubevirt_vmi_storage_write_traffic_bytes_total{` + clusterNSMatchers + extra + `})`
 }
 
 func storageIOPSMetricInstant(extra string) string {
-	return `sum by (cluster,namespace,name)(kubevirt_vmi_storage_iops_read_total{` + clusterNSMatchers + extra + `} + kubevirt_vmi_storage_iops_write_total{` + clusterNSMatchers + extra + `})`
+	return `sum by (cluster,namespace,name)(kubevirt_vmi_storage_iops_read_total{` + clusterNSMatchers + extra + `}) + sum by (cluster,namespace,name)(kubevirt_vmi_storage_iops_write_total{` + clusterNSMatchers + extra + `})`
 }
 
 func vcpuWaitMetricInstant(extra string) string {


### PR DESCRIPTION
## Summary

Backport of #518 to `release-2.17`.

Fixes two bugs in the Top Consumers Perses dashboard that cause VMs to be missing from results:

1. **Hidden variable resolution** (`top-consumers.go`): The hidden `topN` variables used `AllowAllValue(false)` with `DefaultValues("$__all")`. Perses cannot resolve the `$__all` magic value when "allow all" is disabled, causing only the first `topk()` result to be selected instead of all top-N VMs. Fixed by setting `AllowAllValue(true)`.

2. **PromQL aggregation** (`top-consumers-queries.go`): The binary `+` operator was applied inside `sum by (cluster,namespace,name)(... + ...)`, requiring exact label matches (e.g. `interface`, `drive`) between the two metrics before aggregation. Fixed by aggregating each metric independently before the binary addition: `sum by (...)(metric_a) + sum by (...)(metric_b)`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/perses/...` passes
- [x] Verified on live cluster: all 3 VMs now appear in dashboard
- [ ] Deploy to test cluster and verify all top-N VMs appear in each dashboard section


Made with [Cursor](https://cursor.com)