### PR TITLE
fix(perses): correct PromQL operator precedence in service-level hours stat panels

### DIFF
--- a/pkg/perses/panels/virtualization/vm-service-level-queries.go
+++ b/pkg/perses/panels/virtualization/vm-service-level-queries.go
@@ -46,15 +46,15 @@ const serviceLevelUnplannedDowntimePercentQuery = `sum(` + serviceLevelUnplanned
 sum(` + serviceLevelTotalSamplesExpr + `) or vector(0)`
 
 const serviceLevelUptimeHoursQuery = `sum(
-(` + serviceLevelRunningSamplesExpr + ` *300 )/3600
+((` + serviceLevelRunningSamplesExpr + `) *300 )/3600
 ) or vector(0)`
 
 const serviceLevelPlannedDowntimeHoursQuery = `sum(
-(` + serviceLevelPlannedDowntimeSamplesExpr + ` *300 )/3600
+((` + serviceLevelPlannedDowntimeSamplesExpr + `) *300 )/3600
 ) or vector(0)`
 
 const serviceLevelUnplannedDowntimeHoursQuery = `sum(
-(` + serviceLevelUnplannedDowntimeSamplesExpr + ` *300 )/3600
+((` + serviceLevelUnplannedDowntimeSamplesExpr + `) *300 )/3600
 ) or vector(0)`
 
 // Per-VM table sample sub-expressions (no status filter appended — composed below).


### PR DESCRIPTION
## Summary

- Fix PromQL operator precedence bug in the three "Hours" stat panels (Total Uptime, Total Planned Downtime, Total Unplanned Downtime) on the VM Service Level dashboard.
- The `*300` multiplier was binding to `kubevirt_vm_info > 0` (the right operand of `and`) instead of the full `and` result, because PromQL `*` has higher precedence than `and`.
- Wrap each samples sub-expression in parentheses so the status filter resolves before multiplication: `((expr) *300) / 3600`.

## Test plan

- [x] `TestBuildVMServiceLevel` passes
- [ ] Deploy with COO/Perses and verify the "Total Uptime (Hours)", "Total Planned Downtime (Hours)", and "Total Unplanned Downtime (Hours)" stat panels show correct values

Fixes: https://issues.redhat.com/browse/CNV-90471

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy and consistency of per-VM uptime, planned downtime, and unplanned downtime hour calculations.
  * Preserved fallback behavior when no matching data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->