### PR TITLE
Add events.k8s.io group to endpoint controller role

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/endpoint-monitoring-operator/clusterrole.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/endpoint-monitoring-operator/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
   resources: ["configmaps"]
   verbs: ["get", "list", "watch", "create"]
 # warning events for overwritten/mutated configs
-- apiGroups: [""]
+- apiGroups: ["", "events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "patch"]
 {{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/endpoint-monitoring-operator/clusterrole.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/endpoint-monitoring-operator/clusterrole.yaml
@@ -21,7 +21,7 @@ rules:
   resources: ["configmaps"]
   verbs: ["get", "list", "watch", "create"]
 # warning events for overwritten/mutated configs
-- apiGroups: ["", "events.k8s.io"]
+- apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "patch"]
 {{- end }}


### PR DESCRIPTION
Fix error log happening in CI:
err="events.events.k8s.io is forbidden: User                 
   \"system:serviceaccount:open-cluster-management-agent-addon:endpoint-monitoring-operator\" cannot create resource \"events\" in API group \"events.k8s.io\"    
   in the namespace \"openshift-monitoring\"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected event monitoring permissions by updating the RBAC rule to target the `events.k8s.io` API group.
  * Improves reliability of event creation and updates for event resources in the intended Kubernetes API group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->