### PR TITLE
Add specific Dockerfile for prow

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,0 +1,68 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Copy the go source
+COPY main.go main.go
+COPY internal/ internal/
+COPY pkg/ pkg/
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Build
+# Enable CGO for FIPS compliance (dynamic linking)
+RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on go build -mod=readonly -a -o multicluster-observability-addon main.go
+
+# IMPORTANT: When changing base image RHEL version (ubi9 → ubi10):
+# 1. Update FROM statement below
+# 2. Update 'name' label to match new destination repo (rhel9 → rhel10)
+# 3. Update 'cpe' label with correct RHEL version (::el9 → ::el10)
+# 4. Verify destination repository exists in registry.redhat.io
+# 5. Run 'make verify-containerfile-labels' to check consistency (if script exists)
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+ARG VCS_REF
+ARG VCS_URL
+ARG IMAGE_DESCRIPTION
+ARG IMAGE_DISPLAY_NAME
+ARG IMAGE_NAME_ARCH
+ARG IMAGE_MAINTAINER
+ARG IMAGE_VENDOR
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+ARG IMAGE_SUMMARY
+ARG IMAGE_OPENSHIFT_TAGS
+
+LABEL org.label-schema.vendor="Red Hat" \
+    com.redhat.component="mcoa" \
+    org.label-schema.name="$IMAGE_NAME_ARCH" \
+    org.label-schema.description="$IMAGE_DESCRIPTION" \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url=$VCS_URL \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    name="rhacm2/acm-multicluster-observability-addon-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.17::el9" \
+    maintainer="$IMAGE_MAINTAINER" \
+    version="$IMAGE_VERSION" \
+    release="$IMAGE_RELEASE" \
+    description="$IMAGE_DESCRIPTION" \
+    summary="$IMAGE_SUMMARY" \
+    io.k8s.display-name="$IMAGE_DISPLAY_NAME" \
+    io.k8s.description="$IMAGE_DESCRIPTION" \
+    io.openshift.tags="$IMAGE_OPENSHIFT_TAGS"
+
+
+WORKDIR /
+COPY --from=builder /workspace/multicluster-observability-addon .
+USER 65532:65532
+
+ENTRYPOINT ["/multicluster-observability-addon"]


### PR DESCRIPTION
Build using a specific prow file. This is because the Konflux ones are missing some specific tooling that makes the publish step fail with the error:

```
make: *** No rule to make target 'osci/publish'.  Stop.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added container image build and packaging support for the add-on.
  * Updated the runtime image to run as a non-root user and include metadata labels for better image identification.
  * Improved deployment readiness with a multi-stage build that produces a smaller, more consistent container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->