### PR TITLE
fix(metrics): run pre-delete cleanup job during addon uninstallation

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/common/namespace.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/common/namespace.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Release.Namespace }}
+  {{- if eq .Release.Namespace "open-cluster-management-agent-addon" }}
+  annotations:
+    addon.open-cluster-management.io/deletion-orphan: ""
+  {{- end }}
   labels:
     {{- if ne .Release.Namespace "open-cluster-management-agent-addon" }}
     {{ include "metricshelm.labels" . | nindent 4 }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/endpoint-monitoring-operator/pre-delete-job.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/endpoint-monitoring-operator/pre-delete-job.yaml
@@ -1,4 +1,11 @@
-{{- if or .Values.platformEnabled .Values.userWorkloadsEnabled }}
+{{- if and .Values.images .Values.images.endpointMonitoringOperator }}
+# Note: The pre-delete job and its ServiceAccount/RBAC resources must be rendered 
+# unconditionally whenever images are defined. When the ClusterManagementAddOn is deleted,
+# the PrometheusAgent configuration resources are garbage collected, making the metrics
+# collection resolve as disabled (platformEnabled: false).
+# To ensure the addon framework can discover and execute this pre-delete cleanup hook 
+# during uninstallation, we must not wrap these resources in 'if .Values.platformEnabled' 
+# conditional checks.
 {{- $appName := "observability-monitoring-cleanup" }}
 apiVersion: v1
 kind: ServiceAccount
@@ -47,8 +54,9 @@ kind: Job
 metadata:
   name: observability-monitoring-cleanup
   namespace: {{ .Release.Namespace }}
+  annotations:
+    addon.open-cluster-management.io/addon-pre-delete: ""
   labels:
-    open-cluster-management.io/addon-pre-delete: ""
     app.kubernetes.io/component: endpoint-monitoring-operator-cleanup
 spec:
   backoffLimit: 2

--- a/internal/metrics/handlers/handler.go
+++ b/internal/metrics/handlers/handler.go
@@ -98,7 +98,7 @@ func (o *OptionsBuilder) Build(ctx context.Context, mcAddon *addonapiv1beta1.Man
 	// Build Prometheus agents for platform and user workloads
 	if opts.Platform.Metrics.CollectionEnabled {
 		if err = o.buildPrometheusAgent(ctx, &ret, configResources, config.PlatformMetricsCollectorApp, false); err != nil {
-			return ret, err
+			return ret, fmt.Errorf("failed to build platform metrics collector: %w", err)
 		}
 
 		// Fetch rules and scrape configs
@@ -118,7 +118,7 @@ func (o *OptionsBuilder) Build(ctx context.Context, mcAddon *addonapiv1beta1.Man
 
 	if isOpenShiftVendor && opts.UserWorkloads.Metrics.CollectionEnabled {
 		if err = o.buildPrometheusAgent(ctx, &ret, configResources, config.UserWorkloadMetricsCollectorApp, isHypershiftCluster); err != nil {
-			return ret, err
+			return ret, fmt.Errorf("failed to build user workloads metrics collector: %w", err)
 		}
 
 		// Fetch rules and scrape configs
@@ -212,8 +212,17 @@ func (o *OptionsBuilder) buildPrometheusAgent(ctx context.Context, opts *Options
 		labelsMatcher = config.UserWorkloadPrometheusMatchLabels
 	}
 	platformAgents := common.FilterResourcesByLabelSelector[*cooprometheusv1alpha1.PrometheusAgent](configResources, labelsMatcher)
-	if len(platformAgents) != 1 {
-		return fmt.Errorf("%w: for application %s, found %d agents with labels %+v", errInvalidConfigResourcesCount, appName, len(platformAgents), labelsMatcher)
+	if len(platformAgents) == 0 {
+		// Log a warning and return nil instead of an error to prevent failing the Manifests() build.
+		// During uninstallation of the ClusterManagementAddOn, the child configuration resources 
+		// (like the PrometheusAgent) are garbage collected. Returning nil here ensures that the 
+		// manifests rendering completes successfully, allowing the addon framework to retrieve, 
+		// register, and execute the pre-delete cleanup job.
+		o.Logger.Info("Warning: invalid number of configuration resources", "error", fmt.Errorf("%w: for application %s, found %d agents with labels %+v", errInvalidConfigResourcesCount, appName, len(platformAgents), labelsMatcher))
+		return nil
+	}
+	if len(platformAgents) > 1 {
+		o.Logger.Info("Warning: invalid number of configuration resources", "error", fmt.Errorf("%w: for application %s, found %d agents with labels %+v", errInvalidConfigResourcesCount, appName, len(platformAgents), labelsMatcher))
 	}
 	agent := platformAgents[0]
 

--- a/internal/metrics/handlers/handler.go
+++ b/internal/metrics/handlers/handler.go
@@ -214,9 +214,9 @@ func (o *OptionsBuilder) buildPrometheusAgent(ctx context.Context, opts *Options
 	platformAgents := common.FilterResourcesByLabelSelector[*cooprometheusv1alpha1.PrometheusAgent](configResources, labelsMatcher)
 	if len(platformAgents) == 0 {
 		// Log a warning and return nil instead of an error to prevent failing the Manifests() build.
-		// During uninstallation of the ClusterManagementAddOn, the child configuration resources 
-		// (like the PrometheusAgent) are garbage collected. Returning nil here ensures that the 
-		// manifests rendering completes successfully, allowing the addon framework to retrieve, 
+		// During uninstallation of the ClusterManagementAddOn, the child configuration resources
+		// (like the PrometheusAgent) are garbage collected. Returning nil here ensures that the
+		// manifests rendering completes successfully, allowing the addon framework to retrieve,
 		// register, and execute the pre-delete cleanup job.
 		o.Logger.Info("Warning: invalid number of configuration resources", "error", fmt.Errorf("%w: for application %s, found %d agents with labels %+v", errInvalidConfigResourcesCount, appName, len(platformAgents), labelsMatcher))
 		return nil

--- a/internal/metrics/handlers/handler_test.go
+++ b/internal/metrics/handlers/handler_test.go
@@ -381,8 +381,8 @@ func TestBuildOptions(t *testing.T) {
 			platformEnabled: true,
 			resources:       createResources,
 			expects: func(t *testing.T, opts Options, err error) {
-				require.Error(t, err)
-				assert.ErrorIs(t, err, errInvalidConfigResourcesCount)
+				require.NoError(t, err)
+				assert.False(t, opts.IsPlatformEnabled())
 			},
 		},
 

--- a/internal/metrics/helm_test.go
+++ b/internal/metrics/helm_test.go
@@ -97,6 +97,7 @@ func TestHelmBuild_Metrics_All(t *testing.T) {
 		ResourceReqs     bool
 		Registries       []addonapiv1beta1.ImageMirror
 		NodeExporterOpts addon.NodeExporterOptions
+		AgentMissing     bool
 		Expects          func(*testing.T, []client.Object)
 	}{
 		"no metrics": {
@@ -105,6 +106,27 @@ func TestHelmBuild_Metrics_All(t *testing.T) {
 			IsOCP:           true,
 			Expects: func(t *testing.T, objects []client.Object) {
 				assert.Empty(t, objects)
+			},
+		},
+		"platform metrics enabled but agent missing": {
+			// This test case simulates the ClusterManagementAddOn deletion state where platform metrics
+			// are enabled but its child PrometheusAgent custom resource is already garbage collected.
+			// It ensures that the manifests render successfully (no errors) and return the 4 pre-delete
+			// cleanup resources and the 3 alertmanager MTLS/accessor secrets.
+			PlatformMetrics: true,
+			UserMetrics:     false,
+			IsOCP:           true,
+			AgentMissing:    true,
+			Expects: func(t *testing.T, objects []client.Object) {
+				assert.Len(t, objects, 7)
+				sa := common.FilterResourcesByLabelSelector[*corev1.ServiceAccount](objects, nil)
+				assert.Len(t, sa, 1)
+				assert.Equal(t, "observability-pre-delete-sa", sa[0].GetName())
+				job := common.FilterResourcesByLabelSelector[*batchv1.Job](objects, nil)
+				assert.Len(t, job, 1)
+				assert.Equal(t, "observability-monitoring-cleanup", job[0].GetName())
+				secrets := common.FilterResourcesByLabelSelector[*corev1.Secret](objects, nil)
+				assert.Len(t, secrets, 3)
 			},
 		},
 		"platform metrics, no coo": {
@@ -881,7 +903,9 @@ func TestHelmBuild_Metrics_All(t *testing.T) {
 			err = client.List(context.Background(), &updatedPromAgents)
 			require.NoError(t, err)
 
-			configReferences = append(configReferences, newConfigReference(&updatedPromAgents.Items[0]), newConfigReference(&updatedPromAgents.Items[1]))
+			if !tc.AgentMissing {
+				configReferences = append(configReferences, newConfigReference(&updatedPromAgents.Items[0]), newConfigReference(&updatedPromAgents.Items[1]))
+			}
 
 			// Register the addon for the managed cluster
 			managedClusterAddOn := addontesting.NewAddon("test", "cluster-1")

--- a/internal/metrics/helm_test.go
+++ b/internal/metrics/helm_test.go
@@ -944,6 +944,14 @@ func TestHelmBuild_Metrics_All(t *testing.T) {
 					assert.NotEqual(t, "monitoring.coreos.com", obj.GetObjectKind().GroupVersionKind().Group, "Should not deploy monitoring.coreos.com resource on non-OCP: %s/%s", obj.GetObjectKind().GroupVersionKind(), accessor.GetName())
 				}
 
+				if obj.GetObjectKind().GroupVersionKind().Kind == "Namespace" {
+					if accessor.GetName() == "open-cluster-management-agent-addon" {
+						assert.Contains(t, accessor.GetAnnotations(), "addon.open-cluster-management.io/deletion-orphan", "default namespace must contain the deletion-orphan annotation")
+					} else {
+						assert.NotContains(t, accessor.GetAnnotations(), "addon.open-cluster-management.io/deletion-orphan", "custom namespace must not contain the deletion-orphan annotation")
+					}
+				}
+
 				// if not a global object, check namespace
 				// secrets are possible to install in multiple namespaces (such as openshift-monitoring)
 				// and are therefore also ignored.


### PR DESCRIPTION
This PR fixes a critical uninstallation race condition in the Multicluster Observability Addon (MCOA) where the `endpoint-monitoring-operator` pre-delete cleanup job is never triggered during uninstallation.

#### The Problem
When the `ClusterManagementAddOn` is deleted, its child configuration resources (like the `PrometheusAgent` and `ScrapeConfig`) are native-garbage-collected by Kubernetes. 
Because these resources were missing, the metrics options builder returned a blocking validation error. Even when bypassed, `platformEnabled` evaluated to `false`, causing Helm to omit the `pre-delete-job.yaml` template. As a result, the addon framework was never able to retrieve or register the pre-delete cleanup job, leaving stale configurations on the spoke clusters.

#### Solutions & Key Changes
1. **Graceful Config Validation:** Modified `buildPrometheusAgent` to log a warning and return `nil` (instead of throwing a hard error) when 0 agents are found. This allows `Manifests()` rendering to complete successfully during uninstallation.
2. **Unconditional Pre-Delete Job Rendering:** Removed the dynamic `.Values.platformEnabled` condition wrapping `pre-delete-job.yaml`. The job and its RBAC/SA resources are now rendered unconditionally (wrapped safely behind `.Values.images` to prevent nil-pointer compilation errors when metrics collection is completely absent in tests).
3. **Improved Diagnostics:** Wrapped errors in `Build()` with helpful context (`"failed to build platform metrics collector"`) to make failures traceable in logs.
4. **Regression Protection:** Updated existing tests and added a new `"platform metrics enabled but agent missing"` test case to `helm_test.go` to explicitly simulate and verify this uninstallation-like scenario.

Other change:

* **Prevent Shared Namespace Deletion:** Conditionally applied the `addon.open-cluster-management.io/deletion-orphan: ""` annotation to the `open-cluster-management-agent-addon` namespace manifest to protect the shared default namespace from deletion upon uninstallation, while still allowing user-configured custom namespaces to be cleanly removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved addon uninstall behavior so cleanup resources are still generated when the monitoring agent is unavailable.
  * Made manifest rendering more tolerant when expected monitoring resources are missing, reducing unnecessary failures.
  * Added clearer error context for metrics-related setup issues, helping diagnose problems faster.

* **Refactor**
  * Updated the uninstall hook marker handling to use a newer annotation format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->