### PR TITLE
ACM-35781: Add ThanosStore CR template and builder

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/thanos-operator/operator/thanos-store.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/thanos-operator/operator/thanos-store.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.thanosOperator.enabled .Values.thanosOperator.storeSpec.data }}
+apiVersion: monitoring.thanos.io/v1alpha1
+kind: ThanosStore
+metadata:
+  name: mcoa-store
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: store
+    app.kubernetes.io/name: {{ .Values.thanosOperator.appName }}
+    {{ include "metricshelm.labels" . | nindent 4 }}
+spec:
+{{- fromJson .Values.thanosOperator.storeSpec.data | toYaml | nindent 2 }}
+{{- end }}

--- a/internal/addon/manifests/charts/mcoa/charts/metrics/templates/thanos-operator/operator/thanos-store.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/metrics/templates/thanos-operator/operator/thanos-store.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.thanos.io/v1alpha1
 kind: ThanosStore
 metadata:
   name: mcoa-store
-  namespace: {{ .Release.Namespace }}
+  namespace: open-cluster-management-observability
   labels:
     app.kubernetes.io/component: store
     app.kubernetes.io/name: {{ .Values.thanosOperator.appName }}

--- a/internal/metrics/config/config.go
+++ b/internal/metrics/config/config.go
@@ -64,6 +64,15 @@ const (
 	// TODO: replace with image from ACM image overrides ConfigMap once available.
 	ThanosOperatorImage = "quay.io/thanos/thanos-operator:main-2026-04-09-a4dc024"
 
+	// Thanos Store defaults
+	DefaultStoreShards      = 3
+	DefaultStoreStorageSize = "10Gi"
+	ThanosStoreContainerID  = "statefulsets:mcoa-store:thanos"
+
+	// Thanos object storage configuration
+	ObjectStorageSecretName = "thanos-object-storage"
+	ObjectStorageSecretKey  = "thanos.yaml"
+
 	AlertmanagerAccessorSecretName = "observability-alertmanager-accessor"
 	AlertmanagerRouterCASecretName = "hub-alertmanager-router-ca"
 	AlertmanagerRouteBYOCAName     = "alertmanager-byo-ca"

--- a/internal/metrics/handlers/handler.go
+++ b/internal/metrics/handlers/handler.go
@@ -161,9 +161,9 @@ func (o *OptionsBuilder) Build(ctx context.Context, mcAddon *addonapiv1beta1.Man
 				Name:     fmt.Sprintf("%s.%s", cooprometheusv1alpha1.ScrapeConfigName, cooprometheusv1alpha1.SchemeGroupVersion.Group),
 			}
 
-			feedback, err := common.GetFeedbackValuesForResources(ctx, o.Client, managedCluster.Name, addoncfg.Name, promAgentCRD, scrapeConfigCRD)
-			if err != nil {
-				return ret, fmt.Errorf("failed to get feedback for CRDs: %w", err)
+			feedback, feedbackErr := common.GetFeedbackValuesForResources(ctx, o.Client, managedCluster.Name, addoncfg.Name, promAgentCRD, scrapeConfigCRD)
+			if feedbackErr != nil {
+				return ret, fmt.Errorf("failed to get feedback for CRDs: %w", feedbackErr)
 			}
 
 			type CrdTimestamps struct {
@@ -193,9 +193,9 @@ func (o *OptionsBuilder) Build(ctx context.Context, mcAddon *addonapiv1beta1.Man
 			}
 
 			if timestamps.PrometheusAgent != "" && timestamps.ScrapeConfig != "" {
-				jsonBytes, err := json.Marshal(timestamps)
-				if err != nil {
-					return ret, fmt.Errorf("failed to marshal CRD timestamps: %w", err)
+				jsonBytes, marshalErr := json.Marshal(timestamps)
+				if marshalErr != nil {
+					return ret, fmt.Errorf("failed to marshal CRD timestamps: %w", marshalErr)
 				}
 				ret.CRDEstablishedAnnotation = string(jsonBytes)
 			}

--- a/internal/metrics/handlers/handler.go
+++ b/internal/metrics/handlers/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stolostron/multicluster-observability-addon/internal/addon/common"
 	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
 	"github.com/stolostron/multicluster-observability-addon/internal/metrics/config"
+	thanosv1alpha1 "github.com/thanos-community/thanos-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -198,6 +199,13 @@ func (o *OptionsBuilder) Build(ctx context.Context, mcAddon *addonapiv1beta1.Man
 				}
 				ret.CRDEstablishedAnnotation = string(jsonBytes)
 			}
+		}
+	}
+
+	// Build Thanos components for hub clusters
+	if ret.IsHub && opts.ThanosOperatorEnabled {
+		if err = o.buildThanosComponents(ctx, &ret); err != nil {
+			return ret, fmt.Errorf("failed to build Thanos components: %w", err)
 		}
 	}
 
@@ -584,4 +592,89 @@ func getClusterID(ctx context.Context, c client.Client) (string, error) {
 	}
 
 	return string(clusterVersion.Spec.ClusterID), nil
+}
+
+// buildThanosComponents builds Thanos component CRs for hub deployments.
+// Currently only builds ThanosStore; other components (Receive, Query, etc.) will be added in subsequent PRs.
+func (o *OptionsBuilder) buildThanosComponents(ctx context.Context, opts *Options) error {
+	// Fetch the object storage secret reference from config resources.
+	// This is required by Store (and later by Receive, Compact, and Ruler).
+	objStoreSecret, err := o.getObjectStorageConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get object storage config: %w", err)
+	}
+
+	// Add the object storage secret to the list of secrets to be forwarded
+	if err := o.addSecret(ctx, &opts.Secrets, objStoreSecret.Name, objStoreSecret.Namespace, objStoreSecret.Name, ""); err != nil {
+		return fmt.Errorf("failed to add object storage secret: %w", err)
+	}
+
+	objStoreCfg := thanosv1alpha1.ObjectStorageConfig{
+		LocalObjectReference: corev1.LocalObjectReference{Name: objStoreSecret.Name},
+		Key:                  config.ObjectStorageSecretKey,
+	}
+
+	o.buildThanosStore(opts, objStoreCfg)
+
+	return nil
+}
+
+// getObjectStorageConfig fetches the thanos object storage secret from the hub namespace.
+func (o *OptionsBuilder) getObjectStorageConfig(ctx context.Context) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	if err := o.Client.Get(ctx, types.NamespacedName{
+		Name:      config.ObjectStorageSecretName,
+		Namespace: config.HubInstallNamespace,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get object storage secret %s/%s: %w", config.HubInstallNamespace, config.ObjectStorageSecretName, err)
+	}
+	return secret, nil
+}
+
+// buildThanosStore creates the ThanosStore CR spec for long-term metrics storage.
+// Store reads from object storage and serves historical data via StoreAPI.
+func (o *OptionsBuilder) buildThanosStore(opts *Options, objStore thanosv1alpha1.ObjectStorageConfig) {
+	// Unmanaged defaults: shards, storage size — users can modify these on the CR directly.
+	shards := int32(config.DefaultStoreShards)
+
+	opts.Thanos.Store = &thanosv1alpha1.ThanosStore{
+		Spec: thanosv1alpha1.ThanosStoreSpec{
+			Replicas:            1,
+			ObjectStorageConfig: objStore,
+			StorageConfiguration: thanosv1alpha1.StorageConfiguration{
+				Size: thanosv1alpha1.StorageSize(config.DefaultStoreStorageSize),
+			},
+			ShardingStrategy: thanosv1alpha1.ShardingStrategy{
+				Type:   thanosv1alpha1.Block,
+				Shards: shards,
+			},
+			// IndexCacheConfig will be added in ACM-35785 (Memcached caching)
+		},
+	}
+
+	// Managed fields: node selectors, tolerations, and resource requirements from AddOnDeploymentConfig.
+	o.applyCommonThanosFields(&opts.Thanos.Store.Spec.CommonFields, opts, config.ThanosStoreContainerID)
+}
+
+// applyCommonThanosFields applies node selector, tolerations, and resource requirements to Thanos components.
+// Also sets SecurityContext to work with OpenShift's restricted-v2 SCC.
+func (o *OptionsBuilder) applyCommonThanosFields(fields *thanosv1alpha1.CommonFields, opts *Options, containerID string) {
+	if len(opts.NodeSelector) > 0 {
+		fields.NodeSelector = opts.NodeSelector
+	}
+	if len(opts.Tolerations) > 0 {
+		fields.Tolerations = opts.Tolerations
+	}
+	for _, resReq := range opts.ResourceReqs {
+		if resReq.ContainerID == containerID {
+			fields.ResourceRequirements = &resReq.Resources
+		}
+	}
+	// Override the operator default of FSGroup=1001 which is rejected by OpenShift's
+	// restricted-v2 SCC. Setting an empty SecurityContext lets OpenShift assign the
+	// FSGroup from the namespace's allocated range.
+	runAsNonRoot := true
+	fields.SecurityContext = &corev1.PodSecurityContext{
+		RunAsNonRoot: &runAsNonRoot,
+	}
 }

--- a/internal/metrics/manifests/values.go
+++ b/internal/metrics/manifests/values.go
@@ -46,11 +46,12 @@ type MetricsValues struct {
 
 // ThanosOperatorValues holds the Thanos operator deployment values for Helm rendering.
 type ThanosOperatorValues struct {
-	Enabled   bool   `json:"enabled"`
-	IsHub     bool   `json:"isHub"`
-	AppName   string `json:"appName"`
-	Component string `json:"component"`
-	Image     string `json:"image"`
+	Enabled   bool        `json:"enabled"`
+	IsHub     bool        `json:"isHub"`
+	AppName   string      `json:"appName"`
+	Component string      `json:"component"`
+	Image     string      `json:"image"`
+	StoreSpec ConfigValue `json:"storeSpec"`
 }
 
 type NodeExporterValues struct {
@@ -323,7 +324,24 @@ func BuildValues(opts handlers.Options) (*MetricsValues, error) {
 		Image:     thanosOperatorImage,
 	}
 
+	if opts.IsHub && opts.Thanos.Store != nil {
+		if ret.ThanosOperator.StoreSpec, err = marshalThanosSpec(opts.Thanos.Store.Spec); err != nil {
+			return ret, fmt.Errorf("failed to build thanos store values: %w", err)
+		}
+	}
+
 	return ret, nil
+}
+
+// marshalThanosSpec serializes a Thanos CR spec into a ConfigValue for Helm rendering.
+func marshalThanosSpec(spec any) (ConfigValue, error) {
+	specJSON, err := json.Marshal(spec)
+	if err != nil {
+		return ConfigValue{}, err
+	}
+	return ConfigValue{
+		Data: string(specJSON),
+	}, nil
 }
 
 func buildSecrets(secrets []*corev1.Secret) ([]ConfigValue, error) {


### PR DESCRIPTION
## Summary
- Add ThanosStore CR template for long-term metrics storage
- Add builder function to create ThanosStore CR spec
- Add helper functions for Thanos component building
- Add object storage configuration retrieval

## Jira
https://redhat.atlassian.net/browse/ACM-35781

## Implementation
**Template**: `thanos-store.yaml` - gated by `thanosOperator.storeSpec.data`
**Builder**: `buildThanosStore()` - creates CR with:
- Object storage config from `thanos-object-storage` secret
- Default: 3 shards, 10Gi storage
- Sharding strategy: Block-based

**Helpers**:
- `buildThanosComponents()` - orchestrates all Thanos CR building (currently only Store)
- `getObjectStorageConfig()` - fetches object storage secret from hub
- `applyCommonThanosFields()` - applies node selector, tolerations, resource requirements

**Constants**:
- `DefaultStoreShards = 3`
- `DefaultStoreStorageSize = 10Gi`
- `ThanosStoreContainerID` - for resource requirement matching
- `ObjectStorageSecretName/Key` - secret reference

## Architecture
ThanosStore reads from S3/object storage and serves historical data via StoreAPI.
- Deployed only on hub clusters when `ThanosOperatorEnabled=true`
- Requires `thanos-object-storage` secret in hub namespace
- SecurityContext set to work with OpenShift restricted-v2 SCC

## What's NOT included
- **IndexCacheConfig** (Memcached caching) - will be added in ACM-35785
- **Other Thanos components** (Receive, Query, Compact, Ruler) - separate PRs

## Test plan
- [ ] Hub cluster with `mcoa-thanos-operator: true` annotation deploys ThanosStore CR
- [ ] Object storage secret is forwarded from hub
- [ ] Store CR has correct sharding, storage size, and object storage config
- [ ] Store pods scheduled with node selectors/tolerations from AddOnDeploymentConfig

## Dependencies
- Depends on ACM-35772 (annotation plumbing) - merged
- Depends on ACM-35782 (CRDs) - merged  
- Depends on ACM-35783 (operator deployment) - merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Thanos Store deployment via the Thanos Operator when the required store specification is provided.
  * Automatically configures object storage, default shard count, and storage size, and applies common scheduling/resource/security settings.
  * Propagates the required Thanos object-storage secret from the hub into the managed addon configuration.
* **Bug Fixes**
  * Improved error reporting and feedback during CRD establishment and related JSON processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->