### PR TITLE
ACM-35772: Annotation-based enablement for Thanos Operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/perses/plugins/timeserieschart v0.12.1
 	github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring v0.90.1-rhobs1
 	github.com/rhobs/observability-operator/pkg/apis v0.0.0-20250902133632-f98bd8a20a80
+	github.com/thanos-community/thanos-operator v0.0.0-20260313095634-17889a0e1c1a
 	golang.org/x/text v0.37.0
 )
 
@@ -56,8 +57,6 @@ require (
 	github.com/go-openapi/swag/yamlutils v0.25.5 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
-	github.com/onsi/ginkgo/v2 v2.28.1 // indirect
-	github.com/onsi/gomega v1.39.1 // indirect
 	github.com/perses/plugins/barchart v0.11.1 // indirect
 	github.com/perses/plugins/piechart v0.13.2-0.20260326134814-37e86f6b1c58 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -366,6 +366,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/thanos-community/thanos-operator v0.0.0-20260313095634-17889a0e1c1a h1:s4L2OhnhS18fDVUpanomA9YiyvBUeqkUZO0CQnTeDks=
+github.com/thanos-community/thanos-operator v0.0.0-20260313095634-17889a0e1c1a/go.mod h1:/gdS3cTgN4qlBznMNO8XdpgrrPPJ4PFyVSoQlSrD1ac=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 h1:6fotK7otjonDflCTK0BCfls4SPy3NcCVb5dqqmbRknE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75/go.mod h1:KO6IkyS8Y3j8OdNO85qEYBsRPuteD+YciPomcXdrMnk=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/internal/addon/helm/values.go
+++ b/internal/addon/helm/values.go
@@ -89,6 +89,11 @@ func GetValuesFunc(ctx context.Context, k8s client.Client, getter addonutils.Add
 		obsAPIEnabled := aodc.Annotations["mcoa-obs-api"] == "true"
 		userValues.ObsAPI = omanifests.BuildValues(common.IsHubCluster(cluster), obsAPIEnabled)
 
+		// WIP: Temporary solution to enable thanos-operator and will require to delete the mcoa pod to take effect.
+		if userValues.Metrics != nil {
+			userValues.Metrics.ThanosOperator.Enabled = opts.ThanosOperatorEnabled && common.IsHubCluster(cluster)
+		}
+
 		return addonfactory.JsonStructToValues(userValues)
 	}
 }

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/values.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/values.yaml
@@ -22,6 +22,12 @@ nodeExporter:
   hostPort: 19100
   # internalPort is the port that the node-exporter process itself listens on (localhost only).
   internalPort: 19101
+thanosOperator:
+  enabled: false
+  isHub: false
+  appName: thanos-operator
+  component: controller-manager
+  image: ""
 global:
   resourceRequirements: []
   imagePullSecret: open-cluster-management-image-pull-credentials

--- a/internal/addon/options.go
+++ b/internal/addon/options.go
@@ -120,14 +120,15 @@ type ProxyConfig struct {
 }
 
 type Options struct {
-	Platform         PlatformOptions
-	UserWorkloads    UserWorkloadOptions
-	InstallNamespace string
-	Tolerations      []corev1.Toleration
-	NodeSelector     map[string]string
-	ResourceReqs     []addonapiv1beta1.ContainerResourceRequirements
-	ProxyConfig      ProxyConfig
-	Registries       []addonapiv1beta1.ImageMirror
+	Platform              PlatformOptions
+	UserWorkloads         UserWorkloadOptions
+	InstallNamespace      string
+	Tolerations           []corev1.Toleration
+	NodeSelector          map[string]string
+	ResourceReqs          []addonapiv1beta1.ContainerResourceRequirements
+	ProxyConfig           ProxyConfig
+	Registries            []addonapiv1beta1.ImageMirror
+	ThanosOperatorEnabled bool
 }
 
 func (o Options) validate() error {
@@ -177,6 +178,7 @@ func BuildOptions(addOnDeployment *addonapiv1beta1.AddOnDeploymentConfig) (Optio
 
 	opts.ProxyConfig.NoProxy = addOnDeployment.Spec.ProxyConfig.NoProxy
 	opts.Registries = addOnDeployment.Spec.Registries
+	opts.ThanosOperatorEnabled = addOnDeployment.Annotations["mcoa-thanos-operator"] == "true"
 
 	// Default alerts to disabled
 	opts.Platform.Metrics.AlertsEnabled = false

--- a/internal/metrics/config/config.go
+++ b/internal/metrics/config/config.go
@@ -105,7 +105,7 @@ type ImageOverrides struct {
 	NodeExporter               string `json:"node_exporter"`
 	Prometheus                 string `json:"prometheus"`
 	EndpointMonitoringOperator string `json:"endpoint_monitoring_operator"`
-	ThanosOperator             string `json:"thanos_operator,omitempty"`
+	ThanosOperator             string `json:"thanos_operator"`
 }
 
 func GetImageOverrides(ctx context.Context, c client.Client, registries []addonapiv1beta1.ImageMirror, logger logr.Logger) (ImageOverrides, error) {
@@ -144,6 +144,9 @@ func GetImageOverrides(ctx context.Context, c client.Client, registries []addona
 		ret.NodeExporter = overrideImage(ret.NodeExporter, registries, logger)
 		ret.Prometheus = overrideImage(ret.Prometheus, registries, logger)
 		ret.EndpointMonitoringOperator = overrideImage(ret.EndpointMonitoringOperator, registries, logger)
+		if ret.ThanosOperator != "" {
+			ret.ThanosOperator = overrideImage(ret.ThanosOperator, registries, logger)
+		}
 	}
 
 	return ret, nil

--- a/internal/metrics/config/config.go
+++ b/internal/metrics/config/config.go
@@ -59,6 +59,11 @@ const (
 	ScrapeClassUWLTarget      = "prometheus-user-workload.openshift-user-workload-monitoring.svc:9092"
 	MonitoringStackCRDName    = "monitoringstacks.monitoring.rhobs"
 
+	// Thanos Operator
+	ThanosOperatorAppName = "thanos-operator"
+	// TODO: replace with image from ACM image overrides ConfigMap once available.
+	ThanosOperatorImage = "quay.io/thanos/thanos-operator:main-2026-04-09-a4dc024"
+
 	AlertmanagerAccessorSecretName = "observability-alertmanager-accessor"
 	AlertmanagerRouterCASecretName = "hub-alertmanager-router-ca"
 	AlertmanagerRouteBYOCAName     = "alertmanager-byo-ca"
@@ -100,6 +105,7 @@ type ImageOverrides struct {
 	NodeExporter               string `json:"node_exporter"`
 	Prometheus                 string `json:"prometheus"`
 	EndpointMonitoringOperator string `json:"endpoint_monitoring_operator"`
+	ThanosOperator             string `json:"thanos_operator,omitempty"`
 }
 
 func GetImageOverrides(ctx context.Context, c client.Client, registries []addonapiv1beta1.ImageMirror, logger logr.Logger) (ImageOverrides, error) {

--- a/internal/metrics/handlers/hypershift_test.go
+++ b/internal/metrics/handlers/hypershift_test.go
@@ -41,7 +41,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -68,7 +68,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -275,7 +275,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -287,7 +287,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`, // ignore regex
+					`{__name__=~"acm_"}`,                               // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -337,7 +337,7 @@ func TestHypershift_ExtractDependentMetrics(t *testing.T) {
 					Params: map[string][]string{
 						"match[]": {
 							`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-							`{__name__=~"acm_"}`, // ignore regex
+							`{__name__=~"acm_"}`,                               // ignore regex
 							`{__name__="acm_managed_cluster_labels"}`,
 							`{__name__="active_streams_lease:grpc_server_handled_total:sum"}`,
 						},

--- a/internal/metrics/handlers/hypershift_test.go
+++ b/internal/metrics/handlers/hypershift_test.go
@@ -41,7 +41,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -68,7 +68,7 @@ func TestHypershift_Nominal(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -275,7 +275,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="grpc_server_handled_total"}`,
 				},
 			},
@@ -287,7 +287,7 @@ func TestHypershift_NoHypershiftServiceMonitors(t *testing.T) {
 			Params: map[string][]string{
 				"match[]": {
 					`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-					`{__name__=~"acm_"}`,                               // ignore regex
+					`{__name__=~"acm_"}`, // ignore regex
 					`{__name__="acm_managed_cluster_labels"}`,
 				},
 			},
@@ -337,7 +337,7 @@ func TestHypershift_ExtractDependentMetrics(t *testing.T) {
 					Params: map[string][]string{
 						"match[]": {
 							`{__name__=":node_memory_MemAvailable_bytes:sum"}`, // ignore rules
-							`{__name__=~"acm_"}`,                               // ignore regex
+							`{__name__=~"acm_"}`, // ignore regex
 							`{__name__="acm_managed_cluster_labels"}`,
 							`{__name__="active_streams_lease:grpc_server_handled_total:sum"}`,
 						},

--- a/internal/metrics/handlers/options.go
+++ b/internal/metrics/handlers/options.go
@@ -6,6 +6,7 @@ import (
 	cooprometheusv1alpha1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/stolostron/multicluster-observability-addon/internal/addon"
 	mconfig "github.com/stolostron/multicluster-observability-addon/internal/metrics/config"
+	thanosv1alpha1 "github.com/thanos-community/thanos-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 )
@@ -35,6 +36,19 @@ type Options struct {
 	// prevents synchronization issues by ensuring the operator can watch these resources upon startup.
 	CRDEstablishedAnnotation string
 	ProxyConfig              addon.ProxyConfig
+
+	// Thanos holds the hub-only Thanos component specifications.
+	// These are only populated when IsHub is true and platform metrics collection is enabled.
+	Thanos ThanosOptions
+}
+
+// ThanosOptions holds the Thanos operator CR specs for hub deployment.
+type ThanosOptions struct {
+	Receive *thanosv1alpha1.ThanosReceive
+	Query   *thanosv1alpha1.ThanosQuery
+	Compact *thanosv1alpha1.ThanosCompact
+	Store   *thanosv1alpha1.ThanosStore
+	Ruler   *thanosv1alpha1.ThanosRuler
 }
 
 type Collector struct {

--- a/internal/metrics/manifests/values.go
+++ b/internal/metrics/manifests/values.go
@@ -76,7 +76,7 @@ type ImagesValues struct {
 	RBACProxyImage             string `json:"rbacProxyImage"`
 	Prometheus                 string `json:"prometheus"`
 	EndpointMonitoringOperator string `json:"endpointMonitoringOperator"`
-	ThanosOperator             string `json:"thanosOperator,omitempty"`
+	ThanosOperator             string `json:"thanosOperator"`
 }
 
 type ConfigValue struct {

--- a/internal/metrics/manifests/values.go
+++ b/internal/metrics/manifests/values.go
@@ -15,31 +15,31 @@ import (
 )
 
 type MetricsValues struct {
-	PlatformEnabled                bool                `json:"platformEnabled"`
-	UserWorkloadsEnabled           bool                `json:"userWorkloadsEnabled"`
-	Secrets                        []ConfigValue       `json:"secrets"`
-	ConfigMaps                     []ConfigValue       `json:"configMaps"`
-	Images                         ImagesValues        `json:"images"`
-	PrometheusControllerID         string              `json:"prometheusControllerID"`
-	PrometheusCAConfigMapName      string              `json:"prometheusCAConfigMapName"`
-	PrometheusServerName           string              `json:"prometheusServerName"`
-	AlertmanagerRouterCASecretName string              `json:"alertmanagerRouterCASecretName"`
-	AlertmanagerAccessorSecretName string              `json:"alertmanagerAccessorSecretName"`
-	ClientCertSecretName           string              `json:"clientCertSecretName"`
-	HubClusterID                   string              `json:"hubClusterID"`
-	ClusterID                      string              `json:"clusterID"`
-	ClusterName                    string              `json:"clusterName"`
-	PlatformAlertsEnabled          bool                `json:"platformAlertsEnabled"`
-	UserWorkloadAlertsEnabled      bool                `json:"userWorkloadAlertsEnabled"`
-	Platform                       Collector           `json:"platform"`
-	UserWorkload                   Collector           `json:"userWorkload"`
-	DeployNonOCPStack              bool                `json:"deployNonOCPStack"`
-	DeployCOOResources             bool                `json:"deployCOOResources"`
-	IsHub                          bool                `json:"isHub"`
-	PrometheusOperatorAnnotations  string              `json:"prometheusOperatorAnnotations,omitempty"`
-	AlertManagerEndpoint           string              `json:"alertManagerEndpoint,omitempty"`
-	Tolerations                    []corev1.Toleration `json:"tolerations"`
-	NodeSelector                   map[string]string   `json:"nodeSelector"`
+	PlatformEnabled                bool                 `json:"platformEnabled"`
+	UserWorkloadsEnabled           bool                 `json:"userWorkloadsEnabled"`
+	Secrets                        []ConfigValue        `json:"secrets"`
+	ConfigMaps                     []ConfigValue        `json:"configMaps"`
+	Images                         ImagesValues         `json:"images"`
+	PrometheusControllerID         string               `json:"prometheusControllerID"`
+	PrometheusCAConfigMapName      string               `json:"prometheusCAConfigMapName"`
+	PrometheusServerName           string               `json:"prometheusServerName"`
+	AlertmanagerRouterCASecretName string               `json:"alertmanagerRouterCASecretName"`
+	AlertmanagerAccessorSecretName string               `json:"alertmanagerAccessorSecretName"`
+	ClientCertSecretName           string               `json:"clientCertSecretName"`
+	HubClusterID                   string               `json:"hubClusterID"`
+	ClusterID                      string               `json:"clusterID"`
+	ClusterName                    string               `json:"clusterName"`
+	PlatformAlertsEnabled          bool                 `json:"platformAlertsEnabled"`
+	UserWorkloadAlertsEnabled      bool                 `json:"userWorkloadAlertsEnabled"`
+	Platform                       Collector            `json:"platform"`
+	UserWorkload                   Collector            `json:"userWorkload"`
+	DeployNonOCPStack              bool                 `json:"deployNonOCPStack"`
+	DeployCOOResources             bool                 `json:"deployCOOResources"`
+	IsHub                          bool                 `json:"isHub"`
+	PrometheusOperatorAnnotations  string               `json:"prometheusOperatorAnnotations,omitempty"`
+	AlertManagerEndpoint           string               `json:"alertManagerEndpoint,omitempty"`
+	Tolerations                    []corev1.Toleration  `json:"tolerations"`
+	NodeSelector                   map[string]string    `json:"nodeSelector"`
 	NodeExporter                   NodeExporterValues   `json:"nodeExporter"`
 	ThanosOperator                 ThanosOperatorValues `json:"thanosOperator"`
 }

--- a/internal/metrics/manifests/values.go
+++ b/internal/metrics/manifests/values.go
@@ -40,7 +40,17 @@ type MetricsValues struct {
 	AlertManagerEndpoint           string              `json:"alertManagerEndpoint,omitempty"`
 	Tolerations                    []corev1.Toleration `json:"tolerations"`
 	NodeSelector                   map[string]string   `json:"nodeSelector"`
-	NodeExporter                   NodeExporterValues  `json:"nodeExporter"`
+	NodeExporter                   NodeExporterValues   `json:"nodeExporter"`
+	ThanosOperator                 ThanosOperatorValues `json:"thanosOperator"`
+}
+
+// ThanosOperatorValues holds the Thanos operator deployment values for Helm rendering.
+type ThanosOperatorValues struct {
+	Enabled   bool   `json:"enabled"`
+	IsHub     bool   `json:"isHub"`
+	AppName   string `json:"appName"`
+	Component string `json:"component"`
+	Image     string `json:"image"`
 }
 
 type NodeExporterValues struct {
@@ -66,6 +76,7 @@ type ImagesValues struct {
 	RBACProxyImage             string `json:"rbacProxyImage"`
 	Prometheus                 string `json:"prometheus"`
 	EndpointMonitoringOperator string `json:"endpointMonitoringOperator"`
+	ThanosOperator             string `json:"thanosOperator,omitempty"`
 }
 
 type ConfigValue struct {
@@ -297,6 +308,18 @@ func BuildValues(opts handlers.Options) (*MetricsValues, error) {
 		RBACProxyImage:             opts.Images.KubeRBACProxy,
 		Prometheus:                 opts.Images.Prometheus,
 		EndpointMonitoringOperator: opts.Images.EndpointMonitoringOperator,
+		ThanosOperator:             opts.Images.ThanosOperator,
+	}
+
+	thanosOperatorImage := opts.Images.ThanosOperator
+	if thanosOperatorImage == "" {
+		thanosOperatorImage = config.ThanosOperatorImage
+	}
+	ret.ThanosOperator = ThanosOperatorValues{
+		IsHub:     opts.IsHub,
+		AppName:   config.ThanosOperatorAppName,
+		Component: "controller-manager",
+		Image:     thanosOperatorImage,
 	}
 
 	return ret, nil

--- a/internal/metrics/manifests/values.go
+++ b/internal/metrics/manifests/values.go
@@ -311,6 +311,7 @@ func BuildValues(opts handlers.Options) (*MetricsValues, error) {
 		ThanosOperator:             opts.Images.ThanosOperator,
 	}
 
+	// Fallback to hardcoded image until MCO populates thanos_operator in the images-list ConfigMap (ACM-35775).
 	thanosOperatorImage := opts.Images.ThanosOperator
 	if thanosOperatorImage == "" {
 		thanosOperatorImage = config.ThanosOperatorImage

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	addonctrl "github.com/stolostron/multicluster-observability-addon/internal/controllers/addon"
 	"github.com/stolostron/multicluster-observability-addon/internal/controllers/resourcecreator"
 	"github.com/stolostron/multicluster-observability-addon/internal/controllers/watcher"
+	thanosv1alpha1 "github.com/thanos-community/thanos-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -69,6 +70,7 @@ func init() {
 	utilruntime.Must(persesv1.AddToScheme(scheme))
 	utilruntime.Must(routev1.AddToScheme(scheme))
 	utilruntime.Must(addonv1beta1.Install(scheme))
+	utilruntime.Must(thanosv1alpha1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION
## Summary
- Wire `mcoa-thanos-operator: "true"` annotation from AddOnDeploymentConfig through Options → ThanosOperatorValues.Enabled → Helm values
- Add `ThanosOperatorValues` struct with `enabled`, `isHub`, `appName`, `component`, `image` fields
- Register thanos-operator types in scheme and add Go dependency
- No Thanos templates, CRDs, or CR builder functions — those follow in subsequent PRs

## Jira
https://redhat.atlassian.net/browse/ACM-35772

## Test plan
- [ ] `go vet ./...` passes
- [ ] `go test ./internal/addon/... ./internal/metrics/...` passes
- [ ] Without annotation, `thanosOperator.enabled` is `false` in rendered values
- [ ] With `mcoa-thanos-operator: "true"` on ADC, `thanosOperator.enabled` is `true` for hub clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added initial support for Thanos Operator configuration in platform metrics, including hub-only Thanos component settings (receive/query/compact/store/ruler).
  * Introduced the `mcoa-thanos-operator` deployment annotation toggle to enable Thanos Operator Helm rendering.
  * Added Thanos Operator Helm values (enabled/isHub/appName/component) and support for configuring the Thanos Operator image, including image override support.
* **Bug Fixes**
  * Thanos Operator image resolution now consistently falls back to a default image when no override is provided.
* **Chores**
  * Updated dependencies and registered Thanos Operator API types with the controller runtime scheme.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->