### PR TITLE
[release-2.17] fix(perses): rename namespace rightsizing panel titles

### DIFF
--- a/internal/perses/panels/rightsizing/namespace-panels.go
+++ b/internal/perses/panels/rightsizing/namespace-panels.go
@@ -142,7 +142,7 @@ func MemUtilizationPanel(datasourceName string) panelgroup.Option {
 }
 
 func CPUTopNamespacesPanel(datasourceName string) panelgroup.Option {
-	return panelgroup.AddPanel("CPU Utilization of Top Namespaces",
+	return panelgroup.AddPanel("CPU Usage to Request Ratio of Top Namespaces",
 		panel.Description("CPU utilization of the top 20 namespaces by usage/request ratio"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
@@ -174,7 +174,7 @@ func CPUTopNamespacesPanel(datasourceName string) panelgroup.Option {
 }
 
 func MemTopNamespacesPanel(datasourceName string) panelgroup.Option {
-	return panelgroup.AddPanel("Memory Utilization of Top Namespaces",
+	return panelgroup.AddPanel("Memory Usage to Request Ratio of Top Namespaces",
 		panel.Description("Memory utilization of the top 20 namespaces by usage/request ratio"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{


### PR DESCRIPTION
Cherry-pick of #544 to release-2.17.

Original PR: https://github.com/stolostron/multicluster-observability-addon/pull/544

Manual cherrypick of the fix commit only (skipped empty commit that caused automated cherrypick failure).