### PR TITLE
feat(endpoint-operator): allow CRD get and APIServer get/list/watch

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/endpoint-monitoring-operator/clusterrole.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/endpoint-monitoring-operator/clusterrole.yaml
@@ -24,4 +24,10 @@ rules:
 - apiGroups: ["events.k8s.io"]
   resources: ["events"]
   verbs: ["create", "patch"]
+- apiGroups: ["config.openshift.io"]
+  resources: ["apiservers"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
 {{- end }}


### PR DESCRIPTION
[PR 2540](https://github.com/stolostron/multicluster-observability-operator/pull/2540#top) features the read of CRD and APIServer resources on the endpoint-operator deployed by MCOA.

The correct role permissions are needed in order to allow the API calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint monitoring reliability by allowing read-only access to API server configuration and custom resource definitions.
  * No existing permissions were removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->