### PR TITLE
Revert "fix(perses): correct PromQL operator precedence in service-level hours stat panels"

### DIFF
--- a/pkg/perses/panels/virtualization/vm-service-level-queries.go
+++ b/pkg/perses/panels/virtualization/vm-service-level-queries.go
@@ -46,15 +46,15 @@ const serviceLevelUnplannedDowntimePercentQuery = `sum(` + serviceLevelUnplanned
 sum(` + serviceLevelTotalSamplesExpr + `) or vector(0)`
 
 const serviceLevelUptimeHoursQuery = `sum(
-((` + serviceLevelRunningSamplesExpr + `) *300 )/3600
+(` + serviceLevelRunningSamplesExpr + ` *300 )/3600
 ) or vector(0)`
 
 const serviceLevelPlannedDowntimeHoursQuery = `sum(
-((` + serviceLevelPlannedDowntimeSamplesExpr + `) *300 )/3600
+(` + serviceLevelPlannedDowntimeSamplesExpr + ` *300 )/3600
 ) or vector(0)`
 
 const serviceLevelUnplannedDowntimeHoursQuery = `sum(
-((` + serviceLevelUnplannedDowntimeSamplesExpr + `) *300 )/3600
+(` + serviceLevelUnplannedDowntimeSamplesExpr + ` *300 )/3600
 ) or vector(0)`
 
 // Per-VM table sample sub-expressions (no status filter appended — composed below).


### PR DESCRIPTION
Reverts stolostron/multicluster-observability-addon#537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the formatting of service-level hours queries for uptime, planned downtime, and unplanned downtime.
  * Improved calculation consistency by applying time conversion factors with the intended grouping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->