### PR TITLE
ACM-35687-Auto-Discovery-Of-User-Defined-Prometheus-Rules

### DIFF
--- a/internal/addon/common/cleanup_resources.go
+++ b/internal/addon/common/cleanup_resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
@@ -15,18 +16,20 @@ import (
 
 var errNotClientObjectType = errors.New("object is not a client.Object")
 
-// DeleteOrphanResources lists resources of type T owned by CMOA and removes the ones having no existing placement.
+// DeleteOrphanResources lists resources of type T that are either owned by the CMAO (default
+// resources) or opted into MCOA management via the part-of label (user-defined resources), and
+// removes the ones for which none of the placements referenced in their placement-ref annotation
+// (comma-separated "namespace/name" entries, see addoncfg.PlacementAnnotationKey) exist on the
+// CMAO anymore. A resource referencing multiple placements is only deleted once all of them are
+// gone.
 func DeleteOrphanResources[T client.ObjectList](ctx context.Context, logger logr.Logger, k8s client.Client, cmao *addonapiv1beta1.ClusterManagementAddOn, items T) error {
 	if err := k8s.List(ctx, items, client.InNamespace(addoncfg.InstallNamespace)); err != nil {
 		return fmt.Errorf("failed to list PrometheusAgents: %w", err)
 	}
 
-	makePlacementKey := func(namespace, name string) string {
-		return fmt.Sprintf("%s/%s", namespace, name)
-	}
 	placementsDict := map[string]struct{}{}
 	for _, placement := range cmao.Spec.InstallStrategy.Placements {
-		placementsDict[makePlacementKey(placement.Namespace, placement.Name)] = struct{}{}
+		placementsDict[fmt.Sprintf("%s/%s", placement.Namespace, placement.Name)] = struct{}{}
 	}
 
 	// Use the Meta interface to get objects from the list
@@ -46,14 +49,13 @@ func DeleteOrphanResources[T client.ObjectList](ctx context.Context, logger logr
 			return fmt.Errorf("failed to check owner references: %w", err)
 		}
 
-		if !hasOwnerRef {
+		isUserDefined := obj.GetLabels()[addoncfg.PartOfK8sLabelKey] == addoncfg.Name
+
+		if !hasOwnerRef && !isUserDefined {
 			continue
 		}
 
-		labels := obj.GetLabels()
-		placementNs := labels[addoncfg.PlacementRefNamespaceLabelKey]
-		placementName := labels[addoncfg.PlacementRefNameLabelKey]
-		if _, ok := placementsDict[makePlacementKey(placementNs, placementName)]; ok {
+		if hasExistingPlacementRef(obj, placementsDict) {
 			continue
 		}
 
@@ -64,4 +66,34 @@ func DeleteOrphanResources[T client.ObjectList](ctx context.Context, logger logr
 	}
 
 	return nil
+}
+
+// hasExistingPlacementRef returns true if at least one of the "namespace/name" entries in the
+// object's placement-ref annotation is still present in placementsDict, or refers to the internal
+// "dummy" placement sentinel.
+func hasExistingPlacementRef(obj client.Object, placementsDict map[string]struct{}) bool {
+	annotation := obj.GetAnnotations()[addoncfg.PlacementAnnotationKey]
+	if annotation == "" {
+		return false
+	}
+
+	for ref := range strings.SplitSeq(annotation, ",") {
+		ref = strings.TrimSpace(ref)
+		if isDummyPlacementRef(ref) {
+			return true
+		}
+		if _, ok := placementsDict[ref]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isDummyPlacementRef returns true if ref refers to the internal "dummy" placement sentinel used by
+// CreateDefaultAgent as a placeholder when no default agent is otherwise needed. It never
+// corresponds to a real Placement, so it must never be treated as orphaned.
+func isDummyPlacementRef(ref string) bool {
+	_, name, ok := strings.Cut(ref, "/")
+	return ok && name == "dummy"
 }

--- a/internal/addon/common/cleanup_resources_test.go
+++ b/internal/addon/common/cleanup_resources_test.go
@@ -52,9 +52,8 @@ func TestCleanOrphanResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "agent-1",
 						Namespace: testNamespace,
-						Labels: map[string]string{
-							addoncfg.PlacementRefNameLabelKey:      placementName,
-							addoncfg.PlacementRefNamespaceLabelKey: placementNs,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/" + placementName,
 						},
 						// Not owned by CMAO
 					},
@@ -62,6 +61,99 @@ func TestCleanOrphanResources(t *testing.T) {
 			},
 			expectDeleted: map[string]bool{
 				"agent-1": false, // Resource not owned by CMAO, shouldn't be deleted
+			},
+		},
+		{
+			name: "user-defined resource (part-of label, not owned) is deleted when none of its placements exist",
+			cmao: &addonapiv1beta1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1beta1.ClusterManagementAddOnSpec{
+					// No placements
+				},
+			},
+			extraResources: []client.Object{
+				&cooprometheusv1alpha1.PrometheusAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "user-agent-orphan",
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							addoncfg.PartOfK8sLabelKey: addoncfg.Name,
+						},
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/" + placementName,
+						},
+						// Not owned by CMAO, opted in via part-of label instead
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"user-agent-orphan": true, // User-defined and none of its placements exist, should be deleted
+			},
+		},
+		{
+			name: "user-defined resource (part-of label, not owned) is kept while its placement still exists",
+			cmao: &addonapiv1beta1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1beta1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonapiv1beta1.InstallStrategy{
+						Placements: []addonapiv1beta1.PlacementStrategy{
+							{
+								PlacementRef: addonapiv1beta1.PlacementRef{
+									Name:      placementName,
+									Namespace: placementNs,
+								},
+							},
+						},
+					},
+				},
+			},
+			extraResources: []client.Object{
+				&cooprometheusv1alpha1.PrometheusAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "user-agent-covered",
+						Namespace: testNamespace,
+						Labels: map[string]string{
+							addoncfg.PartOfK8sLabelKey: addoncfg.Name,
+						},
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/" + placementName,
+						},
+						// Not owned by CMAO, opted in via part-of label instead
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"user-agent-covered": false, // Its placement still exists, shouldn't be deleted
+			},
+		},
+		{
+			name: "resource with neither CMAO ownership nor part-of label is never touched",
+			cmao: &addonapiv1beta1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1beta1.ClusterManagementAddOnSpec{
+					// No placements
+				},
+			},
+			extraResources: []client.Object{
+				&cooprometheusv1alpha1.PrometheusAgent{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rogue-agent",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/" + placementName,
+						},
+						// Neither owned by CMAO nor opted in via part-of label
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"rogue-agent": false, // Not recognized by MCOA at all, must never be touched
 			},
 		},
 		{
@@ -80,9 +172,8 @@ func TestCleanOrphanResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "agent-2",
 						Namespace: testNamespace,
-						Labels: map[string]string{
-							addoncfg.PlacementRefNameLabelKey:      placementName,
-							addoncfg.PlacementRefNamespaceLabelKey: placementNs,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/" + placementName,
 						},
 						// Will be set as owned by CMAO in the test
 					},
@@ -116,9 +207,8 @@ func TestCleanOrphanResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "agent-3",
 						Namespace: testNamespace,
-						Labels: map[string]string{
-							addoncfg.PlacementRefNameLabelKey:      placementName,
-							addoncfg.PlacementRefNamespaceLabelKey: placementNs,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/" + placementName,
 						},
 						// Not owned by CMAO
 					},
@@ -129,9 +219,8 @@ func TestCleanOrphanResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "agent-4",
 						Namespace: testNamespace,
-						Labels: map[string]string{
-							addoncfg.PlacementRefNameLabelKey:      placementName,
-							addoncfg.PlacementRefNamespaceLabelKey: placementNs,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/" + placementName,
 						},
 						// Not owned by CMAO
 					},
@@ -167,9 +256,8 @@ func TestCleanOrphanResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "agent-5",
 						Namespace: testNamespace,
-						Labels: map[string]string{
-							addoncfg.PlacementRefNameLabelKey:      placementName,
-							addoncfg.PlacementRefNamespaceLabelKey: placementNs,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/" + placementName,
 						},
 						// Will be set as owned by CMAO in the test
 					},
@@ -179,9 +267,8 @@ func TestCleanOrphanResources(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "agent-6",
 						Namespace: testNamespace,
-						Labels: map[string]string{
-							addoncfg.PlacementRefNameLabelKey:      "other-placement",
-							addoncfg.PlacementRefNamespaceLabelKey: placementNs,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/other-placement",
 						},
 						// Will be set as owned by CMAO in the test
 					},
@@ -190,6 +277,131 @@ func TestCleanOrphanResources(t *testing.T) {
 			expectDeleted: map[string]bool{
 				"agent-5": false, // Matches placement, shouldn't be deleted
 				"agent-6": true,  // Owned by CMAO but doesn't match any placement, should be deleted
+			},
+		},
+		{
+			name: "resource referencing multiple placements is kept while at least one still exists",
+			cmao: &addonapiv1beta1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1beta1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonapiv1beta1.InstallStrategy{
+						Placements: []addonapiv1beta1.PlacementStrategy{
+							{
+								PlacementRef: addonapiv1beta1.PlacementRef{
+									Name:      placementName,
+									Namespace: placementNs,
+								},
+							},
+						},
+					},
+				},
+			},
+			cmaoOwnedResources: []*cooprometheusv1alpha1.PrometheusAgent{
+				// Will not be deleted because one of its referenced placements still exists
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-7",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/other-placement," + placementNs + "/" + placementName,
+						},
+						// Will be set as owned by CMAO in the test
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"agent-7": false, // At least one referenced placement still exists, shouldn't be deleted
+			},
+		},
+		{
+			name: "resource referencing multiple placements is deleted once none of them exist",
+			cmao: &addonapiv1beta1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1beta1.ClusterManagementAddOnSpec{
+					// No placements
+				},
+			},
+			cmaoOwnedResources: []*cooprometheusv1alpha1.PrometheusAgent{
+				// Will be deleted because none of its referenced placements exist anymore
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-8",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: placementNs + "/other-placement," + placementNs + "/" + placementName,
+						},
+						// Will be set as owned by CMAO in the test
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"agent-8": true, // None of the referenced placements exist, should be deleted
+			},
+		},
+		{
+			name: "resource referencing the dummy sentinel is never deleted, even with no placements",
+			cmao: &addonapiv1beta1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1beta1.ClusterManagementAddOnSpec{
+					// No placements
+				},
+			},
+			cmaoOwnedResources: []*cooprometheusv1alpha1.PrometheusAgent{
+				// The "dummy" sentinel never corresponds to a real placement by design, so it must
+				// never be treated as orphaned (otherwise CreateDefaultAgent and DeleteOrphanResources
+				// would thrash: create the dummy agent, immediately delete it, repeat).
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-dummy",
+						Namespace: testNamespace,
+						Annotations: map[string]string{
+							addoncfg.PlacementAnnotationKey: testNamespace + "/dummy",
+						},
+						// Will be set as owned by CMAO in the test
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"agent-dummy": false, // dummy is a sentinel, never orphaned
+			},
+		},
+		{
+			name: "resource with no placement-ref annotation owned by CMAO is deleted",
+			cmao: &addonapiv1beta1.ClusterManagementAddOn{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cmaoName,
+				},
+				Spec: addonapiv1beta1.ClusterManagementAddOnSpec{
+					InstallStrategy: addonapiv1beta1.InstallStrategy{
+						Placements: []addonapiv1beta1.PlacementStrategy{
+							{
+								PlacementRef: addonapiv1beta1.PlacementRef{
+									Name:      placementName,
+									Namespace: placementNs,
+								},
+							},
+						},
+					},
+				},
+			},
+			cmaoOwnedResources: []*cooprometheusv1alpha1.PrometheusAgent{
+				// Will be deleted because it has no placement-ref annotation at all
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "agent-9",
+						Namespace: testNamespace,
+						// Will be set as owned by CMAO in the test
+					},
+				},
+			},
+			expectDeleted: map[string]bool{
+				"agent-9": true, // No placement-ref annotation, should be deleted
 			},
 		},
 	}

--- a/internal/addon/common/clustermanagementaddon.go
+++ b/internal/addon/common/clustermanagementaddon.go
@@ -118,13 +118,13 @@ func ensureConfigsInAddon(cmao *addonv1beta1.ClusterManagementAddOn, configs []D
 	}
 }
 
-// removeStaleConfigs removes any user-defined PrometheusRule or ScrapeConfig
+// removeStaleConfigs removes any user-defined PrometheusRule or ScrapeConfig, along with any PrometheusAgent
 // entries from the CMAO placements whose underlying resource no longer exists.
 func removeStaleConfigs(ctx context.Context, k8s client.Client, cmao *addonv1beta1.ClusterManagementAddOn) error {
 	for i, placement := range cmao.Spec.InstallStrategy.Placements {
 		filtered := make([]addonv1beta1.AddOnConfig, 0, len(placement.Configs))
 		for _, cfg := range placement.Configs {
-			_, err := doesScrapeConfigOrPrometheusRuleExist(ctx, k8s, cfg)
+			err := doesScrapeConfigOrPrometheusRuleOrPrometheusAgentExist(ctx, k8s, cfg)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					continue
@@ -138,27 +138,29 @@ func removeStaleConfigs(ctx context.Context, k8s client.Client, cmao *addonv1bet
 	return nil
 }
 
-// doesScrapeConfigOrPrometheusRuleExist checks whether the config references an existing ScrapeConfig or PrometheusRule
-// Returns the raw API error on failure so callers can distinguish NotFound from other errors.
-func doesScrapeConfigOrPrometheusRuleExist(ctx context.Context, k8s client.Client, cfg addonv1beta1.AddOnConfig) (bool, error) {
+// doesScrapeConfigOrPrometheusRuleOrPrometheusAgentExist checks whether the config references an existing
+// ScrapeConfig, PrometheusRule, or PrometheusAgent. Returns the raw API error on failure so callers can
+// distinguish NotFound from other errors. Returns nil for resource kinds it doesn't recognize.
+//
+// The switch below matches on both cfg.Group and cfg.Resource (i.e. the full GVR), not on cfg.Resource
+// alone: the Prometheus Operator's PrometheusRule ("monitoring.coreos.com") and OBO's PrometheusRule
+// ("monitoring.rhobs") share the exact same resource name ("prometheusrules"), so matching on Resource
+// alone would make an OBO PrometheusRule config incorrectly resolve to a Get against the Prometheus
+// Operator's type (or vice versa), returning a spurious NotFound and causing removeStaleConfigs to drop
+// a config that actually still exists.
+func doesScrapeConfigOrPrometheusRuleOrPrometheusAgentExist(ctx context.Context, k8s client.Client, cfg addonv1beta1.AddOnConfig) error {
 	key := types.NamespacedName{Name: cfg.Name, Namespace: cfg.Namespace}
-	switch cfg.Resource {
-	case cooprometheusv1alpha1.ScrapeConfigName:
-		sc := &cooprometheusv1alpha1.ScrapeConfig{}
-		if err := k8s.Get(ctx, key, sc); err != nil {
-			return false, err
-		} else {
-			return true, nil
-		}
-	case prometheusv1.PrometheusRuleName:
-		rule := &prometheusv1.PrometheusRule{}
-		if err := k8s.Get(ctx, key, rule); err != nil {
-			return false, err
-		} else {
-			return true, nil
-		}
+	switch {
+	case cfg.Group == cooprometheusv1alpha1.SchemeGroupVersion.Group && cfg.Resource == cooprometheusv1alpha1.ScrapeConfigName:
+		return k8s.Get(ctx, key, &cooprometheusv1alpha1.ScrapeConfig{})
+	case cfg.Group == cooprometheusv1.SchemeGroupVersion.Group && cfg.Resource == cooprometheusv1.PrometheusRuleName:
+		return k8s.Get(ctx, key, &cooprometheusv1.PrometheusRule{})
+	case cfg.Group == prometheusv1.SchemeGroupVersion.Group && cfg.Resource == prometheusv1.PrometheusRuleName:
+		return k8s.Get(ctx, key, &prometheusv1.PrometheusRule{})
+	case cfg.Group == cooprometheusv1alpha1.SchemeGroupVersion.Group && cfg.Resource == cooprometheusv1alpha1.PrometheusAgentName:
+		return k8s.Get(ctx, key, &cooprometheusv1alpha1.PrometheusAgent{})
 	default:
-		return false, nil
+		return nil
 	}
 }
 

--- a/internal/addon/common/clustermanagementaddon_test.go
+++ b/internal/addon/common/clustermanagementaddon_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	cooprometheusv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
 	cooprometheusv1alpha1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	addoncfg "github.com/stolostron/multicluster-observability-addon/internal/addon/config"
 	"github.com/stretchr/testify/assert"
@@ -221,6 +222,7 @@ func newCMAOTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	require.NoError(t, prometheusv1.AddToScheme(scheme))
+	require.NoError(t, cooprometheusv1.AddToScheme(scheme))
 	require.NoError(t, cooprometheusv1alpha1.AddToScheme(scheme))
 	return scheme
 }
@@ -277,6 +279,24 @@ func TestRemoveStaleConfigs(t *testing.T) {
 		},
 	}
 
+	existingAgent := &cooprometheusv1alpha1.PrometheusAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-agent",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
+	otherCfg := addonv1beta1.AddOnConfig{
+		ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+			Group:    "apps",
+			Resource: "deployments",
+		},
+		ConfigReferent: addonv1beta1.ConfigReferent{
+			Name:      "some-deployment",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
 	testCases := []struct {
 		name            string
 		existingObjects []client.Object
@@ -286,33 +306,39 @@ func TestRemoveStaleConfigs(t *testing.T) {
 	}{
 		{
 			name:            "existing resources are kept",
-			existingObjects: []client.Object{existingScrapeConfig.DeepCopy(), existingPromRule.DeepCopy()},
+			existingObjects: []client.Object{existingScrapeConfig.DeepCopy(), existingPromRule.DeepCopy(), existingAgent.DeepCopy()},
 			initialConfigs:  []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
 			expectedConfigs: []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
 		},
 		{
 			name:            "non-existent scrapeconfig is removed",
-			existingObjects: []client.Object{existingPromRule.DeepCopy()},
+			existingObjects: []client.Object{existingPromRule.DeepCopy(), existingAgent.DeepCopy()},
 			initialConfigs:  []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
 			expectedConfigs: []addonv1beta1.AddOnConfig{promRuleCfg, agentCfg},
 		},
 		{
 			name:            "non-existent prometheusrule is removed",
-			existingObjects: []client.Object{existingScrapeConfig.DeepCopy()},
+			existingObjects: []client.Object{existingScrapeConfig.DeepCopy(), existingAgent.DeepCopy()},
 			initialConfigs:  []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
 			expectedConfigs: []addonv1beta1.AddOnConfig{scrapeConfigCfg, agentCfg},
+		},
+		{
+			name:            "non-existent agent is removed",
+			existingObjects: []client.Object{existingScrapeConfig.DeepCopy(), existingPromRule.DeepCopy()},
+			initialConfigs:  []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
+			expectedConfigs: []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg},
 		},
 		{
 			name:            "all stale configs removed",
 			existingObjects: []client.Object{},
 			initialConfigs:  []addonv1beta1.AddOnConfig{scrapeConfigCfg, promRuleCfg, agentCfg},
-			expectedConfigs: []addonv1beta1.AddOnConfig{agentCfg},
+			expectedConfigs: []addonv1beta1.AddOnConfig{},
 		},
 		{
-			name:            "non-scrapeconfig-or-promrule configs are never removed",
+			name:            "unsupported resource types are never removed",
 			existingObjects: []client.Object{},
-			initialConfigs:  []addonv1beta1.AddOnConfig{agentCfg},
-			expectedConfigs: []addonv1beta1.AddOnConfig{agentCfg},
+			initialConfigs:  []addonv1beta1.AddOnConfig{otherCfg},
+			expectedConfigs: []addonv1beta1.AddOnConfig{otherCfg},
 		},
 		{
 			name:            "empty configs - no change",
@@ -351,7 +377,7 @@ func TestRemoveStaleConfigs(t *testing.T) {
 	}
 }
 
-func TestDoesScrapeConfigOrPrometheusRuleExist(t *testing.T) {
+func TestDoesScrapeConfigOrPrometheusRuleOrPrometheusAgentExist(t *testing.T) {
 	scheme := newCMAOTestScheme(t)
 
 	existingScrapeConfig := &cooprometheusv1alpha1.ScrapeConfig{
@@ -368,19 +394,38 @@ func TestDoesScrapeConfigOrPrometheusRuleExist(t *testing.T) {
 		},
 	}
 
+	existingAgent := &cooprometheusv1alpha1.PrometheusAgent{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-agent",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
+	// Same name as existingPromRule, but registered under OBO's PrometheusRule group
+	// (monitoring.rhobs) instead of the Prometheus Operator's (monitoring.coreos.com). Both
+	// share the identical "prometheusrules" resource name, so this fixture is what exercises the
+	// Group+Resource disambiguation.
+	existingOboPromRule := &cooprometheusv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-obo-rule",
+			Namespace: addoncfg.InstallNamespace,
+		},
+	}
+
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 		existingScrapeConfig,
 		existingPromRule,
+		existingOboPromRule,
+		existingAgent,
 	).Build()
 
 	testCases := []struct {
 		name           string
 		cfg            addonv1beta1.AddOnConfig
-		expected       bool
 		expectNotFound bool
 	}{
 		{
-			name: "existing scrapeconfig returns true",
+			name: "existing scrapeconfig returns no error",
 			cfg: addonv1beta1.AddOnConfig{
 				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
 					Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
@@ -391,7 +436,6 @@ func TestDoesScrapeConfigOrPrometheusRuleExist(t *testing.T) {
 					Namespace: addoncfg.InstallNamespace,
 				},
 			},
-			expected: true,
 		},
 		{
 			name: "non-existent scrapeconfig returns not found",
@@ -408,7 +452,7 @@ func TestDoesScrapeConfigOrPrometheusRuleExist(t *testing.T) {
 			expectNotFound: true,
 		},
 		{
-			name: "existing prometheusrule returns true",
+			name: "existing prometheusrule returns no error",
 			cfg: addonv1beta1.AddOnConfig{
 				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
 					Group:    prometheusv1.SchemeGroupVersion.Group,
@@ -419,7 +463,6 @@ func TestDoesScrapeConfigOrPrometheusRuleExist(t *testing.T) {
 					Namespace: addoncfg.InstallNamespace,
 				},
 			},
-			expected: true,
 		},
 		{
 			name: "non-existent prometheusrule returns not found",
@@ -436,7 +479,81 @@ func TestDoesScrapeConfigOrPrometheusRuleExist(t *testing.T) {
 			expectNotFound: true,
 		},
 		{
-			name: "other resource type returns false with no error",
+			name: "existing OBO prometheusrule returns no error",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    cooprometheusv1.SchemeGroupVersion.Group,
+					Resource: cooprometheusv1.PrometheusRuleName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "existing-obo-rule",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+		},
+		{
+			name: "non-existent OBO prometheusrule returns not found",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    cooprometheusv1.SchemeGroupVersion.Group,
+					Resource: cooprometheusv1.PrometheusRuleName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "gone-obo-rule",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expectNotFound: true,
+		},
+		{
+			// Regression test: "existing-rule" only exists as a Prometheus Operator (monitoring.coreos.com)
+			// PrometheusRule. Both groups share the identical "prometheusrules" resource name, so a
+			// Resource-only match would incorrectly resolve this OBO-group lookup against the Prometheus
+			// Operator's type and report it as existing.
+			name: "prometheusrule existing under a different group is reported as not found",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    cooprometheusv1.SchemeGroupVersion.Group,
+					Resource: cooprometheusv1.PrometheusRuleName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "existing-rule",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expectNotFound: true,
+		},
+		{
+			// Symmetric regression test in the other direction: "existing-obo-rule" only exists as an
+			// OBO PrometheusRule, not a Prometheus Operator one.
+			name: "OBO prometheusrule looked up under prometheus-operator group is reported as not found",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    prometheusv1.SchemeGroupVersion.Group,
+					Resource: prometheusv1.PrometheusRuleName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "existing-obo-rule",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+			expectNotFound: true,
+		},
+		{
+			name: "existing prometheusagent returns no error",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
+					Resource: cooprometheusv1alpha1.PrometheusAgentName,
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "existing-agent",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
+		},
+		{
+			name: "non-existent prometheusagent returns not found",
 			cfg: addonv1beta1.AddOnConfig{
 				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
 					Group:    cooprometheusv1alpha1.SchemeGroupVersion.Group,
@@ -447,20 +564,32 @@ func TestDoesScrapeConfigOrPrometheusRuleExist(t *testing.T) {
 					Namespace: addoncfg.InstallNamespace,
 				},
 			},
-			expected: false,
+			expectNotFound: true,
+		},
+		{
+			name: "unsupported resource type returns no error",
+			cfg: addonv1beta1.AddOnConfig{
+				ConfigGroupResource: addonv1beta1.ConfigGroupResource{
+					Group:    "apps",
+					Resource: "deployments",
+				},
+				ConfigReferent: addonv1beta1.ConfigReferent{
+					Name:      "some-deployment",
+					Namespace: addoncfg.InstallNamespace,
+				},
+			},
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := doesScrapeConfigOrPrometheusRuleExist(context.Background(), fakeClient, tt.cfg)
+			err := doesScrapeConfigOrPrometheusRuleOrPrometheusAgentExist(context.Background(), fakeClient, tt.cfg)
 			if tt.expectNotFound {
 				require.Error(t, err)
 				assert.True(t, apierrors.IsNotFound(err), "expected NotFound error, got: %v", err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/internal/controllers/resourcecreator/controller.go
+++ b/internal/controllers/resourcecreator/controller.go
@@ -164,6 +164,9 @@ func (r *ResourceCreatorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err := r.Get(ctx, types.NamespacedName{Name: addoncfg.Name}, cmao); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get ClusterManagementAddOn: %w", err)
 	}
+	// Deletes owned PrometheusAgents whose placement-ref annotation no longer references any
+	// placement declared on the CMAO. Agents referencing multiple placements are kept as long as
+	// at least one of them still exists.
 	if err := common.DeleteOrphanResources(ctx, r.Log, r.Client, cmao, &cooprometheusv1alpha1.PrometheusAgentList{}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to clean orphan resources: %w", err)
 	}

--- a/internal/metrics/resource/agentssa.go
+++ b/internal/metrics/resource/agentssa.go
@@ -13,12 +13,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	addonv1beta1 "open-cluster-management.io/api/addon/v1beta1"
 )
 
 // NewDefaultPrometheusAgent generates the default prometheusAgent resource containing sensible
 // defaults that can be overridden by the user.
-func NewDefaultPrometheusAgent(ns, name string, isUWL bool, placementRef addonv1beta1.PlacementRef) *cooprometheusv1alpha1.PrometheusAgent {
+func NewDefaultPrometheusAgent(ns, name string, isUWL bool) *cooprometheusv1alpha1.PrometheusAgent {
 	agent := &cooprometheusv1alpha1.PrometheusAgent{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       cooprometheusv1alpha1.PrometheusAgentsKind,
@@ -59,22 +58,35 @@ func NewDefaultPrometheusAgent(ns, name string, isUWL bool, placementRef addonv1
 		agent.Spec.ScrapeConfigNamespaceSelector = &metav1.LabelSelector{}
 	}
 
-	maps.Copy(agent.Labels, makeConfigResourceLabels(isUWL, placementRef))
+	maps.Copy(agent.Labels, makeUWLOrPlatformLabels(isUWL))
 
 	return agent
 }
 
-func makeConfigResourceLabels(isUWL bool, placementRef addonv1beta1.PlacementRef) map[string]string {
-	appName := config.PlatformMetricsCollectorApp
-	if isUWL {
-		appName = config.UserWorkloadMetricsCollectorApp
-	}
+func makeUWLOrPlatformLabels(isUWL bool) map[string]string {
 	return map[string]string{
-		addoncfg.ManagedByK8sLabelKey:          addoncfg.Name,
-		addoncfg.ComponentK8sLabelKey:          appName,
-		addoncfg.PlacementRefNameLabelKey:      placementRef.Name,
-		addoncfg.PlacementRefNamespaceLabelKey: placementRef.Namespace,
+		addoncfg.ManagedByK8sLabelKey: addoncfg.Name,
+		addoncfg.ComponentK8sLabelKey: componentName(isUWL),
 	}
+}
+
+// makeComponentLabelSelector returns the label set used to discover PrometheusAgents to reconcile.
+// It only matches on the component label, which tells us whether an agent is a platform or
+// user-workload collector: that information can't be inferred any other way. It deliberately
+// excludes the managed-by label, since that would exclude user-defined agents that only opt in
+// via the part-of label (see isRecognizedAgent), even though they are legitimately referenced by
+// the CMAO.
+func makeComponentLabelSelector(isUWL bool) map[string]string {
+	return map[string]string{
+		addoncfg.ComponentK8sLabelKey: componentName(isUWL),
+	}
+}
+
+func componentName(isUWL bool) string {
+	if isUWL {
+		return config.UserWorkloadMetricsCollectorApp
+	}
+	return config.PlatformMetricsCollectorApp
 }
 
 // PrometheusAgentSSA applies configuration and invariants to an existing PrometheusAgent
@@ -86,6 +98,7 @@ type PrometheusAgentSSA struct {
 	KubeRBACProxyImage  string
 	Labels              map[string]string
 	RemoteWriteEndpoint string
+	Annotations         map[string]string
 
 	desiredAgent *cooprometheusv1alpha1.PrometheusAgent
 }
@@ -138,6 +151,14 @@ func (p *PrometheusAgentSSA) Build() *cooprometheusv1alpha1.PrometheusAgent {
 		p.desiredAgent.Labels = map[string]string{}
 	}
 	p.desiredAgent.Labels[addoncfg.BackupLabelKey] = addoncfg.BackupLabelValue
+
+	if len(p.Annotations) > 0 {
+		p.desiredAgent.Annotations = maps.Clone(p.ExistingAgent.Annotations)
+		if p.desiredAgent.Annotations == nil {
+			p.desiredAgent.Annotations = map[string]string{}
+		}
+		maps.Copy(p.desiredAgent.Annotations, p.Annotations)
+	}
 
 	p.setPrometheusRemoteWriteConfig()
 	p.setWatchedResources()

--- a/internal/metrics/resource/resource.go
+++ b/internal/metrics/resource/resource.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 
@@ -28,7 +27,6 @@ import (
 )
 
 var (
-	errTooManyConfigResources    = errors.New("too many configuration resources")
 	errMissingHubEndpoint        = errors.New("hub endpoint is missing")
 	errInvalidPlacementReference = errors.New("invalid placement reference")
 )
@@ -58,17 +56,18 @@ func (d DefaultStackResources) Reconcile(ctx context.Context) ([]common.DefaultC
 			break
 		}
 	}
+	// Migrate existing agents from placement labels to annotations
+	if err := d.migrateAgentPlacementLabels(ctx); err != nil {
+		return configs, fmt.Errorf("failed to migrate agent placement labels: %w", err)
+	}
 
 	hasHostedClusters := config.HasHostedCLusters(ctx, d.Client, d.Logger)
 	if d.AddonOptions.Platform.Metrics.CollectionEnabled {
-		// Generate a specific agent config for each placement
-		for _, placement := range d.CMAO.Spec.InstallStrategy.Placements {
-			agentConfig, err := d.reconcileAgentForPlacement(ctx, placement.PlacementRef, false)
-			if err != nil {
-				return configs, fmt.Errorf("failed to reconcile prometheusAgent %s for placement %s: %w", agentConfig.Config.Name, placement.Name, err)
-			}
-			configs = append(configs, agentConfig)
+		agentConfig, err := d.reconcileAgents(ctx, false)
+		if err != nil {
+			return configs, fmt.Errorf("failed to reconcile prometheusAgents %w", err)
 		}
+		configs = append(configs, agentConfig...)
 
 		// ScrapeConfigs are common to all placements
 		scConfigs, err := d.reconcileScrapeConfigs(ctx, mcoUID, false, hasHostedClusters)
@@ -79,14 +78,11 @@ func (d DefaultStackResources) Reconcile(ctx context.Context) ([]common.DefaultC
 	}
 
 	if d.AddonOptions.UserWorkloads.Metrics.CollectionEnabled {
-		// Generate a specific agent config for each placement
-		for _, placement := range d.CMAO.Spec.InstallStrategy.Placements {
-			agentConfig, err := d.reconcileAgentForPlacement(ctx, placement.PlacementRef, true)
-			if err != nil {
-				return configs, fmt.Errorf("failed to reconcile prometheusAgent %s for placement %s: %w", agentConfig.Config.Name, placement.Name, err)
-			}
-			configs = append(configs, agentConfig)
+		agentConfig, err := d.reconcileAgents(ctx, true)
+		if err != nil {
+			return configs, fmt.Errorf("failed to reconcile prometheusAgents %w", err)
 		}
+		configs = append(configs, agentConfig...)
 
 		// ScrapeConfigs are common to all placements
 		scConfigs, err := d.reconcileScrapeConfigs(ctx, mcoUID, true, hasHostedClusters)
@@ -279,86 +275,186 @@ func (d DefaultStackResources) getPrometheusRules(ctx context.Context, mcoUID ty
 	return configs, nil
 }
 
-func (d DefaultStackResources) reconcileAgentForPlacement(ctx context.Context, placementRef addonv1beta1.PlacementRef, isUWL bool) (common.DefaultConfig, error) {
-	d.Logger.V(2).Info("reconciling prometheus agent", "placementName", placementRef.Name, "placementNamespace", placementRef.Namespace, "isUWL", isUWL)
-	// Get or create default
-	agent, err := d.getOrCreateDefaultAgent(ctx, placementRef, isUWL)
+// migrateAgentPlacementLabels migrates the placement labels to an annotation for all PrometheusAgents in the Hub install namespace.
+func (d DefaultStackResources) migrateAgentPlacementLabels(ctx context.Context) error {
+	promAgents := &cooprometheusv1alpha1.PrometheusAgentList{}
+	if err := d.Client.List(ctx, promAgents, &client.ListOptions{
+		Namespace: config.HubInstallNamespace,
+		LabelSelector: labels.SelectorFromSet(labels.Set{
+			addoncfg.ManagedByK8sLabelKey: addoncfg.Name,
+		}),
+	}); err != nil {
+		return fmt.Errorf("failed to list prometheusAgents for migration: %w", err)
+	}
+
+	for i := range promAgents.Items {
+		agent := &promAgents.Items[i]
+		if migrateAgentPlacementLabelsToAnnotation(agent) {
+			if err := d.Client.Update(ctx, agent); err != nil {
+				return fmt.Errorf("failed to update migrated agent %s/%s: %w", agent.Namespace, agent.Name, err)
+			}
+			d.Logger.Info("migrated agent placement labels to annotation", "name", agent.Name)
+		}
+	}
+
+	return nil
+}
+
+// migrateAgentPlacementLabelsToAnnotation migrates the placement labels to an annotation for a given PrometheusAgent.
+// If the placement labels are not present, it returns false.
+// If the placement labels are present, it migrates them to an annotation and returns true.
+func migrateAgentPlacementLabelsToAnnotation(agent *cooprometheusv1alpha1.PrometheusAgent) bool {
+	placementName := agent.Labels[addoncfg.PlacementRefNameLabelKey]
+	placementNS := agent.Labels[addoncfg.PlacementRefNamespaceLabelKey]
+
+	if placementName == "" || placementNS == "" {
+		return false
+	}
+
+	if agent.Annotations == nil {
+		agent.Annotations = map[string]string{}
+	}
+
+	newRef := placementNS + "/" + placementName
+	existing := agent.Annotations[addoncfg.PlacementAnnotationKey]
+	if existing == "" {
+		agent.Annotations[addoncfg.PlacementAnnotationKey] = newRef
+	} else if !strings.Contains(existing, newRef) {
+		agent.Annotations[addoncfg.PlacementAnnotationKey] = existing + "," + newRef
+	}
+
+	delete(agent.Labels, addoncfg.PlacementRefNameLabelKey)
+	delete(agent.Labels, addoncfg.PlacementRefNamespaceLabelKey)
+
+	return true
+}
+
+func (d DefaultStackResources) reconcileAgents(ctx context.Context, isUWL bool) ([]common.DefaultConfig, error) {
+	_, err := d.CreateDefaultAgent(ctx, isUWL)
 	if err != nil {
-		return common.DefaultConfig{}, fmt.Errorf("failed to get or create agent for placement %s: %w", placementRef.Name, err)
+		return nil, fmt.Errorf("failed to create default agent: %w", err)
 	}
 
 	if d.AddonOptions.Platform.Metrics.HubEndpoint.Host == "" {
-		return common.DefaultConfig{}, errMissingHubEndpoint
+		return nil, errMissingHubEndpoint
 	}
 
-	// SSA mendatory field values
-	promBuilder := PrometheusAgentSSA{
-		ExistingAgent:       agent,
-		IsUwl:               isUWL,
-		PrometheusImage:     d.PrometheusImage,
-		KubeRBACProxyImage:  d.KubeRBACProxyImage,
-		RemoteWriteEndpoint: d.AddonOptions.Platform.Metrics.HubEndpoint.String(),
-		Labels: map[string]string{
-			addoncfg.PlacementRefNameLabelKey:      placementRef.Name,
-			addoncfg.PlacementRefNamespaceLabelKey: placementRef.Namespace,
-		},
-	}
-	promSSA := promBuilder.Build()
-
-	// SSA the objects rendered
-	if !equality.Semantic.DeepDerivative(promSSA.Spec, agent.Spec) || !maps.Equal(promSSA.Labels, agent.Labels) {
-		if err = common.ServerSideApply(ctx, d.Client, promSSA, d.CMAO); err != nil {
-			return common.DefaultConfig{}, fmt.Errorf("failed to server-side apply for %s/%s: %w", promSSA.Namespace, promSSA.Name, err)
-		}
-		d.Logger.Info("updated prometheus agent with server-side apply", "namespace", promSSA.Namespace, "name", promSSA.Name)
-	}
-
-	cfg, err := common.ObjectToAddonConfig(promSSA)
-	if err != nil {
-		return common.DefaultConfig{}, fmt.Errorf("failed to generate addon config for %s: %w", agent.Name, err)
-	}
-
-	return common.DefaultConfig{
-		PlacementRef: placementRef,
-		Config:       cfg,
-	}, nil
-}
-
-func (d DefaultStackResources) getOrCreateDefaultAgent(ctx context.Context, placementRef addonv1beta1.PlacementRef, isUWL bool) (*cooprometheusv1alpha1.PrometheusAgent, error) {
 	promAgents := &cooprometheusv1alpha1.PrometheusAgentList{}
 	if err := d.Client.List(ctx, promAgents, &client.ListOptions{
 		Namespace:     config.HubInstallNamespace,
-		LabelSelector: labels.SelectorFromSet(labels.Set(makeConfigResourceLabels(isUWL, placementRef))),
+		LabelSelector: labels.SelectorFromSet(labels.Set(makeComponentLabelSelector(isUWL))),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list prometheusAgents: %w", err)
+	}
+
+	configs := []common.DefaultConfig{}
+	for i := range promAgents.Items {
+		agent := &promAgents.Items[i]
+
+		if !isRecognizedAgent(agent, d.CMAO.UID) {
+			continue
+		}
+
+		promBuilder := PrometheusAgentSSA{
+			ExistingAgent:       agent,
+			IsUwl:               isUWL,
+			PrometheusImage:     d.PrometheusImage,
+			KubeRBACProxyImage:  d.KubeRBACProxyImage,
+			RemoteWriteEndpoint: d.AddonOptions.Platform.Metrics.HubEndpoint.String(),
+		}
+		promSSA := promBuilder.Build()
+
+		if !equality.Semantic.DeepDerivative(promSSA.Spec, agent.Spec) {
+			if err := common.ServerSideApply(ctx, d.Client, promSSA, d.CMAO); err != nil {
+				return nil, fmt.Errorf("failed to server-side apply for %s/%s: %w", promSSA.Namespace, promSSA.Name, err)
+			}
+		}
+
+		placementAnnotation := agent.Annotations[addoncfg.PlacementAnnotationKey]
+		placementRefs, err := d.generatePlacementRefs(placementAnnotation)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate placement refs for agent %s: %w", agent.Name, err)
+		}
+
+		cfg, err := common.ObjectToAddonConfig(promSSA)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate addon config for %s: %w", agent.Name, err)
+		}
+
+		for _, ref := range placementRefs {
+			configs = append(configs, common.DefaultConfig{
+				PlacementRef: ref,
+				Config:       cfg,
+			})
+		}
+	}
+	return configs, nil
+}
+
+func (d DefaultStackResources) CreateDefaultAgent(ctx context.Context, isUWL bool) (*cooprometheusv1alpha1.PrometheusAgent, error) {
+	promAgents := &cooprometheusv1alpha1.PrometheusAgentList{}
+	if err := d.Client.List(ctx, promAgents, &client.ListOptions{
+		Namespace:     config.HubInstallNamespace,
+		LabelSelector: labels.SelectorFromSet(labels.Set(makeComponentLabelSelector(isUWL))),
 	}); err != nil {
 		return nil, fmt.Errorf("failed to list existing prometheusAgents: %w", err)
 	}
+	// Look up the "global" placement's actual namespace directly from the CMAO instead of assuming
+	// it lives in config.HubInstallNamespace: OCM's "global" Placement conventionally lives in its
+	// own namespace (e.g. open-cluster-management-global-set), separate from where MCOA installs
+	// its own resources.
+	globalNamespace, globalExists := findPlacementNamespace(d.CMAO, "global")
 
-	if len(promAgents.Items) > 1 {
-		names := []string{}
-		for _, item := range promAgents.Items {
-			names = append(names, item.Name)
-		}
-		return nil, fmt.Errorf("%w: found %d prometheusAgents in namespace %q with names %+v", errTooManyConfigResources, len(promAgents.Items), config.HubInstallNamespace, names)
-	}
-
-	if len(promAgents.Items) == 1 {
-		return &promAgents.Items[0], nil
-	}
-	// Create default resource
 	appName := config.PlatformMetricsCollectorApp
 	if isUWL {
 		appName = config.UserWorkloadMetricsCollectorApp
 	}
-	agent := NewDefaultPrometheusAgent(config.HubInstallNamespace, makeAgentName(appName, placementRef.Name), isUWL, placementRef)
+	globalReferenced := false
+	defaultGlobalAgentName := makeAgentName(appName, "global") + "-default"
+
+	for _, agent := range promAgents.Items {
+		if !isRecognizedAgent(&agent, d.CMAO.UID) {
+			continue
+		}
+		if agentTargetsPlacement(&agent, config.HubInstallNamespace, "dummy") {
+			return nil, nil
+		}
+		if globalExists && agentTargetsPlacement(&agent, globalNamespace, "global") && agent.Name == defaultGlobalAgentName {
+			return nil, nil
+		}
+		if globalExists && agentTargetsPlacement(&agent, globalNamespace, "global") {
+			globalReferenced = true
+		}
+	}
+	agent := &cooprometheusv1alpha1.PrometheusAgent{}
+	placementRefNamespace := config.HubInstallNamespace
+	placementRefName := "dummy"
+	// If there is no global placement reference, create a dummy Prometheus Agent that points at dummy
+	if !globalExists {
+		agent = NewDefaultPrometheusAgent(config.HubInstallNamespace, makeAgentName(appName, "dummy"), isUWL)
+	} else if globalReferenced {
+		// Global placement exists and an agent already covers it, create a dummy agent
+		agent = NewDefaultPrometheusAgent(config.HubInstallNamespace, makeAgentName(appName, "dummy"), isUWL)
+	} else {
+		// Global placement exists but no agent covers it, create a default agent for global
+		agent = NewDefaultPrometheusAgent(config.HubInstallNamespace, defaultGlobalAgentName, isUWL)
+		placementRefNamespace = globalNamespace
+		placementRefName = "global"
+	}
+
+	if agent.Annotations == nil {
+		agent.Annotations = map[string]string{}
+	}
+	agent.Annotations[addoncfg.PlacementAnnotationKey] = placementRefNamespace + "/" + placementRefName
 
 	if err := controllerutil.SetControllerReference(d.CMAO, agent, d.Client.Scheme()); err != nil {
-		return nil, fmt.Errorf("failed to set owner reference on default agent for placement %q: %w", placementRef.Name, err)
+		return nil, fmt.Errorf("failed to set owner reference on default agent for placement %q: %w", placementRefName, err)
 	}
 
 	if err := d.Client.Create(ctx, agent); err != nil {
-		return nil, fmt.Errorf("failed to create the default agent for placement %q: %w", placementRef.Name, err)
+		return nil, fmt.Errorf("failed to create the default agent for placement %q: %w", placementRefName, err)
 	}
-	d.Logger.Info("created default prometheus agent for placement", "agentNamespace", agent.Namespace, "agentName", agent.Name, "placementName", placementRef.Name)
+	d.Logger.Info("created default prometheus agent for placement", "agentNamespace", agent.Namespace, "agentName", agent.Name, "placementName", placementRefName)
 
 	// Re-fetch the agent to populate server-side fields and, critically, TypeMeta.
 	// The 'agent' object was mutated by Create() and its TypeMeta is now empty.
@@ -369,6 +465,31 @@ func (d DefaultStackResources) getOrCreateDefaultAgent(ctx context.Context, plac
 	}
 
 	return createdAgent, nil
+}
+
+// findPlacementNamespace returns the namespace of the placement with the given name, as declared
+// in the CMAO's install strategy, and whether it was found.
+func findPlacementNamespace(cmao *addonv1beta1.ClusterManagementAddOn, name string) (string, bool) {
+	for _, p := range cmao.Spec.InstallStrategy.Placements {
+		if p.Name == name {
+			return p.Namespace, true
+		}
+	}
+	return "", false
+}
+
+func agentTargetsPlacement(agent *cooprometheusv1alpha1.PrometheusAgent, namespace, name string) bool {
+	annotation := agent.Annotations[addoncfg.PlacementAnnotationKey]
+	if annotation == "" {
+		return false
+	}
+	target := namespace + "/" + name
+	for ref := range strings.SplitSeq(annotation, ",") {
+		if strings.TrimSpace(ref) == target {
+			return true
+		}
+	}
+	return false
 }
 
 func (d DefaultStackResources) generateConfigsForAllPlacements(object []client.Object) ([]common.DefaultConfig, error) {
@@ -402,6 +523,7 @@ func (d DefaultStackResources) generatePlacementRefs(placementAnnotations string
 	placements := strings.Split(placementAnnotations, ",")
 	placementRefs := []addonv1beta1.PlacementRef{}
 	for _, placement := range placements {
+		placement = strings.TrimSpace(placement)
 		if placement == "" {
 			continue
 		}
@@ -432,4 +554,13 @@ func hasControllerUID(ownerRefs []metav1.OwnerReference, uid types.UID) bool {
 		}
 	}
 	return false
+}
+
+// isRecognizedAgent returns true if the agent is either owned by the CMAO (default agents)
+// or has the part-of label indicating it's a user-defined agent that opts into MCOA management.
+func isRecognizedAgent(agent *cooprometheusv1alpha1.PrometheusAgent, cmaoUID types.UID) bool {
+	if hasControllerUID(agent.OwnerReferences, cmaoUID) {
+		return true
+	}
+	return agent.Labels[addoncfg.PartOfK8sLabelKey] == addoncfg.Name
 }

--- a/internal/metrics/resource/resource_test.go
+++ b/internal/metrics/resource/resource_test.go
@@ -31,102 +31,162 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func TestGetOrCreateDefaultAgent(t *testing.T) {
-	cmao := newCMAO()
+// testGlobalNamespace mirrors the real-world namespace of the OCM "global" Placement
+// (open-cluster-management-global-set), which is deliberately different from
+// config.HubInstallNamespace (where MCOA's own resources live) to exercise that distinction.
+const testGlobalNamespace = "open-cluster-management-global-set"
 
-	// Existing Platform Agent
-	placementRef := addonv1beta1.PlacementRef{
-		Name:      "global",
-		Namespace: config.HubInstallNamespace,
+func TestCreateDefaultAgent(t *testing.T) {
+	globalPlacement := addonv1beta1.PlacementStrategy{
+		PlacementRef: addonv1beta1.PlacementRef{
+			Name:      "global",
+			Namespace: testGlobalNamespace,
+		},
 	}
-	platformAppName := config.PlatformMetricsCollectorApp
-	existingPlatformAgent := NewDefaultPrometheusAgent(config.HubInstallNamespace, makeAgentName(platformAppName, placementRef.Name), false, placementRef)
-	require.NoError(t, controllerutil.SetControllerReference(cmao, existingPlatformAgent, newTestScheme()))
-
-	// Existing UWL Agent
-	uwlAppName := config.UserWorkloadMetricsCollectorApp
-	existingUWLAgent := NewDefaultPrometheusAgent(config.HubInstallNamespace, makeAgentName(uwlAppName, placementRef.Name), true, placementRef)
-	require.NoError(t, controllerutil.SetControllerReference(cmao, existingUWLAgent, newTestScheme()))
 
 	testCases := []struct {
-		name         string
-		placementRef addonv1beta1.PlacementRef
-		isUWL        bool
-		initObjs     []client.Object
+		name               string
+		isUWL              bool
+		placements         []addonv1beta1.PlacementStrategy
+		initObjs           []client.Object
+		expectCreated      bool
+		expectTargetsDummy bool
 	}{
 		{
-			name: "creates platform agent",
-			placementRef: addonv1beta1.PlacementRef{
-				Name:      "my-placement",
-				Namespace: config.HubInstallNamespace,
+			name:               "creates dummy agent when no global placement",
+			isUWL:              false,
+			placements:         []addonv1beta1.PlacementStrategy{},
+			expectCreated:      true,
+			expectTargetsDummy: true,
+		},
+		{
+			name:               "creates global agent when global placement exists and no agent covers it",
+			isUWL:              false,
+			placements:         []addonv1beta1.PlacementStrategy{globalPlacement},
+			expectCreated:      true,
+			expectTargetsDummy: false,
+		},
+		{
+			name:       "creates dummy agent when global exists but another user agent already covers it",
+			isUWL:      false,
+			placements: []addonv1beta1.PlacementStrategy{globalPlacement},
+			initObjs: []client.Object{
+				func() client.Object {
+					a := NewDefaultPrometheusAgent(config.HubInstallNamespace, "user-agent", false)
+					a.Labels[addoncfg.PartOfK8sLabelKey] = addoncfg.Name
+					a.Annotations = map[string]string{
+						addoncfg.PlacementAnnotationKey: testGlobalNamespace + "/global",
+					}
+					return a
+				}(),
 			},
-			isUWL:    false,
-			initObjs: []client.Object{cmao},
+			expectCreated:      true,
+			expectTargetsDummy: true,
 		},
 		{
-			name:         "updates platform agent",
-			placementRef: placementRef,
-			isUWL:        false,
-			initObjs:     []client.Object{cmao, existingPlatformAgent},
-		},
-		{
-			name: "creates uwl agent",
-			placementRef: addonv1beta1.PlacementRef{
-				Name:      "my-placement",
-				Namespace: config.HubInstallNamespace,
+			name:       "returns nil when default global agent already exists",
+			isUWL:      false,
+			placements: []addonv1beta1.PlacementStrategy{globalPlacement},
+			initObjs: []client.Object{
+				func() client.Object {
+					appName := config.PlatformMetricsCollectorApp
+					a := NewDefaultPrometheusAgent(config.HubInstallNamespace, makeAgentName(appName, "global")+"-default", false)
+					a.Annotations = map[string]string{
+						addoncfg.PlacementAnnotationKey: testGlobalNamespace + "/global",
+					}
+					a.OwnerReferences = []metav1.OwnerReference{
+						{UID: types.UID("test-cmao-uid"), Controller: ptr.To(true)},
+					}
+					return a
+				}(),
 			},
-			isUWL:    true,
-			initObjs: []client.Object{cmao},
+			expectCreated: false,
 		},
 		{
-			name:         "updates uwl agent",
-			placementRef: placementRef,
-			isUWL:        true,
-			initObjs:     []client.Object{cmao, existingUWLAgent},
+			name:       "returns nil when dummy agent already exists",
+			isUWL:      false,
+			placements: []addonv1beta1.PlacementStrategy{},
+			initObjs: []client.Object{
+				func() client.Object {
+					appName := config.PlatformMetricsCollectorApp
+					a := NewDefaultPrometheusAgent(config.HubInstallNamespace, makeAgentName(appName, "dummy"), false)
+					a.Annotations = map[string]string{
+						addoncfg.PlacementAnnotationKey: config.HubInstallNamespace + "/dummy",
+					}
+					a.OwnerReferences = []metav1.OwnerReference{
+						{UID: types.UID("test-cmao-uid"), Controller: ptr.To(true)},
+					}
+					return a
+				}(),
+			},
+			expectCreated: false,
+		},
+		{
+			name:               "creates uwl dummy agent when no global placement",
+			isUWL:              true,
+			placements:         []addonv1beta1.PlacementStrategy{},
+			expectCreated:      true,
+			expectTargetsDummy: true,
+		},
+		{
+			name:               "creates uwl global agent when global placement exists",
+			isUWL:              true,
+			placements:         []addonv1beta1.PlacementStrategy{globalPlacement},
+			expectCreated:      true,
+			expectTargetsDummy: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(tc.initObjs...).Build()
+			cmao := newCMAO(tc.placements...)
+			initObjs := append(tc.initObjs, cmao)
+			fakeClient := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(initObjs...).Build()
 			d := DefaultStackResources{
 				Client: fakeClient,
 				CMAO:   cmao,
 				Logger: klog.Background(),
 			}
 
-			gotAgent, err := d.getOrCreateDefaultAgent(context.Background(), tc.placementRef, tc.isUWL)
+			gotAgent, err := d.CreateDefaultAgent(context.Background(), tc.isUWL)
 			require.NoError(t, err)
-			assert.True(t, controllerutil.HasControllerReference(gotAgent))
 
-			// ensure there is only one agent
-			if err == nil {
-				res := &cooprometheusv1alpha1.PrometheusAgentList{}
-				err := fakeClient.List(context.Background(), res)
-				require.NoError(t, err)
-				assert.Len(t, res.Items, 1)
+			if !tc.expectCreated {
+				assert.Nil(t, gotAgent)
+				return
 			}
 
-			// ensure correct labels are set on the agent
+			require.NotNil(t, gotAgent)
+			assert.True(t, controllerutil.HasControllerReference(gotAgent))
+
+			// ensure correct labels
 			if tc.isUWL {
-				assert.Equal(t, gotAgent.Labels[addoncfg.ComponentK8sLabelKey], config.UserWorkloadPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey])
+				assert.Equal(t, config.UserWorkloadMetricsCollectorApp, gotAgent.Labels[addoncfg.ComponentK8sLabelKey])
 			} else {
-				assert.Equal(t, gotAgent.Labels[addoncfg.ComponentK8sLabelKey], config.PlatformPrometheusMatchLabels[addoncfg.ComponentK8sLabelKey])
+				assert.Equal(t, config.PlatformMetricsCollectorApp, gotAgent.Labels[addoncfg.ComponentK8sLabelKey])
+			}
+
+			// ensure annotation is set
+			annotation := gotAgent.Annotations[addoncfg.PlacementAnnotationKey]
+			assert.NotEmpty(t, annotation)
+			if tc.expectTargetsDummy {
+				assert.Contains(t, annotation, "/dummy")
+			} else {
+				assert.Contains(t, annotation, "/global")
 			}
 		})
 	}
 }
 
-func TestReconcileAgent(t *testing.T) {
-	cmao := newCMAO()
+func TestReconcileAgents(t *testing.T) {
+	globalPlacement := addonv1beta1.PlacementStrategy{
+		PlacementRef: addonv1beta1.PlacementRef{Name: "global", Namespace: testGlobalNamespace},
+	}
+	cmao := newCMAO(globalPlacement)
 	opts := newAddonOptions(true, true)
 	kubeRbacImage := "kube-rbac-proxy:version"
 	prometheusImage := "prometheus:version"
-	placementRef := addonv1beta1.PlacementRef{Name: "my-placement", Namespace: "my-namespace"}
 
-	// Dynamic fake client doesn't support apply types of patch. This is overridden with an interceptor toward a
-	// merge type patch that has no unwanted effect for this unit test.
-	patchCalls := 0
 	scheme := newTestScheme()
 	fakeClient := fake.NewClientBuilder().WithInterceptorFuncs(ensureGVKIsSet(scheme)).WithScheme(scheme).WithObjects(cmao).Build()
 	d := DefaultStackResources{
@@ -138,12 +198,13 @@ func TestReconcileAgent(t *testing.T) {
 		PrometheusImage:    prometheusImage,
 	}
 
-	// >>> Platform agent
-	retAgent, err := d.reconcileAgentForPlacement(context.Background(), placementRef, false)
+	// >>> Platform agents
+	configs, err := d.reconcileAgents(context.Background(), false)
 	require.NoError(t, err)
+	require.Len(t, configs, 1)
 
 	foundAgent := cooprometheusv1alpha1.PrometheusAgent{}
-	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: retAgent.Config.Namespace, Name: retAgent.Config.Name}, &foundAgent)
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: configs[0].Config.Namespace, Name: configs[0].Config.Name}, &foundAgent)
 	require.NoError(t, err)
 
 	// Check default fields
@@ -152,24 +213,34 @@ func TestReconcileAgent(t *testing.T) {
 	assert.Equal(t, kubeRbacImage, foundAgent.Spec.Containers[0].Image)
 	assert.Equal(t, prometheusImage, *foundAgent.Spec.Image)
 	assert.Equal(t, config.PlatformMetricsCollectorApp, foundAgent.Spec.ServiceAccountName)
-	// Check placement labels
-	assert.Equal(t, foundAgent.Labels[addoncfg.PlacementRefNameLabelKey], placementRef.Name)
-	// Check platform specific values: appName and ScrapeConfigNamespaceSelector
-	assert.Equal(t, config.PlatformMetricsCollectorApp, foundAgent.Spec.ServiceAccountName)
+	// Check platform specific values: ScrapeConfigNamespaceSelector
 	assert.Nil(t, foundAgent.Spec.ScrapeConfigNamespaceSelector)
+	// Check placement annotation
+	assert.Contains(t, foundAgent.Annotations[addoncfg.PlacementAnnotationKey], "global")
 
-	// Subsequent reconcile does not trigger update
-	previousPatchCalls := patchCalls
-	_, err = d.reconcileAgentForPlacement(context.Background(), placementRef, false)
+	// Subsequent reconcile does not create additional agents
+	configs2, err := d.reconcileAgents(context.Background(), false)
 	require.NoError(t, err)
-	assert.Equal(t, previousPatchCalls, patchCalls)
+	assert.Len(t, configs2, 1)
 
-	// >>> UWL agent
-	retAgent, err = d.reconcileAgentForPlacement(context.Background(), placementRef, true)
+	agents := cooprometheusv1alpha1.PrometheusAgentList{}
+	err = fakeClient.List(context.Background(), &agents)
 	require.NoError(t, err)
+	platformCount := 0
+	for _, a := range agents.Items {
+		if a.Labels[addoncfg.ComponentK8sLabelKey] == config.PlatformMetricsCollectorApp {
+			platformCount++
+		}
+	}
+	assert.Equal(t, 1, platformCount)
+
+	// >>> UWL agents
+	configs, err = d.reconcileAgents(context.Background(), true)
+	require.NoError(t, err)
+	require.Len(t, configs, 1)
 
 	foundAgent = cooprometheusv1alpha1.PrometheusAgent{}
-	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: retAgent.Config.Namespace, Name: retAgent.Config.Name}, &foundAgent)
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: configs[0].Config.Namespace, Name: configs[0].Config.Name}, &foundAgent)
 	require.NoError(t, err)
 
 	// Check uwl specific values: appName and ScrapeConfigNamespaceSelector
@@ -177,8 +248,298 @@ func TestReconcileAgent(t *testing.T) {
 	assert.Equal(t, &metav1.LabelSelector{}, foundAgent.Spec.ScrapeConfigNamespaceSelector)
 }
 
+func TestReconcileAgentsUserDefined(t *testing.T) {
+	globalPlacement := addonv1beta1.PlacementStrategy{
+		PlacementRef: addonv1beta1.PlacementRef{Name: "global", Namespace: testGlobalNamespace},
+	}
+	placementB := addonv1beta1.PlacementStrategy{
+		PlacementRef: addonv1beta1.PlacementRef{Name: "custom-placement", Namespace: config.HubInstallNamespace},
+	}
+	kubeRbacImage := "kube-rbac-proxy:version"
+	prometheusImage := "prometheus:version"
+
+	t.Run("SSA enforcement on user agent with conflicting fields", func(t *testing.T) {
+		cmao := newCMAO(globalPlacement)
+		opts := newAddonOptions(true, true)
+
+		userAgent := NewDefaultPrometheusAgent(config.HubInstallNamespace, "my-custom-platform-agent", false)
+		userAgent.Labels[addoncfg.PartOfK8sLabelKey] = addoncfg.Name
+		userAgent.Annotations = map[string]string{
+			addoncfg.PlacementAnnotationKey: testGlobalNamespace + "/global",
+		}
+		userAgent.Spec.Image = ptr.To("wrong-image:latest")
+		userAgent.Spec.ServiceAccountName = "wrong-sa"
+		userAgent.Spec.ArbitraryFSAccessThroughSMs = cooprometheusv1.ArbitraryFSAccessThroughSMsConfig{Deny: false}
+
+		scheme := newTestScheme()
+		fakeClient := fake.NewClientBuilder().WithInterceptorFuncs(ensureGVKIsSet(scheme)).WithScheme(scheme).WithObjects(cmao, userAgent).Build()
+		d := DefaultStackResources{
+			Client:             fakeClient,
+			CMAO:               cmao,
+			AddonOptions:       opts,
+			Logger:             klog.Background(),
+			KubeRBACProxyImage: kubeRbacImage,
+			PrometheusImage:    prometheusImage,
+		}
+
+		configs, err := d.reconcileAgents(context.Background(), false)
+		require.NoError(t, err)
+
+		// Find the config for the user agent (targeting global)
+		var userAgentConfig *common.DefaultConfig
+		for i, cfg := range configs {
+			if cfg.PlacementRef.Name == "global" {
+				userAgentConfig = &configs[i]
+				break
+			}
+		}
+		require.NotNil(t, userAgentConfig, "expected a config targeting global placement from user agent")
+
+		foundAgent := cooprometheusv1alpha1.PrometheusAgent{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: config.HubInstallNamespace, Name: "my-custom-platform-agent"}, &foundAgent)
+		require.NoError(t, err)
+
+		// SSA should enforce mandatory fields over user values
+		assert.Equal(t, prometheusImage, *foundAgent.Spec.Image)
+		assert.Equal(t, config.PlatformMetricsCollectorApp, foundAgent.Spec.ServiceAccountName)
+		assert.True(t, foundAgent.Spec.ArbitraryFSAccessThroughSMs.Deny)
+		assert.NotEmpty(t, foundAgent.Spec.Containers, "kube-rbac-proxy sidecar should be injected")
+		assert.Equal(t, kubeRbacImage, foundAgent.Spec.Containers[0].Image)
+	})
+
+	t.Run("user agent with multiple placement annotations", func(t *testing.T) {
+		cmao := newCMAO(globalPlacement, placementB)
+		opts := newAddonOptions(true, false)
+
+		userAgent := NewDefaultPrometheusAgent(config.HubInstallNamespace, "multi-placement-agent", false)
+		userAgent.Labels[addoncfg.PartOfK8sLabelKey] = addoncfg.Name
+		userAgent.Annotations = map[string]string{
+			addoncfg.PlacementAnnotationKey: testGlobalNamespace + "/global," + config.HubInstallNamespace + "/custom-placement",
+		}
+
+		scheme := newTestScheme()
+		fakeClient := fake.NewClientBuilder().WithInterceptorFuncs(ensureGVKIsSet(scheme)).WithScheme(scheme).WithObjects(cmao, userAgent).Build()
+		d := DefaultStackResources{
+			Client:             fakeClient,
+			CMAO:               cmao,
+			AddonOptions:       opts,
+			Logger:             klog.Background(),
+			KubeRBACProxyImage: kubeRbacImage,
+			PrometheusImage:    prometheusImage,
+		}
+
+		configs, err := d.reconcileAgents(context.Background(), false)
+		require.NoError(t, err)
+
+		// User agent targets both placements, plus dummy agent creates a config for dummy
+		globalConfigs := 0
+		customConfigs := 0
+		for _, cfg := range configs {
+			if cfg.PlacementRef.Name == "global" {
+				globalConfigs++
+			}
+			if cfg.PlacementRef.Name == "custom-placement" {
+				customConfigs++
+			}
+		}
+		assert.Equal(t, 1, globalConfigs, "user agent should produce a config for global")
+		assert.Equal(t, 1, customConfigs, "user agent should produce a config for custom-placement")
+	})
+
+	t.Run("user agent without placement annotation generates no configs", func(t *testing.T) {
+		cmao := newCMAO(globalPlacement)
+		opts := newAddonOptions(true, false)
+
+		userAgent := NewDefaultPrometheusAgent(config.HubInstallNamespace, "no-annotation-agent", false)
+		userAgent.Labels[addoncfg.PartOfK8sLabelKey] = addoncfg.Name
+		// No placement annotation set — agent has correct labels but no annotation
+
+		scheme := newTestScheme()
+		fakeClient := fake.NewClientBuilder().WithInterceptorFuncs(ensureGVKIsSet(scheme)).WithScheme(scheme).WithObjects(cmao, userAgent).Build()
+		d := DefaultStackResources{
+			Client:             fakeClient,
+			CMAO:               cmao,
+			AddonOptions:       opts,
+			Logger:             klog.Background(),
+			KubeRBACProxyImage: kubeRbacImage,
+			PrometheusImage:    prometheusImage,
+		}
+
+		configs, err := d.reconcileAgents(context.Background(), false)
+		require.NoError(t, err)
+
+		// The agent without annotation should not generate any configs
+		// Only the dummy agent (created by CreateDefaultAgent since global is covered by no one with annotation)
+		// Actually since "no-annotation-agent" doesn't target global, CreateDefaultAgent creates global-default
+		// global-default targets global → 1 config
+		for _, cfg := range configs {
+			assert.NotEqual(t, "no-annotation-agent", cfg.Config.Name,
+				"agent without annotation should not produce a config")
+		}
+
+		// Verify SSA was still applied to the no-annotation agent
+		foundAgent := cooprometheusv1alpha1.PrometheusAgent{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: config.HubInstallNamespace, Name: "no-annotation-agent"}, &foundAgent)
+		require.NoError(t, err)
+		assert.Equal(t, prometheusImage, *foundAgent.Spec.Image, "SSA should still enforce image")
+		assert.Equal(t, config.PlatformMetricsCollectorApp, foundAgent.Spec.ServiceAccountName, "SSA should still enforce serviceAccountName")
+	})
+
+	t.Run("user agent targeting non-global placement", func(t *testing.T) {
+		cmao := newCMAO(globalPlacement, placementB)
+		opts := newAddonOptions(true, false)
+
+		userAgent := NewDefaultPrometheusAgent(config.HubInstallNamespace, "custom-placement-agent", false)
+		userAgent.Labels[addoncfg.PartOfK8sLabelKey] = addoncfg.Name
+		userAgent.Annotations = map[string]string{
+			addoncfg.PlacementAnnotationKey: config.HubInstallNamespace + "/custom-placement",
+		}
+
+		scheme := newTestScheme()
+		fakeClient := fake.NewClientBuilder().WithInterceptorFuncs(ensureGVKIsSet(scheme)).WithScheme(scheme).WithObjects(cmao, userAgent).Build()
+		d := DefaultStackResources{
+			Client:             fakeClient,
+			CMAO:               cmao,
+			AddonOptions:       opts,
+			Logger:             klog.Background(),
+			KubeRBACProxyImage: kubeRbacImage,
+			PrometheusImage:    prometheusImage,
+		}
+
+		configs, err := d.reconcileAgents(context.Background(), false)
+		require.NoError(t, err)
+
+		// User agent targets custom-placement, CreateDefaultAgent creates global-default for global
+		globalConfigs := 0
+		customConfigs := 0
+		for _, cfg := range configs {
+			if cfg.PlacementRef.Name == "global" {
+				globalConfigs++
+			}
+			if cfg.PlacementRef.Name == "custom-placement" {
+				customConfigs++
+			}
+		}
+		assert.Equal(t, 1, globalConfigs, "default agent should produce a config for global")
+		assert.Equal(t, 1, customConfigs, "user agent should produce a config for custom-placement")
+
+		// Verify user agent had SSA applied
+		foundAgent := cooprometheusv1alpha1.PrometheusAgent{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: config.HubInstallNamespace, Name: "custom-placement-agent"}, &foundAgent)
+		require.NoError(t, err)
+		assert.Equal(t, prometheusImage, *foundAgent.Spec.Image)
+		assert.True(t, foundAgent.Spec.ArbitraryFSAccessThroughSMs.Deny)
+	})
+
+	t.Run("user agent without managed-by label is still recognized", func(t *testing.T) {
+		cmao := newCMAO(globalPlacement)
+		opts := newAddonOptions(true, false)
+
+		// A real user-authored agent would only set the component label (required so MCOA
+		// knows whether it's a platform or UWL agent) and the part-of label (to opt in). It
+		// would have no reason to also set the internal managed-by label.
+		userAgent := &cooprometheusv1alpha1.PrometheusAgent{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       cooprometheusv1alpha1.PrometheusAgentsKind,
+				APIVersion: cooprometheusv1alpha1.SchemeGroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-managed-by-agent",
+				Namespace: config.HubInstallNamespace,
+				Labels: map[string]string{
+					addoncfg.ComponentK8sLabelKey: config.PlatformMetricsCollectorApp,
+					addoncfg.PartOfK8sLabelKey:    addoncfg.Name,
+				},
+				Annotations: map[string]string{
+					addoncfg.PlacementAnnotationKey: testGlobalNamespace + "/global",
+				},
+			},
+		}
+
+		scheme := newTestScheme()
+		fakeClient := fake.NewClientBuilder().WithInterceptorFuncs(ensureGVKIsSet(scheme)).WithScheme(scheme).WithObjects(cmao, userAgent).Build()
+		d := DefaultStackResources{
+			Client:             fakeClient,
+			CMAO:               cmao,
+			AddonOptions:       opts,
+			Logger:             klog.Background(),
+			KubeRBACProxyImage: kubeRbacImage,
+			PrometheusImage:    prometheusImage,
+		}
+
+		configs, err := d.reconcileAgents(context.Background(), false)
+		require.NoError(t, err)
+
+		var found bool
+		for _, cfg := range configs {
+			if cfg.Config.Name == "no-managed-by-agent" {
+				found = true
+			}
+		}
+		assert.True(t, found, "user agent without managed-by label should still be discovered and produce a config")
+
+		foundAgent := cooprometheusv1alpha1.PrometheusAgent{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: config.HubInstallNamespace, Name: "no-managed-by-agent"}, &foundAgent)
+		require.NoError(t, err)
+		assert.Equal(t, prometheusImage, *foundAgent.Spec.Image, "SSA should have been applied to the user agent")
+	})
+
+	t.Run("unrecognized agent is ignored", func(t *testing.T) {
+		cmao := newCMAO(globalPlacement)
+		opts := newAddonOptions(true, false)
+
+		// Agent has matching labels but no owner ref and no part-of label
+		unrecognizedAgent := NewDefaultPrometheusAgent(config.HubInstallNamespace, "rogue-agent", false)
+		unrecognizedAgent.Annotations = map[string]string{
+			addoncfg.PlacementAnnotationKey: testGlobalNamespace + "/global",
+		}
+
+		scheme := newTestScheme()
+		fakeClient := fake.NewClientBuilder().WithInterceptorFuncs(ensureGVKIsSet(scheme)).WithScheme(scheme).WithObjects(cmao, unrecognizedAgent).Build()
+		d := DefaultStackResources{
+			Client:             fakeClient,
+			CMAO:               cmao,
+			AddonOptions:       opts,
+			Logger:             klog.Background(),
+			KubeRBACProxyImage: kubeRbacImage,
+			PrometheusImage:    prometheusImage,
+		}
+
+		configs, err := d.reconcileAgents(context.Background(), false)
+		require.NoError(t, err)
+
+		// The unrecognized agent should NOT generate any configs
+		for _, cfg := range configs {
+			assert.NotEqual(t, "rogue-agent", cfg.Config.Name,
+				"unrecognized agent should not produce configs")
+		}
+
+		// The unrecognized agent should NOT have SSA applied to it
+		foundAgent := cooprometheusv1alpha1.PrometheusAgent{}
+		err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: config.HubInstallNamespace, Name: "rogue-agent"}, &foundAgent)
+		require.NoError(t, err)
+		assert.Nil(t, foundAgent.Spec.Image, "unrecognized agent should not have image overwritten")
+
+		// CreateDefaultAgent should also not consider the unrecognized agent as covering global
+		// so a default global agent should have been created
+		agents := cooprometheusv1alpha1.PrometheusAgentList{}
+		err = fakeClient.List(context.Background(), &agents)
+		require.NoError(t, err)
+		defaultFound := false
+		for _, a := range agents.Items {
+			if a.Name == makeAgentName(config.PlatformMetricsCollectorApp, "global")+"-default" {
+				defaultFound = true
+			}
+		}
+		assert.True(t, defaultFound, "default global agent should be created since unrecognized agent is ignored")
+	})
+}
+
 func TestReconcileAgentWithRegistries(t *testing.T) {
-	cmao := newCMAO()
+	globalPlacement := addonv1beta1.PlacementStrategy{
+		PlacementRef: addonv1beta1.PlacementRef{Name: "global", Namespace: testGlobalNamespace},
+	}
+	cmao := newCMAO(globalPlacement)
 	registries := []addonv1beta1.ImageMirror{
 		{
 			Source: "quay.io/prometheus/prometheus",
@@ -229,12 +590,12 @@ func TestReconcileAgentWithRegistries(t *testing.T) {
 		PrometheusImage:    images.Prometheus,
 	}
 
-	placementRef := addonv1beta1.PlacementRef{Name: "my-placement", Namespace: "my-namespace"}
-	retAgent, err := d.reconcileAgentForPlacement(context.Background(), placementRef, false)
+	configs, err := d.reconcileAgents(context.Background(), false)
 	require.NoError(t, err)
+	require.Len(t, configs, 1)
 
 	foundAgent := cooprometheusv1alpha1.PrometheusAgent{}
-	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: retAgent.Config.Namespace, Name: retAgent.Config.Name}, &foundAgent)
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Namespace: configs[0].Config.Namespace, Name: configs[0].Config.Name}, &foundAgent)
 	require.NoError(t, err)
 
 	// Check overridden images
@@ -243,24 +604,17 @@ func TestReconcileAgentWithRegistries(t *testing.T) {
 }
 
 func TestReconcile(t *testing.T) {
-	placementRefA := addonv1beta1.PlacementRef{
-		Namespace: "ns",
-		Name:      "a",
-	}
-	placementRefB := addonv1beta1.PlacementRef{
-		Namespace: "ns",
-		Name:      "b",
+	globalPlacementRef := addonv1beta1.PlacementRef{
+		Namespace: testGlobalNamespace,
+		Name:      "global",
 	}
 	hubUrl, err := url.Parse("https://test.com")
 	require.NoError(t, err)
 
-	platformAppName := "platform-app"
-	platformAgent := NewDefaultPrometheusAgent(config.HubInstallNamespace, makeAgentName(platformAppName, placementRefA.Name), false, placementRefA)
-	platformAgent.Labels = map[string]string{ // expected labels for identifying an agent configuration
-		addoncfg.PlacementRefNamespaceLabelKey: placementRefA.Namespace,
-		addoncfg.PlacementRefNameLabelKey:      placementRefA.Name,
-		addoncfg.ManagedByK8sLabelKey:          addoncfg.Name,
-		addoncfg.ComponentK8sLabelKey:          config.PlatformMetricsCollectorApp,
+	platformAgent := NewDefaultPrometheusAgent(config.HubInstallNamespace, "existing-platform-agent", false)
+	platformAgent.Labels[addoncfg.PartOfK8sLabelKey] = addoncfg.Name
+	platformAgent.Annotations = map[string]string{
+		addoncfg.PlacementAnnotationKey: testGlobalNamespace + "/global",
 	}
 
 	platformSC := &cooprometheusv1alpha1.ScrapeConfig{
@@ -380,37 +734,37 @@ func TestReconcile(t *testing.T) {
 			expectAgentsCount: 0,
 		},
 		{
-			name: "one placement with disabled monitoring",
+			name: "global placement with disabled monitoring",
 			initialPlacements: []addonv1beta1.PlacementStrategy{
 				{
 					Configs:      []addonv1beta1.AddOnConfig{},
-					PlacementRef: placementRefA,
+					PlacementRef: globalPlacementRef,
 				},
 			},
 			initObjs:           []client.Object{platformAgent, platformSC},
-			expectAgentsCount:  1, // exists in init objects but is ignored for the configs
+			expectAgentsCount:  1,
 			expectConfigsCount: 0,
 		},
 		{
-			name: "one placement with enabled monitoring",
+			name: "global placement with enabled platform and uwl monitoring",
 			initialPlacements: []addonv1beta1.PlacementStrategy{
 				{
 					Configs:      []addonv1beta1.AddOnConfig{},
-					PlacementRef: placementRefA,
+					PlacementRef: globalPlacementRef,
 				},
 			},
 			platformEnabled:    true,
 			uwlEnabled:         true,
-			initObjs:           []client.Object{platformAgent, platformSC, uwlSC},
-			expectAgentsCount:  2,
-			expectConfigsCount: 4, // platform and uwl agents + scrapeConfigs
+			initObjs:           []client.Object{platformSC, uwlSC},
+			expectAgentsCount:  2, // one default platform agent + one default uwl agent
+			expectConfigsCount: 4, // platform agent + uwl agent + platformSC + uwlSC
 		},
 		{
-			name: "one placement with enabled monitoring and hcp",
+			name: "global placement with enabled monitoring and hcp",
 			initialPlacements: []addonv1beta1.PlacementStrategy{
 				{
 					Configs:      []addonv1beta1.AddOnConfig{},
-					PlacementRef: placementRefA,
+					PlacementRef: globalPlacementRef,
 				},
 			},
 			platformEnabled: true,
@@ -418,58 +772,36 @@ func TestReconcile(t *testing.T) {
 			initObjs: []client.Object{
 				hostedCluster, hcpApiserverSC, hcpEtcdSC, hcpApiserverRule, hcpEtcdRule,
 			},
-			expectAgentsCount:  2,
-			expectConfigsCount: 6, // platform and uwl agents + 4 hcp scrapeConfigs and rules
+			expectAgentsCount:  2, // one default platform agent + one default uwl agent
+			expectConfigsCount: 6, // platform agent + uwl agent + 2 hcp scrapeConfigs + 2 hcp rules
 		},
 		{
-			name: "one placement with enabled monitoring",
+			name: "global placement with existing platform agent covering global",
 			initialPlacements: []addonv1beta1.PlacementStrategy{
 				{
 					Configs:      []addonv1beta1.AddOnConfig{},
-					PlacementRef: placementRefA,
+					PlacementRef: globalPlacementRef,
 				},
 			},
 			platformEnabled:    true,
 			uwlEnabled:         true,
 			initObjs:           []client.Object{platformAgent, platformSC, uwlSC},
-			expectAgentsCount:  2,
-			expectConfigsCount: 4, // platform and uwl agents + scrapeConfigs
+			expectAgentsCount:  3, // existing platform agent + dummy platform agent + default uwl agent
+			expectConfigsCount: 4, // existing platform agent (targets global) + uwl agent + platformSC + uwlSC
 		},
 		{
-			name: "two placements with enabled platform monitoring",
+			name: "global placement with enabled platform only",
 			initialPlacements: []addonv1beta1.PlacementStrategy{
 				{
 					Configs:      []addonv1beta1.AddOnConfig{},
-					PlacementRef: placementRefA,
-				},
-				{
-					Configs:      []addonv1beta1.AddOnConfig{},
-					PlacementRef: placementRefB,
+					PlacementRef: globalPlacementRef,
 				},
 			},
 			platformEnabled:    true,
 			uwlEnabled:         false,
-			initObjs:           []client.Object{platformAgent, platformSC, uwlSC},
-			expectAgentsCount:  2, // one platform agent for each placement
-			expectConfigsCount: 2, // platform agent and scrapeConfig
-		},
-		{
-			name: "two placements with enabled monitoring",
-			initialPlacements: []addonv1beta1.PlacementStrategy{
-				{
-					Configs:      []addonv1beta1.AddOnConfig{},
-					PlacementRef: placementRefA,
-				},
-				{
-					Configs:      []addonv1beta1.AddOnConfig{},
-					PlacementRef: placementRefB,
-				},
-			},
-			platformEnabled:    true,
-			uwlEnabled:         true,
-			initObjs:           []client.Object{platformAgent, platformSC, uwlSC},
-			expectAgentsCount:  4, // 2 agent for each placement
-			expectConfigsCount: 4, // 2 agents and 2 scs
+			initObjs:           []client.Object{platformSC},
+			expectAgentsCount:  1, // one default platform agent
+			expectConfigsCount: 2, // platform agent + platformSC
 		},
 	}
 
@@ -1085,6 +1417,88 @@ func TestGetPrometheusRules(t *testing.T) {
 	}
 }
 
+func TestMigrateAgentPlacementLabelsToAnnotation(t *testing.T) {
+	testCases := []struct {
+		name                string
+		labels              map[string]string
+		existingAnnotations map[string]string
+		expectMigrated      bool
+		expectAnnotation    string
+		expectLabelsKept    bool
+	}{
+		{
+			name:             "no placement labels returns false",
+			labels:           map[string]string{},
+			expectMigrated:   false,
+			expectLabelsKept: true,
+		},
+		{
+			name: "only name label present returns false",
+			labels: map[string]string{
+				addoncfg.PlacementRefNameLabelKey: "placement-a",
+			},
+			expectMigrated:   false,
+			expectLabelsKept: true,
+		},
+		{
+			name: "only namespace label present returns false",
+			labels: map[string]string{
+				addoncfg.PlacementRefNamespaceLabelKey: "ns-a",
+			},
+			expectMigrated:   false,
+			expectLabelsKept: true,
+		},
+		{
+			name: "both labels present migrates to annotation",
+			labels: map[string]string{
+				addoncfg.PlacementRefNameLabelKey:      "placement-a",
+				addoncfg.PlacementRefNamespaceLabelKey: "ns-a",
+			},
+			expectMigrated:   true,
+			expectAnnotation: "ns-a/placement-a",
+			expectLabelsKept: false,
+		},
+		{
+			name: "both labels present appends to existing annotation",
+			labels: map[string]string{
+				addoncfg.PlacementRefNameLabelKey:      "placement-b",
+				addoncfg.PlacementRefNamespaceLabelKey: "ns-b",
+			},
+			existingAnnotations: map[string]string{
+				addoncfg.PlacementAnnotationKey: "ns-a/placement-a",
+			},
+			expectMigrated:   true,
+			expectAnnotation: "ns-a/placement-a,ns-b/placement-b",
+			expectLabelsKept: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent := NewDefaultPrometheusAgent(config.HubInstallNamespace, "test-agent", false)
+			agent.Labels = tc.labels
+			agent.Annotations = tc.existingAnnotations
+
+			migrated := migrateAgentPlacementLabelsToAnnotation(agent)
+			assert.Equal(t, tc.expectMigrated, migrated)
+
+			if tc.expectMigrated {
+				assert.Equal(t, tc.expectAnnotation, agent.Annotations[addoncfg.PlacementAnnotationKey])
+			}
+
+			_, hasName := agent.Labels[addoncfg.PlacementRefNameLabelKey]
+			_, hasNS := agent.Labels[addoncfg.PlacementRefNamespaceLabelKey]
+			if tc.expectLabelsKept {
+				assert.Equal(t, tc.labels[addoncfg.PlacementRefNameLabelKey] != "", hasName)
+				assert.Equal(t, tc.labels[addoncfg.PlacementRefNamespaceLabelKey] != "", hasNS)
+			} else {
+				assert.False(t, hasName)
+				assert.False(t, hasNS)
+			}
+		})
+	}
+}
+
 func TestGeneratePlacementRefs(t *testing.T) {
 	d := DefaultStackResources{}
 
@@ -1119,6 +1533,23 @@ func TestGeneratePlacementRefs(t *testing.T) {
 			annotations: "ns-a/placement-a,",
 			expected: []addonv1beta1.PlacementRef{
 				{Namespace: "ns-a", Name: "placement-a"},
+			},
+		},
+		{
+			name:        "whitespace around entries is trimmed",
+			annotations: "ns-a/placement-a, ns-b/placement-b , \tns-c/placement-c\t",
+			expected: []addonv1beta1.PlacementRef{
+				{Namespace: "ns-a", Name: "placement-a"},
+				{Namespace: "ns-b", Name: "placement-b"},
+				{Namespace: "ns-c", Name: "placement-c"},
+			},
+		},
+		{
+			name:        "whitespace-only entry between commas is ignored",
+			annotations: "ns-a/placement-a, ,ns-b/placement-b",
+			expected: []addonv1beta1.PlacementRef{
+				{Namespace: "ns-a", Name: "placement-a"},
+				{Namespace: "ns-b", Name: "placement-b"},
 			},
 		},
 		{


### PR DESCRIPTION
Summary:

Fixes [ACM-35687](https://redhat.atlassian.net/browse/ACM-35687)

Problem:

Users currently lack an easy way to deploy their own prometheusAgents onto managed clusters.

Root Cause:

The MCOA resource controller was only focusing on MCO-created prometheusAgents, it wasn't watching user-created resources.

Fix:

feat(metrics): auto-discover placement agents

- Recognize user-defined PrometheusAgents (opted in via the
  app.kubernetes.io/part-of label) alongside the CMAO-owned default
  agent, and reconcile/SSA both the same way.
- Track each agent's placement references via an annotation
  (observability.open-cluster-management.io/placements) instead of
  labels, with automatic one-time migration of existing agents.
- Look up the "global" placement's real namespace from the CMAO
  instead of assuming it lives in the install namespace.
- Stop the default/dummy agent from being repeatedly created and
  deleted by excluding the "dummy" placement sentinel from orphan
  cleanup.
- Extend orphan-resource cleanup to also remove user-defined
  PrometheusAgents once none of their referenced placements exist,
  not just CMAO-owned ones.
- Disambiguate OBO vs Prometheus Operator PrometheusRule configs by
  Group+Resource instead of Resource alone, since both share the
  same "prometheusrules" resource name.
- Trim whitespace when parsing multi-placement annotations.

Files Changed:

Modified:

internal/addon/common/clustermanagementaddon.go
internal/addon/common/clustermanagementaddon_test.go
internal/controllers/resourcecreator/controller.go
internal/metrics/resource/agentssa.go
internal/metrics/resource/resource.go
internal/metrics/resource/resource_test.go

Test Plan:

Created and updated unit tests covering: default agent creation logic (global vs dummy), SSA enforcement on user-defined agents with conflicting fields, multi-placement annotation targeting, agents without annotations, unrecognized agents being ignored, ownership filtering (CMAO controller reference or part-of label), stale config cleanup for PrometheusAgents, and end-to-end reconciliation with various placement configurations. All unit tests pass (go test ./...). Ran end-to-end tests manually and verified that a user-created PrometheusAgent is recognized by MCOA, added to the correct placement in the CMAO, and included in the generated ManifestWork delivered to the matching spoke cluster.

[ACM-35687]: https://redhat.atlassian.net/browse/ACM-35687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `PrometheusAgent` support to stale configuration cleanup.
  * Switched placement targeting to placement **annotations**, including automatic migration from placement labels.
  * Enhanced agent reconciliation to preserve and layer user-provided agent annotations and to create/manage default agents via streamlined bulk reconciliation.

* **Bug Fixes**
  * Improved orphan cleanup to respect `placement-ref` annotations, including multi-placement and dummy-sentinel references, preventing unintended `PrometheusAgent` deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->