### PR TITLE
fix(perses): rename namespace rightsizing panel titles

### DIFF
--- a/internal/perses/panels/rightsizing/namespace-panels.go
+++ b/internal/perses/panels/rightsizing/namespace-panels.go
@@ -142,7 +142,7 @@ func MemUtilizationPanel(datasourceName string) panelgroup.Option {
 }
 
 func CPUTopNamespacesPanel(datasourceName string) panelgroup.Option {
-	return panelgroup.AddPanel("CPU Utilization of Top Namespaces",
+	return panelgroup.AddPanel("CPU Usage to Request Ratio of Top Namespaces",
 		panel.Description("CPU utilization of the top 20 namespaces by usage/request ratio"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
@@ -174,7 +174,7 @@ func CPUTopNamespacesPanel(datasourceName string) panelgroup.Option {
 }
 
 func MemTopNamespacesPanel(datasourceName string) panelgroup.Option {
-	return panelgroup.AddPanel("Memory Utilization of Top Namespaces",
+	return panelgroup.AddPanel("Memory Usage to Request Ratio of Top Namespaces",
 		panel.Description("Memory utilization of the top 20 namespaces by usage/request ratio"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{


### PR DESCRIPTION
<!-- issue-fix-agent:jira=OBSINTA-1549 -->

## Summary
Rename the namespace rightsizing dashboard panel titles per MCO team feedback to more accurately describe the usage/request ratio data shown.

## Root Cause
The Perses namespace rightsizing dashboard panel titles used "Utilization" (e.g., "CPU Utilization of Top Namespaces") which did not accurately describe what the panels show — they display usage/request ratio, not raw utilization.

## Changes
- `internal/perses/panels/rightsizing/namespace-panels.go`: Renamed "CPU Utilization of Top Namespaces" to "CPU Usage to Request Ratio of Top Namespaces" and "Memory Utilization of Top Namespaces" to "Memory Usage to Request Ratio of Top Namespaces"

## Testing
- [x] Existing tests pass (`go test ./internal/perses/...`)
- [x] Build passes (`go build ./...`)
- [x] Vet passes (`go vet ./internal/perses/...`)
- [ ] Regression test added (not applicable — string-only label change, existing dashboard tests cover serialization)

## Jira
[OBSINTA-1549](https://redhat.atlassian.net/browse/OBSINTA-1549)

---
Assisted-by: OpenCode / claude-opus-4-6


[OBSINTA-1549]: https://redhat.atlassian.net/browse/OBSINTA-1549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ