### PR TITLE
fix(rightsizing): use max() instead of sum() for VM memory_request recording rules

### DIFF
--- a/internal/analytics/rightsizing/virtualization/prometheusrule.go
+++ b/internal/analytics/rightsizing/virtualization/prometheusrule.go
@@ -77,7 +77,7 @@ func buildNamespaceRules5m(nsFilter string, rb *rightsizing.RuleBuilder) []monit
 		rb.Rule(
 			"acm_rs_vm:namespace:memory_request:5m",
 			fmt.Sprintf(
-				`max_over_time(sum (
+				`max_over_time(max (
 				  kubevirt_vm_resource_requests{%s, resource="memory"}
 				) by (name,namespace)[5m:])`,
 				nsFilter,
@@ -150,9 +150,11 @@ func buildClusterRules5m(nsFilter string, rb *rightsizing.RuleBuilder) []monitor
 		rb.RuleNoJoin(
 			"acm_rs_vm:cluster:memory_request:5m",
 			fmt.Sprintf(
-				`max_over_time(sum (
-				  kubevirt_vm_resource_requests{%s, resource="memory"}
-				) by (cluster)[5m:])`,
+				`max_over_time(sum by (cluster) (
+				  max by (name, namespace, cluster) (
+				    kubevirt_vm_resource_requests{%s, resource="memory"}
+				  )
+				)[5m:])`,
 				nsFilter,
 			),
 		),


### PR DESCRIPTION
## Summary

`kubevirt_vm_resource_requests` emits multiple series per VM with different `source` label values
(domain, guest, guest_effective, hugepages) since KubeVirt v1.5.0 (CNV 4.18+). Using `sum()`
double/triple-counts the memory request.

## Changes

- `acm_rs_vm:namespace:memory_request:5m`: `sum()` → `max()` by (name, namespace) to deduplicate sources per VM
- `acm_rs_vm:cluster:memory_request:5m`: `sum()` → `sum(max per VM)` by cluster — deduplicate sources per VM first, then total across all VMs