### PR TITLE
ACM-35863: Ship Thanos dashboards via Perses

### DIFF
--- a/internal/addon/manifests/charts/mcoa/charts/coo/templates/perses/platform-prometheus-datasource.yaml
+++ b/internal/addon/manifests/charts/mcoa/charts/coo/templates/perses/platform-prometheus-datasource.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.enabled .Values.monitoringUIPlugin }}
+apiVersion: perses.dev/v1alpha1
+kind: PersesDatasource
+metadata:
+  name: platform-prometheus-datasource
+  namespace: open-cluster-management-observability
+spec:
+  client:
+    tls:
+      caCert:
+        certPath: /ca/service-ca.crt
+        type: file
+      enable: true
+  config:
+    default: false
+    plugin:
+      kind: PrometheusDatasource
+      spec:
+        proxy:
+          kind: HTTPProxy
+          spec:
+            url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
+            secret: platform-prometheus-datasource-secret
+        scrapeInterval: 5m
+{{- end }}

--- a/internal/coo/manifests/values.go
+++ b/internal/coo/manifests/values.go
@@ -3,6 +3,7 @@ package manifests
 import (
 	"encoding/json"
 	"log"
+	"strings"
 
 	persesv1 "github.com/perses/perses-operator/api/v1alpha1"
 	"github.com/perses/perses/go-sdk/dashboard"
@@ -16,12 +17,14 @@ import (
 	networking "github.com/stolostron/multicluster-observability-addon/pkg/perses/dashboards/acm/k8s/networking"
 	slo "github.com/stolostron/multicluster-observability-addon/pkg/perses/dashboards/acm/k8s/slo"
 	incident_management "github.com/stolostron/multicluster-observability-addon/pkg/perses/dashboards/incident-management"
+	"github.com/stolostron/multicluster-observability-addon/pkg/perses/dashboards/thanos"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
-	dsThanos         = "rbac-query-proxy-datasource"
-	clusterLabelName = ""
+	dsThanos             = "rbac-query-proxy-datasource"
+	dsPlatformPrometheus = "platform-prometheus-datasource"
+	clusterLabelName     = ""
 )
 
 type DashboardValue struct {
@@ -64,6 +67,7 @@ func BuildValues(opts addon.Options, installOfCOOOnTheHubIsNeeded bool, isHubClu
 		if metricsUI.Enabled {
 			dashboards = append(dashboards, buildACMDashboards()...)
 			dashboards = append(dashboards, buildK8sDashboards()...)
+			dashboards = append(dashboards, buildThanosDashboards()...)
 			if hasCardinalityRules {
 				dashboards = append(dashboards, buildCardinalityDashboards()...)
 			}
@@ -178,6 +182,44 @@ func buildACMDashboards() []DashboardValue {
 	}
 
 	return buildDashboards(builders, dsThanos, config.InstallNamespace)
+}
+
+// thanosVariableMetricRenames covers the small set of metric names referenced
+// directly by community-mixins' Thanos dashboard-level variables (job/
+// namespace/cluster/tenant), which aren't covered by the
+// ThanosCommonPanelQueries override in pkg/perses/dashboards/thanos since
+// they're not panel queries.
+var thanosVariableMetricRenames = strings.NewReplacer(
+	"thanos_build_info", "acm_thanos_build_info",
+	"thanos_status", "acm_thanos_status",
+	"prometheus_tsdb_head_max_time", "acm_prometheus_tsdb_head_max_time",
+)
+
+func buildThanosDashboards() []DashboardValue {
+	objs, err := thanos.BuildThanosDashboards(config.InstallNamespace, dsPlatformPrometheus, clusterLabelName)
+	if err != nil {
+		log.Printf("Failed to build Thanos dashboards: %v", err)
+		return nil
+	}
+
+	var dashboards []DashboardValue
+	for _, obj := range objs {
+		db, ok := obj.(*persesv1.PersesDashboard)
+		if !ok {
+			log.Printf("Failed to convert object to PersesDashboard: %v", obj)
+			continue
+		}
+		data, err := json.Marshal(db.Spec)
+		if err != nil {
+			log.Printf("Failed to marshal Thanos dashboard %s: %v", db.Name, err)
+			continue
+		}
+		dashboards = append(dashboards, DashboardValue{
+			Name: db.Name,
+			Data: thanosVariableMetricRenames.Replace(string(data)),
+		})
+	}
+	return dashboards
 }
 
 func buildCardinalityDashboards() []DashboardValue {

--- a/pkg/perses/dashboards/thanos/dash-thanos.go
+++ b/pkg/perses/dashboards/thanos/dash-thanos.go
@@ -1,0 +1,76 @@
+package thanos
+
+import (
+	"flag"
+
+	"github.com/perses/community-mixins/pkg/dashboards"
+	thanosDashboards "github.com/perses/community-mixins/pkg/dashboards/thanos"
+	"github.com/perses/community-mixins/pkg/panels/gostats"
+	thanosPanels "github.com/perses/community-mixins/pkg/panels/thanos"
+	promqlbuilder "github.com/perses/promql-builder"
+	"github.com/prometheus/prometheus/promql/parser"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func init() {
+	// These flags are required by the github.com/perses/community-mixins/pkg/dashboards library.
+	// They are looked up in NewExec() which is called by NewDashboardWriter().
+	if flag.Lookup("output") == nil {
+		flag.String("output", "", "output format of the dashboard exec")
+	}
+	if flag.Lookup("output-dir") == nil {
+		flag.String("output-dir", "", "output directory of the dashboard exec")
+	}
+}
+
+// init rewrites every upstream Thanos and shared "gostats" (the Resources
+// panel group: memory/goroutines/GC/CPU) panel query to reference RHACM's
+// actual metric names: platform metrics are relabeled with an "acm_"
+// prefix (e.g. thanos_compact_halted -> acm_thanos_compact_halted, or
+// go_goroutines -> acm_go_goroutines) before they land in the observability
+// backend, so the community-mixins queries (which target the raw upstream
+// names) need this override to return data.
+func init() {
+	thanosPanels.OverrideThanosPanelQueries(rewriteQueries(thanosPanels.ThanosCommonPanelQueries))
+	gostats.OverrideGoPanelQueries(rewriteQueries(gostats.GoCommonPanelQueries))
+}
+
+func rewriteQueries(queries map[string]parser.Expr) map[string]parser.Expr {
+	rewritten := make(map[string]parser.Expr, len(queries))
+	for key, expr := range queries {
+		e := promqlbuilder.DeepCopyExpr(expr)
+		promqlbuilder.Inspect(e, func(node parser.Node, _ []parser.Node) error {
+			vs, ok := node.(*parser.VectorSelector)
+			if !ok {
+				return nil
+			}
+			if vs.Name != "" {
+				vs.Name = "acm_" + vs.Name
+			}
+			for _, m := range vs.LabelMatchers {
+				if m.Name == "__name__" && m.Value != "" {
+					m.Value = "acm_" + m.Value
+				}
+			}
+			return nil
+		})
+		rewritten[key] = e
+	}
+	return rewritten
+}
+
+// BuildThanosDashboards renders the upstream community-mixins Thanos
+// dashboards (Query, Query Frontend, Store, Compact, Receive, Rule), with
+// panel queries pointed at RHACM's own metric names via the init() override
+// above.
+func BuildThanosDashboards(project string, datasource string, clusterLabelName string) ([]runtime.Object, error) {
+	dashboardWriter := dashboards.NewDashboardWriter()
+	dashboardWriter.Add(thanosDashboards.BuildThanosQueryOverview(project, datasource, clusterLabelName))
+	dashboardWriter.Add(thanosDashboards.BuildThanosQueryFrontendOverview(project, datasource, clusterLabelName))
+	dashboardWriter.Add(thanosDashboards.BuildThanosStoreOverview(project, datasource, clusterLabelName))
+	dashboardWriter.Add(thanosDashboards.BuildThanosCompactOverview(project, datasource, clusterLabelName))
+	dashboardWriter.Add(thanosDashboards.BuildThanosReceiveOverview(project, datasource, clusterLabelName))
+	dashboardWriter.Add(thanosDashboards.BuildThanosRulerOverview(project, datasource, clusterLabelName))
+
+	return dashboardWriter.OperatorResources(), nil
+}

--- a/pkg/perses/dashboards/thanos/dash_thanos_test.go
+++ b/pkg/perses/dashboards/thanos/dash_thanos_test.go
@@ -1,0 +1,18 @@
+package thanos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildThanosDashboards(t *testing.T) {
+	objs, err := BuildThanosDashboards("test-project", "test-datasource", "")
+	require.NoError(t, err)
+	require.Len(t, objs, 6)
+
+	// Call it again - this should not panic (init() rewrite only runs once).
+	objs, err = BuildThanosDashboards("test-project", "test-datasource", "")
+	require.NoError(t, err)
+	require.Len(t, objs, 6)
+}


### PR DESCRIPTION
## Summary

Ships RHACM Observability's Thanos health dashboards (Query, Query Frontend, Store, Compact, Receive, Rule) as `PersesDashboard` CRs, resolving ACM-35863.

Wraps `github.com/perses/community-mixins/pkg/dashboards/thanos` directly (same pattern as `dash-k8s.go`) instead of hand-porting dashboards, so upstream improvements flow in automatically.
Community-mixins queries raw upstream metric names, but RHACM relabels them with an `acm_` prefix `pkg/perses/dashboards/thanos/dash-thanos.go` uses community-mixins' `Override*PanelQueries` extension points
(`ThanosCommonPanelQueries` + the separate `gostats.GoCommonPanelQueries`
used by the shared Resources panel group) to rewrite all panel queries
at init time. `values.go` handles three dashboard-variable metric names that live outside those overridable maps.

Dashboards query a new `platform-prometheus-datasource` (`thanos-querier.openshift-monitoring`)

## Test plan

- [x] `go build`/`go test` pass in `pkg/perses` and at repo root
- [x] `make lint-fix` clean
- [x] `helm template` renders the datasource and all 6 dashboards
- [x] Verified marshaled dashboard JSON uses `acm_`-prefixed metrics
      with no unprefixed leftovers
- [ ] Not yet verified end-to-end on a live hub — please spot-check
      before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve ACM-35863`